### PR TITLE
Binning class and PSTH

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -8,6 +8,9 @@ docstring goes here.
 
 from __future__ import division, print_function
 
+import neo
+import scipy
+import scipy.sparse as sps
 import numpy as np
 import quantities as pq
 
@@ -152,3 +155,706 @@ def binarize(spiketrain, sampling_rate=None, t_start=None, t_stop=None,
     else:
         return res, pq.Quantity(np.arange(t_start, t_stop+sampling_period,
                                           sampling_period), units=units)
+
+
+
+###############################################################################
+#
+# Methods to calculate parameters, t_start, t_stop, bin size, number of bins
+#
+###############################################################################
+def calc_tstart(num_bins, binsize, t_stop):
+    """
+    Calculates the start point from given parameter.
+
+    Calculates the start point :attr:`t_start` from the three parameter
+    :attr:`t_stop`, :attr:`num_bins` and :attr`binsize`.
+
+    Parameters
+    ----------
+    num_bins: int
+        Number of bins
+    binsize: quantities.Quantity
+        Size of Bins
+    t_stop: quantities.Quantity
+        Stop time
+
+    Returns
+    -------
+    t_start : quantities.Quantity
+        Starting point calculated from given parameter.
+    """
+    if num_bins is not None and binsize is not None and t_stop is not None:
+        return t_stop.rescale(binsize.units) - num_bins * binsize
+
+
+def calc_tstop(num_bins, binsize, t_start):
+    """
+    Calculates the stop point from given parameter.
+
+    Calculates the stop point :attr:`t_stop` from the three parameter
+    :attr:`t_start`, :attr:`num_bins` and :attr`binsize`.
+
+    Parameters
+    ----------
+    num_bins: int
+        Number of bins
+    binsize: quantities.Quantity
+        Size of bins
+    t_start: quantities.Quantity
+        Start time
+
+    Returns
+    -------
+    t_stop : quantities.Quantity
+        Stoping point calculated from given parameter.
+    """
+    if num_bins is not None and binsize is not None and t_start is not None:
+        return t_start.rescale(binsize.units) + num_bins * binsize
+
+
+def calc_num_bins(binsize, t_start, t_stop):
+    """
+    Calculates the number of bins from given parameter.
+
+    Calculates the number of bins :attr:`num_bins` from the three parameter
+    :attr:`t_start`, :attr:`t_stop` and :attr`binsize`.
+
+    Parameters
+    ----------
+    binsize: quantities.Quantity
+        Size of Bins
+    t_start : quantities.Quantity
+        Start time
+    t_stop: quantities.Quantity
+        Stop time
+
+    Returns
+    -------
+    num_bins : int
+       Number of bins  calculated from given parameter.
+
+    Raises
+    ------
+    ValueError :
+        Raised when :attr:`t_stop` is smaller than :attr:`t_start`".
+
+    """
+    if binsize is not None and t_start is not None and t_stop is not None:
+        if t_stop < t_start:
+            raise ValueError("t_stop (%s) is smaller than t_start (%s)"
+                             % (t_stop, t_start))
+        return int(((t_stop - t_start).rescale(
+            binsize.units) / binsize).magnitude)
+
+
+def calc_binsize(num_bins, t_start, t_stop):
+    """
+    Calculates the stop point from given parameter.
+
+    Calculates the size of bins :attr:`binsize` from the three parameter
+    :attr:`num_bins`, :attr:`t_start` and :attr`t_stop`.
+
+    Parameters
+    ----------
+    num_bins: int
+        Number of bins
+    t_start: quantities.Quantity
+        Start time
+    t_stop
+       Stop time
+
+    Returns
+    -------
+    binsize : quantities.Quantity
+        Size of bins calculated from given parameter.
+
+    Raises
+    ------
+    ValueError :
+        Raised when :attr:`t_stop` is smaller than :attr:`t_start`".
+    """
+
+    if num_bins is not None and t_start is not None and t_stop is not None:
+        if t_stop < t_start:
+            raise ValueError("t_stop (%s) is smaller than t_start (%s)"
+                             % (t_stop, t_start))
+        return (t_stop - t_start) / num_bins
+
+
+def set_start_stop_from_input(spiketrains):
+    """
+    Sets the start :attr:`t_start`and stop :attr:`t_stop` point
+    from given input.
+
+    If one neo.SpikeTrain objects is given the start :attr:`t_stop `and stop
+    :attr:`t_stop` of the spike train is returned.
+    Otherwise the aligned times are returned, which are the maximal start point
+    and minimal stop point.
+
+    Parameters
+    ----------
+    spiketrains: neo.SpikeTrain object, list or array of neo.core.SpikeTrain
+                 objects
+        List of neo.core SpikeTrain objects to extract `t_start` and
+        `t_stop` from.
+
+    Returns
+    -------
+    start : quantities.Quantity
+        Start point extracted from input :attr:`spiketrains`
+    stop : quantities.Quantity
+        Stop point extracted from input :attr:`spiketrains`
+    """
+    if isinstance(spiketrains, neo.SpikeTrain):
+        return spiketrains.t_start, spiketrains.t_stop
+    else:
+        start = max([elem.t_start for elem in spiketrains])
+        stop = min([elem.t_stop for elem in spiketrains])
+    return start, stop
+
+
+class Binned:
+    """
+    Class which calculates a binned spike train and provides methods to
+    transform the binned spike train to clipped or unclipped matrix.
+
+    A binned spike train represents the occurrence of spikes in a certain time
+    frame.
+    I.e., a time series like [0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] is
+    represented as [0, 0, 1, 3, 4, 5, 6]. The outcome is dependent on given
+    parameter such as size of bins, number of bins, start and stop points.
+
+    A clipped matrix represents the binned spike train in a binary manner.
+    It's rows represent the number of spike trains
+    and the columns represent the binned index position of a spike in a
+    spike train.
+    The calculated matrix columns contain only ones, which indicate
+    a spike.
+
+    An unclipped matrix is calculated the same way, but its columns
+    contain the number of spikes that occurred in the spike train(s). It counts
+    the occurrence of the timing of a spike in its respective spike train.
+
+    Parameters
+    ----------
+    spiketrains : List of `neo.SpikeTrain` or a `neo.SpikeTrain` object
+        Object or list of `neo.core.SpikeTrain` objects to be binned.
+    binsize : quantities.Quantity
+        Width of each time bin.
+        Default is `None`
+    num_bins : int
+        Number of bins of the binned spike train.
+        Default is `None`
+    t_start : quantities.Quantity
+        Time of the first bin (left extreme; included).
+        Default is `None`
+    t_stop : quantities.Quantity
+        Stopping time of the last bin (right extreme; excluded).
+        Default is `None`
+    store_mat : bool
+        If set to **True** unclipped matrix will be stored in memory.
+        If set to **False** matrix will always be calculated on demand.
+        This boolean indicates that the unclipped matrix will be stored in
+        memory.
+        Default is False.
+
+    See also
+    --------
+    __convert_to_binned
+    spike_indices
+    mat_clipped
+    mat_unclipped
+
+    Notes
+    -----
+    There are four cases the given parameters must fulfill.
+    Each parameter must be a combination of following order or it will raise
+    a value error:
+    * t_start, num_bins, binsize
+    * t_start, num_bins, t_stop
+    * t_start, bin_size, t_stop
+    * t_stop, num_bins, binsize
+
+    It is possible to give the SpikeTrain objects and one parameter
+    (:attr:`num_bins` or :attr:`binsize`). The start and stop time will be
+    calculated from given SpikeTrain objects (max start and min stop point).
+    Missing parameter will also be calculated automatically.
+
+    """
+
+    def __init__(self, spiketrains, binsize=None, num_bins=None, t_start=None,
+                 t_stop=None, store_mat=False):
+        """
+        Defines a binned spike train class
+
+        """
+        # Converting spiketrains to a list, if spiketrains is one
+        # SpikeTrain object
+        if type(spiketrains) == neo.core.SpikeTrain:
+            spiketrains = [spiketrains]
+
+        # Check that spiketrains is a list of neo Spike trains.
+        if not all([type(elem) == neo.core.SpikeTrain for elem in spiketrains]):
+            raise TypeError(
+                "All elements of the input list must be neo.core.SpikeTrain "
+                "objects ")
+        # Link to input
+        self.lst_input = spiketrains
+        # Set given parameter
+        self.t_start = t_start
+        self.t_stop = t_stop
+        self.num_bins = num_bins
+        self.binsize = binsize
+        self.matrix_columns = num_bins
+        self.matrix_rows = len(spiketrains)
+        # Boolean, indicates if matrix shall stored
+        self.store_mat_u = store_mat
+        # Empty matrix for storage, unclipped matrix
+        self.mat_u = None
+        # Check all parameter, set also missing values
+        self.__calc_start_stop(spiketrains)
+        self.__check_init_params(binsize, num_bins, self.t_start, self.t_stop)
+        self.__check_consistency(spiketrains, self.binsize, self.num_bins,
+                                 self.t_start, self.t_stop)
+        # Variables to store the sparse matrices
+        self._sparse_mat_u = None
+        self._sparse_mat_c = None
+        # Now create unclipped version of sparse matrix
+        self.__convert_to_binned(spiketrains)
+
+    # =========================================================================
+    # There are four cases the given parameters must fulfill
+    # Each parameter must be a combination of following order or it will raise
+    # a value error:
+    # t_start, num_bins, binsize
+    # t_start, num_bins, t_stop
+    # t_start, bin_size, t_stop
+    # t_stop, num_bins, binsize
+    # ==========================================================================
+
+    def __check_init_params(self, binsize, num_bins, t_start, t_stop):
+        """
+        Checks given parameter.
+        Calculates also missing parameter.
+
+        Parameters
+        ----------
+        binsize : quantity.Quantity
+            Size of Bins
+        num_bins : int
+            Number of Bins
+        t_start: quantity.Quantity
+            Start time of the spike
+        t_stop: quantity.Quantity
+            Stop time of the spike
+
+        Raises
+        ------
+        ValueError :
+            If all parameters are `None`, a ValueError is raised.
+        TypeError:
+            If type of :attr:`num_bins` is not an Integer.
+        """
+        # Raise error if no argument is given
+        if binsize is None and t_start is None and t_stop is None \
+                and num_bins is None:
+            raise ValueError(
+                "No arguments given. Please enter at least three arguments")
+        # Check if num_bins is an integer (special case)
+        if num_bins is not None:
+            if type(num_bins) is not int:
+                raise TypeError("num_bins is not an integer!")
+        # Check if all parameters can be calculated, otherwise raise ValueError
+        if t_start is None:
+            self.t_start = calc_tstart(num_bins, binsize, t_stop)
+        elif t_stop is None:
+            self.t_stop = calc_tstop(num_bins, binsize, t_start)
+        elif num_bins is None:
+            self.num_bins = calc_num_bins(binsize, t_start, t_stop)
+            if self.matrix_columns is None:
+                self.matrix_columns = self.num_bins
+        elif binsize is None:
+            self.binsize = calc_binsize(num_bins, t_start, t_stop)
+
+    def __calc_start_stop(self, spiketrains):
+        """
+        Calculates start, stop from given spike trains.
+
+         The start and stop points are calculated from given spike trains, only
+         if they are not calculable from given parameter or the number of
+         parameters is less than three.
+
+        """
+        if self.__count_params() is False:
+            if self.t_stop is None:
+                start, stop = set_start_stop_from_input(spiketrains)
+                self.t_start = start
+            if self.t_stop is None:
+                if stop:
+                    self.t_stop = stop
+                else:
+                    self.t_stop = set_start_stop_from_input(spiketrains)[1]
+
+    def __count_params(self):
+        """
+        Counts the parameter and returns **True** if the count is greater
+        or equal to `3`.
+
+        The calculation of the binned matrix is only possible if there are at
+        least three parameter (fourth parameter will be calculated out of
+        them).
+        This method counts the necessary parameter and returns **True** if the
+        count is greater or equal to `3`.
+
+        Returns
+        -------
+        bool :
+            True, if the count is greater or equal to `3`.
+            False, otherwise.
+
+        """
+        param_count = 0
+        if self.t_start:
+            param_count += 1
+        if self.t_stop:
+            param_count += 1
+        if self.binsize:
+            param_count += 1
+        if self.num_bins:
+            param_count += 1
+        return False if param_count < 3 else True
+
+    def __check_consistency(self, spiketrains, binsize, num_bins, t_start,
+                            t_stop):
+        """
+        Checks the given parameters for consistency
+
+        Raises
+        ------
+        ValueError :
+            A ValueError is raised if an inconsistency regarding the parameter
+            appears.
+        AttributeError :
+            An AttributeError is raised if there is an insufficient number of
+            parameters.
+
+        """
+        if self.__count_params() is False:
+            raise AttributeError("Too less parameter given. Please provide "
+                                 "at least one of the parameter which are "
+                                 "None.\n"
+                                 "t_start: %s, t_stop: %s, binsize: %s, "
+                                 "numb_bins: %s" % (
+                                     self.t_start,
+                                     self.t_stop,
+                                     self.binsize,
+                                     self.num_bins))
+        t_starts = [elem.t_start for elem in spiketrains]
+        t_stops = [elem.t_stop for elem in spiketrains]
+        max_tstart = max(t_starts)
+        min_tstop = min(t_stops)
+        if max_tstart >= min_tstop:
+            raise ValueError(
+                "Starting time of each spike train must be smaller than each "
+                "stopping time")
+        elif t_start < max_tstart or t_start > min_tstop:
+            raise ValueError(
+                'some spike trains are not defined in the time given '
+                'by t_start')
+        elif num_bins != int((
+                    (t_stop - t_start).rescale(binsize.units) / binsize).magnitude):
+            raise ValueError(
+                "Inconsistent arguments t_start (%s), " % t_start +
+                "t_stop (%s), binsize (%d) " % (t_stop, binsize) +
+                "and num_bins (%d)" % num_bins)
+        elif not (t_start < t_stop <= min_tstop):
+            raise ValueError(
+                'too many / too large time bins. Some spike trains are '
+                'not defined in the ending time')
+        elif num_bins - int(num_bins) != 0 or num_bins < 0:
+            raise TypeError(
+                "Number of bins (num_bins) is not an integer: " + str(
+                    num_bins))
+        elif t_stop > min_tstop or t_stop < max_tstart:
+            raise ValueError(
+                'some spike trains are not defined in the time given '
+                'by t_stop')
+        elif self.matrix_columns < 1 or self.num_bins < 1:
+            raise ValueError(
+                "Calculated matrix columns and/or num_bins are smaller "
+                "than 1: (matrix_columns: %s, num_bins: %s). "
+                "Please check your input parameter." % (
+                    self.matrix_columns, self.num_bins))
+
+    @property
+    def edges(self):
+        """
+        Returns all time edges with :attr:`num_bins` bins as a quantity array.
+
+        The borders of all time steps between start and stop [start, stop]
+        with:attr:`num_bins` bins are regarded as edges.
+        The border of the last bin is included.
+
+        Returns
+        -------
+        bin_edges : quantities.Quantity array
+            All edges in interval [start, stop] with :attr:`num_bins` bins
+            are returned as a quantity array.
+        """
+        return np.linspace(self.t_start, self.t_stop,
+                           self.num_bins + 1, endpoint=True)
+
+    @property
+    def left_edges(self):
+        """
+        Returns an quantity array containing all left edges and
+        :attr:`num_bins` bins.
+
+        The left borders of all time steps between start and excluding stop
+        [start, stop) with number of bins from given input are regarded as
+        edges.
+        The border of the last bin is excluded.
+
+        Returns
+        -------
+        bin_edges : quantities.Quantity array
+            All edges in interval [start, stop) with :attr:`num_bins` bins
+            are returned as a quantity array.
+        """
+        return np.linspace(self.t_start, self.t_stop, self.num_bins,
+                           endpoint=False)
+
+    @property
+    def right_edges(self):
+        """
+        Returns the right edges with :attr:`num_bins` bins as a
+        quantities array.
+
+        The right borders of all time steps between excluding start and
+        including stop (start, stop] with :attr:`num_bins` from given input
+        are regarded as edges.
+        The border of the first bin is excluded, but the last border is
+        included.
+
+        Returns
+        -------
+        bin_edges : quantities.Quantity array
+            All edges in interval [start, stop) with :attr:`num_bins` bins
+            are returned as a quantity array.
+        """
+        return self.left_edges + self.binsize
+
+    @property
+    def center_edges(self):
+        """
+        Returns each center time point of all bins between start and stop
+        points.
+
+        The center of each bin of all time steps between start and stop
+        (start, stop).
+
+        Returns
+        -------
+        bin_edges : quantities.Quantity array
+            All center edges in interval (start, stop) are returned as
+            a quantity array.
+        """
+        return self.left_edges + self.binsize / 2
+
+    @property
+    def sparse_mat_unclip(self):
+        """
+        Getter for **unclipped** version of the sparse matrix.
+
+        Returns
+        -------
+        matrix: scipy.sparse.csr_matrix
+            Sparse matrix, counted, unclipped version.
+
+        See also
+        --------
+        scipy.sparse.csr_matrix
+        mat_unclipped
+        """
+        if self._sparse_mat_u is not None:
+            return self._sparse_mat_u
+
+    @property
+    def sparse_mat_clip(self):
+        """
+        Getter for **clipped** version of the sparse matrix.
+
+        Returns
+        -------
+        matrix: scipy.sparse.csr_matrix
+            Sparse matrix, binary, clipped version.
+
+        See also
+        --------
+        scipy.sparse.csr_matrix
+        mat_clipped
+        """
+        if self._sparse_mat_c is not None:
+            return self._sparse_mat_c
+        # Return sparse Matrix without storing
+        tmp_mat = self._sparse_mat_u.copy()
+        tmp_mat[tmp_mat.nonzero()] = 1
+        return tmp_mat
+
+    def store_sparse_mat_clip(self):
+        """
+        Stores the clipped version of the matrix in memory.
+
+        """
+        if self._sparse_mat_c is not None:
+            self._sparse_mat_c = self.sparse_mat_clip
+
+    @property
+    def spike_indices(self):
+        """
+        A list of lists for each spike train (i.e., rows of the binned matrix),
+        that in turn contains for each spike the index into the binned matrix
+        where this spike enters.
+
+        In contrast to sparse_mat_unclip.nonzero(), this function will report
+        two spikes falling in the same bin as two entries.
+
+        Examples
+        --------
+        >>> import elephant.conversion as conv
+        >>> import neo as n
+        >>> import quantities as pq
+        >>> st = n.SpikeTrain([0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] * pq.s, t_stop=10.0 * pq.s)
+        >>> x = conv.Binned(st, num_bins=10, binsize=1 * pq.s, t_start=0 * pq.s)
+        >>> print(x.spike_indices)
+        [[0, 0, 1, 3, 4, 5, 6]]
+        >>> print(x.sparse_mat_unclip.nonzero()[1])
+        [0 1 3 4 5 6]
+
+        """
+        spike_idx = []
+        for row in self._sparse_mat_u:
+            l = []
+            # Extract each non-zeros column index and how often it exists,
+            # i.e., how many spikes fall in this column
+            for col, count in zip(row.nonzero()[1], row.data):
+                # Append the column index for each spike
+                l.extend([col] * count)
+            spike_idx.append(l)
+        return spike_idx
+
+    @property
+    def mat_clipped(self):
+        """
+        Returns a sparse matrix (`scipy.sparse.csr_matrix`), which rows
+        represent the number of spike trains and the columns represent the
+        binned index position of a spike in a spike train.
+        The matrix columns contain only ones, which indicate a spike.
+
+        Returns
+        -------
+        clipped matrix : numpy.ndarray
+            Returns a dense matrix representation of the sparse matrix,
+            with ones indicating a spike and zeros for non spike.
+            The ones in the columns represent the index
+            position of the spike in the spike train and rows represent the
+            number of spike trains.
+
+        Examples
+        --------
+        >>> import elephant.conversion as conv
+        >>> import neo as n
+        >>> import quantities as pq
+        >>> a = n.SpikeTrain([0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] * pq.s, t_stop=10.0 * pq.s)
+        >>> x = conv.Binned(a, num_bins=10, binsize=1 * pq.s, t_start=0 * pq.s)
+        >>> print(x.mat_clipped)
+        [[1 1 0 1 1 1 1 0 0 0]]
+
+        See also
+        --------
+        scipy.sparse.csr_matrix
+        scipy.sparse.csr_matrix.toarray
+        """
+        return abs(scipy.sign(self.mat_unclipped))
+
+    @property
+    def mat_unclipped(self):
+        """
+        Returns the sparse matrix, which rows represents the number of
+        spike trains and the columns represents the binned index position
+        of a spike in a spike train.
+        The  matrix columns contain the number of spikes that
+        occurred in the spike train(s).
+        If **bool** :attr:`store_mat` is set to **True** last calculated
+        `unclipped` matrix will be returned.
+
+        Returns
+        -------
+        unclipped matrix : numpy.ndarray
+            Matrix with spike times. Columns represent the index position of
+            the binned spike and rows represent the number of spike trains.
+
+        Examples
+        --------
+        >>> import elephant.conversion as conv
+        >>> import neo as n
+        >>> a = n.SpikeTrain([0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] * pq.s, t_stop=10.0 * pq.s)
+        >>> x = conv.Binned(a, num_bins=10, binsize=1 * pq.s, t_start=0 * pq.s)
+        >>> print(x.mat_unclipped)
+        [[2 1 0 1 1 1 1 0 0 0]]
+
+        See also
+        --------
+        scipy.sparse.csr_matrix
+        scipy.sparse.csr_matrix.toarray
+
+        """
+        if self.mat_u is not None:
+            return self.mat_u
+        if self.store_mat_u:
+            self.mat_u = self.sparse_mat_unclip.toarray()
+            return self.mat_u
+        # Matrix on demand
+        else:
+            return self._sparse_mat_u.toarray()
+
+    def store_mat_unclipped(self):
+        if self.mat_u is None:
+            self.mat_u = self.sparse_mat_unclip.toarray()
+            self.store_mat_u = True
+
+    def __convert_to_binned(self, spiketrains):
+        """
+        Converts neo.core.SpikeTrain objects to a sparse matrix
+        (`scipy.sparse.csr_matrix`), which contains the binned times.
+
+        Parameters
+        ----------
+        spiketrains : neo.SpikeTrain object or list of SpikeTrain objects
+           The binned time array :attr:`spike_indices` is calculated from a
+           SpikeTrain object or from a list of SpikeTrain objects.
+
+        Examples
+        --------
+        >>> import elephant.conversion as conv
+        >>> import neo as n
+        >>> import quantities as pq
+        >>> a = n.SpikeTrain([0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] * pq.s, t_stop=10.0 * pq.s)
+        >>> x = conv.Binned(a, num_bins=10, binsize=1 * pq.s, t_start=0 * pq.s)
+        >>> print(x.sparse_mat_unclip.nonzero()[1])
+        [0 1 3 4 5 6]
+        """
+        lil_mat = sps.lil_matrix((self.matrix_rows, self.matrix_columns),
+                                 dtype=int)
+        for idx, elem in enumerate(spiketrains):
+            ev = elem.view(pq.Quantity)
+            scale = np.array(((ev - self.t_start).rescale(
+                self.binsize.units) / self.binsize).magnitude, dtype=int)
+            l = np.logical_and(ev >= self.t_start.rescale(self.binsize.units),
+                               ev <= self.t_stop.rescale(self.binsize.units))
+            filled = scale[l]
+            filled = filled[filled < self.num_bins]
+            for inner_elem in filled:
+                lil_mat[idx, inner_elem] += 1
+        self._sparse_mat_u = lil_mat.tocsr()

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -17,7 +17,7 @@ import elephant.conversion as cv
 
 
 def get_nearest(times, time):
-    return (np.abs(times-time)).argmin()
+    return (np.abs(times - time)).argmin()
 
 
 class binarize_TestCase(unittest.TestCase):
@@ -27,7 +27,7 @@ class binarize_TestCase(unittest.TestCase):
     def test_binarize_with_spiketrain_exact(self):
         st = neo.SpikeTrain(self.test_array_1d, units='ms',
                             t_stop=10.0, sampling_rate=100)
-        times = np.arange(0, 10.+.01, .01)
+        times = np.arange(0, 10. + .01, .01)
         target = np.zeros_like(times).astype('bool')
         for time in self.test_array_1d:
             target[get_nearest(times, time)] = True
@@ -40,7 +40,7 @@ class binarize_TestCase(unittest.TestCase):
     def test_binarize_with_spiketrain_exact_set_ends(self):
         st = neo.SpikeTrain(self.test_array_1d, units='ms',
                             t_stop=10.0, sampling_rate=100)
-        times = np.arange(5., 10.+.01, .01)
+        times = np.arange(5., 10. + .01, .01)
         target = np.zeros_like(times).astype('bool')
         times = pq.Quantity(times, units='ms')
 
@@ -51,7 +51,7 @@ class binarize_TestCase(unittest.TestCase):
     def test_binarize_with_spiketrain_round(self):
         st = neo.SpikeTrain(self.test_array_1d, units='ms',
                             t_stop=10.0, sampling_rate=10.0)
-        times = np.arange(0, 10.+.1, .1)
+        times = np.arange(0, 10. + .1, .1)
         target = np.zeros_like(times).astype('bool')
         for time in np.round(self.test_array_1d, 1):
             target[get_nearest(times, time)] = True
@@ -63,44 +63,44 @@ class binarize_TestCase(unittest.TestCase):
 
     def test_binarize_with_quantities_exact(self):
         st = pq.Quantity(self.test_array_1d, units='ms')
-        times = np.arange(0, 1.23+.01, .01)
+        times = np.arange(0, 1.23 + .01, .01)
         target = np.zeros_like(times).astype('bool')
         for time in self.test_array_1d:
             target[get_nearest(times, time)] = True
         times = pq.Quantity(times, units='ms')
 
         res, tres = cv.binarize(st, return_times=True,
-                                sampling_rate=100.*pq.kHz)
+                                sampling_rate=100. * pq.kHz)
         assert_array_almost_equal(res, target, decimal=9)
         assert_array_almost_equal(tres, times, decimal=9)
 
     def test_binarize_with_quantities_exact_set_ends(self):
         st = pq.Quantity(self.test_array_1d, units='ms')
-        times = np.arange(0, 10.+.01, .01)
+        times = np.arange(0, 10. + .01, .01)
         target = np.zeros_like(times).astype('bool')
         for time in self.test_array_1d:
             target[get_nearest(times, time)] = True
         times = pq.Quantity(times, units='ms')
 
         res, tres = cv.binarize(st, return_times=True, t_stop=10.,
-                                sampling_rate=100.*pq.kHz)
+                                sampling_rate=100. * pq.kHz)
         assert_array_almost_equal(res, target, decimal=9)
         assert_array_almost_equal(tres, times, decimal=9)
 
     def test_binarize_with_quantities_round_set_ends(self):
         st = pq.Quantity(self.test_array_1d, units='ms')
-        times = np.arange(5., 10.+.1, .1)
+        times = np.arange(5., 10. + .1, .1)
         target = np.zeros_like(times).astype('bool')
         times = pq.Quantity(times, units='ms')
 
         res, tres = cv.binarize(st, return_times=True, t_start=5., t_stop=10.,
-                                sampling_rate=10.*pq.kHz)
+                                sampling_rate=10. * pq.kHz)
         assert_array_almost_equal(res, target, decimal=9)
         assert_array_almost_equal(tres, times, decimal=9)
 
     def test_binarize_with_plain_array_exact(self):
         st = self.test_array_1d
-        times = np.arange(0, 1.23+.01, .01)
+        times = np.arange(0, 1.23 + .01, .01)
         target = np.zeros_like(times).astype('bool')
         for time in self.test_array_1d:
             target[get_nearest(times, time)] = True
@@ -111,18 +111,19 @@ class binarize_TestCase(unittest.TestCase):
 
     def test_binarize_with_plain_array_exact_set_ends(self):
         st = self.test_array_1d
-        times = np.arange(0, 10.+.01, .01)
+        times = np.arange(0, 10. + .01, .01)
         target = np.zeros_like(times).astype('bool')
         for time in self.test_array_1d:
             target[get_nearest(times, time)] = True
 
-        res, tres = cv.binarize(st, return_times=True, t_stop=10., sampling_rate=100.)
+        res, tres = cv.binarize(st, return_times=True, t_stop=10.,
+                                sampling_rate=100.)
         assert_array_almost_equal(res, target, decimal=9)
         assert_array_almost_equal(tres, times, decimal=9)
 
     def test_binarize_no_time(self):
         st = self.test_array_1d
-        times = np.arange(0, 1.23+.01, .01)
+        times = np.arange(0, 1.23 + .01, .01)
         target = np.zeros_like(times).astype('bool')
         for time in self.test_array_1d:
             target[get_nearest(times, time)] = True
@@ -154,7 +155,7 @@ class binarize_TestCase(unittest.TestCase):
                           t_stop=pq.Quantity(10, 'ms'),
                           sampling_rate=10.)
         self.assertRaises(TypeError, cv.binarize, st,
-                          sampling_rate=10.*pq.Hz)
+                          sampling_rate=10. * pq.Hz)
 
     def test_binariz_without_sampling_rate_valueerror(self):
         st0 = self.test_array_1d
@@ -172,6 +173,274 @@ class binarize_TestCase(unittest.TestCase):
                           t_start=0., t_stop=pq.Quantity(10, 'ms'))
         self.assertRaises(ValueError, cv.binarize, st1)
 
+
+class BinnedTestCase(unittest.TestCase):
+    def setUp(self):
+        self.spiketrain_a = neo.SpikeTrain(
+            [0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] * pq.s, t_stop=10.0 * pq.s)
+        self.spiketrain_b = neo.SpikeTrain(
+            [0.1, 0.7, 1.2, 2.2, 4.3, 5.5, 8.0] * pq.s, t_stop=10.0 * pq.s)
+        self.binsize = 1 * pq.s
+
+    def tearDown(self):
+        self.spiketrain_a = None
+        del self.spiketrain_a
+        self.spiketrain_b = None
+        del self.spiketrain_b
+
+    def test_binned_sparse(self):
+        a = neo.SpikeTrain([1.7, 1.8, 4.3] * pq.s, t_stop=10.0 * pq.s)
+        b = neo.SpikeTrain([1.7, 1.8, 4.3] * pq.s, t_stop=10.0 * pq.s)
+        binsize = 1 * pq.s
+        nbins = 10
+        x = cv.Binned([a, b], num_bins=nbins, binsize=binsize,
+                      t_start=0 * pq.s)
+        x_sparse = [2, 1, 2, 1]
+        s = x.sparse_mat_unclip
+        self.assertTrue(np.array_equal(s.data, x_sparse))
+        self.assertTrue(
+            np.array_equal(x.spike_indices, [[1, 1, 4], [1, 1, 4]]))
+
+    def test_binned_shape(self):
+        a = self.spiketrain_a
+        x_unclipped = cv.Binned(a, num_bins=10,
+                                binsize=self.binsize,
+                                t_start=0 * pq.s)
+        x_clipped = cv.Binned(a, num_bins=10, binsize=self.binsize,
+                              t_start=0 * pq.s)
+        self.assertTrue(x_unclipped.mat_unclipped.shape == (1, 10))
+        self.assertTrue(x_clipped.mat_clipped.shape == (1, 10))
+
+    # shape of the matrix for a list of spike trains
+    def test_binned_shape_list(self):
+        a = self.spiketrain_a
+        b = self.spiketrain_b
+        c = [a, b]
+        nbins = 5
+        x_unclipped = cv.Binned(c, num_bins=nbins, t_start=0 * pq.s,
+                                t_stop=10.0 * pq.s)
+        x_clipped = cv.Binned(c, num_bins=nbins, t_start=0 * pq.s,
+                              t_stop=10.0 * pq.s)
+        self.assertTrue(x_unclipped.mat_unclipped.shape == (2, 5))
+        self.assertTrue(x_clipped.mat_clipped.shape == (2, 5))
+
+    def test_binned_neg_times(self):
+        a = neo.SpikeTrain([-6.5, 0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] * pq.s,
+                           t_start=-6.5 * pq.s, t_stop=10.0 * pq.s)
+        binsize = self.binsize
+        nbins = 16
+        x = cv.Binned(a, num_bins=nbins, binsize=binsize,
+                      t_start=-6.5 * pq.s)
+        y = [np.array([1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0])]
+        self.assertTrue(np.array_equal(x.mat_clipped, y))
+
+    def test_binned_neg_times_list(self):
+        a = neo.SpikeTrain([-6.5, 0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] * pq.s,
+                           t_start=-7 * pq.s, t_stop=7 * pq.s)
+        b = neo.SpikeTrain([-0.1, -0.7, 1.2, 2.2, 4.3, 5.5, 8.0] * pq.s,
+                           t_start=-1 * pq.s, t_stop=8 * pq.s)
+        c = [a, b]
+
+        binsize = self.binsize
+        x_clipped = cv.Binned(c, binsize=binsize)
+        y_clipped = [[0, 1, 1, 0, 1, 1, 1, 1],
+                     [1, 0, 1, 1, 0, 1, 1, 0]]
+
+        self.assertTrue(np.array_equal(x_clipped.mat_clipped, y_clipped))
+
+    # checking spike_indices(f) and matrix(m) for 1 spiketrain with clip(c) and
+    # without clip(u)
+    def test_binned_fmcu(self):
+        a = self.spiketrain_a
+        binsize = self.binsize
+        nbins = 10
+        x_unclipped = cv.Binned(a, num_bins=nbins, binsize=binsize,
+                                t_start=0 * pq.s)
+        x_clipped = cv.Binned(a, num_bins=nbins, binsize=binsize,
+                              t_start=0 * pq.s)
+        y_matrix_unclipped = [
+            np.array([2., 1., 0., 1., 1., 1., 1., 0., 0., 0.])]
+        y_matrix_clipped = [np.array([1., 1., 0., 1., 1., 1., 1., 0., 0., 0.])]
+        self.assertTrue(
+            np.array_equal(x_unclipped.mat_unclipped, y_matrix_unclipped))
+        self.assertTrue(
+            np.array_equal(x_clipped.mat_clipped, y_matrix_clipped))
+        self.assertTrue(
+            np.array_equal(x_clipped.mat_clipped, y_matrix_clipped))
+        s = x_clipped.sparse_mat_clip[x_clipped.sparse_mat_clip.nonzero()]
+        self.assertTrue(np.array_equal(s, [[1, 1, 1, 1, 1, 1]]))
+
+    def test_binned_fmcu_list(self):
+        a = self.spiketrain_a
+        b = self.spiketrain_b
+
+        binsize = self.binsize
+        nbins = 10
+        c = [a, b]
+        x_unclipped = cv.Binned(c, num_bins=nbins, binsize=binsize,
+                                t_start=0 * pq.s)
+        x_clipped = cv.Binned(c, num_bins=nbins, binsize=binsize,
+                              t_start=0 * pq.s)
+        y_matrix_unclipped = np.array(
+            [[2, 1, 0, 1, 1, 1, 1, 0, 0, 0], [2, 1, 1, 0, 1, 1, 0, 0, 1, 0]])
+        y_matrix_clipped = np.array(
+            [[1, 1, 0, 1, 1, 1, 1, 0, 0, 0], [1, 1, 1, 0, 1, 1, 0, 0, 1, 0]])
+        self.assertTrue(
+            np.array_equal(x_unclipped.mat_unclipped, y_matrix_unclipped))
+        self.assertTrue(
+            np.array_equal(x_clipped.mat_clipped, y_matrix_clipped))
+
+    # t_stop is None
+    def test_binned_list_t_stop(self):
+        a = self.spiketrain_a
+        b = self.spiketrain_b
+        c = [a, b]
+        binsize = self.binsize
+        nbins = 10
+        x = cv.Binned(c, num_bins=nbins, binsize=binsize, t_start=0 * pq.s,
+                      t_stop=None)
+        x_clipped = cv.Binned(c, num_bins=nbins, binsize=binsize,
+                              t_start=0 * pq.s)
+        self.assertTrue(x.t_stop == 10 * pq.s)
+        self.assertTrue(x_clipped.t_stop == 10 * pq.s)
+
+    # Test number of bins
+    def test_binned_list_numbins(self):
+        a = self.spiketrain_a
+        b = self.spiketrain_b
+        c = [a, b]
+        binsize = 1 * pq.s
+        x_unclipped = cv.Binned(c, binsize=binsize, t_start=0 * pq.s,
+                                t_stop=10. * pq.s)
+        x_clipped = cv.Binned(c, binsize=binsize, t_start=0 * pq.s,
+                              t_stop=10. * pq.s)
+        self.assertTrue(x_unclipped.num_bins == 10)
+        self.assertTrue(x_clipped.num_bins == 10)
+
+    def test_binned_matrix(self):
+        # Init
+        a = self.spiketrain_a
+        b = self.spiketrain_b
+        x_clipped_a = cv.Binned(a, binsize=pq.s, t_start=0 * pq.s,
+                                t_stop=10. * pq.s)
+        x_clipped_b = cv.Binned(b, binsize=pq.s, t_start=0 * pq.s,
+                                t_stop=10. * pq.s, store_mat=True)
+
+        # Assumed results
+        y_matrix_unclipped_a = [np.array([2, 1, 0, 1, 1, 1, 1, 0, 0, 0])]
+        y_matrix_clipped_a = [np.array([1, 1, 0, 1, 1, 1, 1, 0, 0, 0])]
+        y_matrix_clipped_b = [np.array([1, 1, 1, 0, 1, 1, 0, 0, 1, 0])]
+        y_clip_add = [np.array(
+            [1, 1, 1, 1, 1, 1, 1, 0, 1, 0])]  # matrix of the clipped addition
+        y_uclip_add = [np.array([4, 2, 1, 1, 2, 2, 1, 0, 1, 0])]
+        # Asserts
+        self.assertTrue(
+            np.array_equal(x_clipped_a.mat_clipped, y_matrix_clipped_a))
+        self.assertTrue(np.array_equal(x_clipped_b.mat_clipped,
+                                       y_matrix_clipped_b))
+        self.assertTrue(
+            np.array_equal(x_clipped_a.mat_unclipped,
+                           y_matrix_unclipped_a))
+
+    def test_binned_matrix_storing(self):
+        a = self.spiketrain_a
+        b = self.spiketrain_b
+
+        x_clipped = cv.Binned(a, binsize=pq.s, t_start=0 * pq.s,
+                              t_stop=10. * pq.s, store_mat=True)
+        x_unclipped = cv.Binned(b, binsize=pq.s, t_start=0 * pq.s,
+                                t_stop=10. * pq.s, store_mat=True)
+        # Store Matrix in variable
+        matrix_clipped = x_clipped.mat_clipped
+        matrix_unclipped = x_unclipped.mat_unclipped
+
+        # Check for boolean
+        self.assertEqual(x_unclipped.store_mat_u, True)
+        # Check if same matrix
+        self.assertTrue(np.array_equal(x_unclipped.mat_u,
+                                       matrix_unclipped))
+        # Get the stored matrix using method
+        self.assertTrue(
+            np.array_equal(x_clipped.mat_clipped,
+                           matrix_clipped))
+        self.assertTrue(
+            np.array_equal(x_unclipped.mat_unclipped,
+                           matrix_unclipped))
+        x_unclipped.store_mat_unclipped()
+
+        # Test storing of sparse mat
+        sparse_clip = x_clipped.sparse_mat_clip
+        x_clipped.store_sparse_mat_clip()
+        self.assertTrue(np.array_equal(sparse_clip.toarray(),
+                                       x_clipped.sparse_mat_clip.toarray()))
+
+        # New class without calculating the matrix
+        x_clipped = cv.Binned(a, binsize=pq.s, t_start=0 * pq.s,
+                              t_stop=10. * pq.s, store_mat=True)
+        x_unclipped = cv.Binned(b, binsize=pq.s, t_start=0 * pq.s,
+                                t_stop=10. * pq.s, store_mat=True)
+        # No matrix calculated, should be None
+        self.assertEqual(x_unclipped.mat_u, None)
+        # Test with stored matrix
+        self.assertFalse(np.array_equal(x_unclipped, matrix_unclipped))
+
+    # Test if t_start is calculated correctly
+    def test_binned_parameter_calc_tstart(self):
+        a = self.spiketrain_a
+        x = cv.Binned(a, binsize=1 * pq.s, num_bins=10,
+                      t_stop=10. * pq.s)
+        self.assertEqual(x.t_start, 0. * pq.s)
+        self.assertEqual(x.t_stop, 10. * pq.s)
+        self.assertEqual(x.binsize, 1 * pq.s)
+        self.assertEqual(x.num_bins, 10)
+
+    # Test if error raises when type of num_bins is not an integer
+    def test_binned_numbins_type_error(self):
+        a = self.spiketrain_a
+        self.assertRaises(TypeError, cv.Binned, a, binsize=pq.s,
+                          num_bins=1.4, t_start=0 * pq.s, t_stop=10. * pq.s)
+
+    # Test if error is raised when providing insufficient number of parameter
+    def test_binned_insufficient_arguments(self):
+        a = self.spiketrain_a
+        self.assertRaises(AttributeError, cv.Binned, a)
+
+    # Test edges
+    def test_binned_bin_edges(self):
+        a = self.spiketrain_a
+        x = cv.Binned(a, binsize=1 * pq.s, num_bins=10,
+                      t_stop=10. * pq.s)
+        # Test all edges
+        edges = [float(i) for i in range(11)]
+        self.assertTrue(np.array_equal(x.edges, edges))
+
+        # Test left edges
+        edges = [float(i) for i in range(10)]
+        self.assertTrue(np.array_equal(x.left_edges, edges))
+
+        # Test right edges
+        edges = [float(i) for i in range(1, 11)]
+        self.assertTrue(np.array_equal(x.right_edges, edges))
+
+        # Test center edges
+        edges = np.arange(0, 10) + 0.5
+        self.assertTrue(np.array_equal(x.center_edges, edges))
+
+    # Test for different units but same times
+    def test_binned_different_units(self):
+        a = self.spiketrain_a
+        b = a.rescale(pq.ms)
+        binsize = 1 * pq.s
+        xa = cv.Binned(a, binsize=binsize)
+        xb = cv.Binned(b, binsize=binsize.rescale(pq.ms))
+        self.assertTrue(
+            np.array_equal(xa.mat_clipped, xb.mat_clipped))
+        self.assertTrue(
+            np.array_equal(xa.sparse_mat_unclip.data,
+                           xb.sparse_mat_unclip.data))
+        self.assertTrue(
+            np.array_equal(xa.left_edges,
+                           xb.left_edges.rescale(binsize.units)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -10,7 +10,7 @@ import unittest
 
 import neo
 import numpy as np
-from numpy.testing.utils import assert_array_almost_equal
+from numpy.testing.utils import assert_array_almost_equal, assert_array_equal
 import quantities as pq
 
 import elephant.statistics as es
@@ -334,6 +334,51 @@ class LVTestCase(unittest.TestCase):
         self.assertRaises(AttributeError, es.lv, [])
         self.assertRaises(AttributeError, es.lv, 1)
         self.assertRaises(ValueError, es.lv, np.array([seq, seq]))
+
+
+class PSTHTestCase(unittest.TestCase):
+    def setUp(self):
+        self.spiketrain_a = neo.SpikeTrain(
+            [0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] * pq.s, t_stop=10.0 * pq.s)
+        self.spiketrain_b = neo.SpikeTrain(
+            [0.1, 0.7, 1.2, 2.2, 4.3, 5.5, 8.0] * pq.s, t_stop=10.0 * pq.s)
+        self.spiketrains = [self.spiketrain_a, self.spiketrain_b]
+
+    def tearDown(self):
+        del self.spiketrain_a
+        self.spiketrain_a = None
+        del self.spiketrain_b
+        self.spiketrain_b = None
+
+    def test_psth_unclipped(self):
+        targ = [4, 2, 1, 1, 2, 2, 1, 0, 1, 0]
+        psth = es.psth(self.spiketrains, w=pq.s)
+        assert_array_equal(targ, psth.magnitude)
+
+    def test_psth_clipped(self):
+        targ = [2, 2, 1, 1, 2, 2, 1, 0, 1, 0]
+        psth = es.psth(self.spiketrains, w=pq.s, clip=True)
+        assert_array_equal(targ, psth.magnitude)
+
+    def test_psth_tstart_tstop(self):
+        # Start, stop short range
+        targ = [2, 1]
+        psth = es.psth(self.spiketrains, w=pq.s, t_start=5*pq.s, t_stop=7*pq.s)
+        assert_array_equal(targ, psth.magnitude)
+
+    def test_psth_output(self):
+        # Normalization mean
+        psth = es.psth(self.spiketrains, w=pq.s, output='mean')
+        targ = np.array([4, 2, 1, 1, 2, 2, 1, 0, 1, 0], dtype=float) / 2
+        assert_array_equal(targ, psth.magnitude)
+
+        # Normalization rate
+        psth = es.psth(self.spiketrains, w=pq.s, output='rate')
+        assert_array_equal(psth.view(pq.Quantity), targ * 1/pq.s)
+
+        # Normalization unspecified, raises error
+        self.assertRaises(ValueError, es.psth, self.spiketrains, w=pq.s,
+                          output=' ')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request contains two components. First we integrate a binning class `Binned` in the `conversion` module, that provides a representation of binned (clipped, unclipped) spike trains based on sparse matrices, which is an important feature for large sets of spike trains in combination with fine-grained binning. This binning class therefore acts more as a specialized data type within elephant. The advantage of this class is that it takes care of efficiently handling the sparse matrix management for the user (optionally keeping the “non-sparse” matrices in memory) and handles the clipping, but also keeps the time axis in order (similar to the `AnalogSignal` class of `Neo`). Please note: The existing binning function in elephant (`conversion.binarize`) has intentionally not been touched in this PR.

Second, we added a short function `psth` to the to `statistics` module that calculates the peristimulus time histogram (PSTH). It is meant as a very simple example of how to use the binning class in a function (however, more complex functions such as the correlation coefficient can exploit the benefits of the sparse matrix representation offered by the Binning class more dramatically).