### PR TITLE
added signal.welchpsd(), a power spectrum estimation function for AnalogSignal

### DIFF
--- a/elephant/signal.py
+++ b/elephant/signal.py
@@ -11,8 +11,9 @@ import quantities as pq
 import neo
 
 
-def welchpsd(data, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
-             **kargs):
+def welch_psd(data, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
+              fs=1.0, window='hanning', nfft=None, detrend='constant',
+              return_onesided=True, scaling='density', axis=-1):
     """
     Estimates power spectrum density (PSD) of a given AnalogSignal using
     Welch's method, which works in the following steps:
@@ -24,65 +25,73 @@ def welchpsd(data, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
             data is cut into 8 segments.
         2. apply a window function to each segment. Hanning window is used by
             default. This can be changed by giving a window function or an
-            array as parameter *window* (for details, see the documentation of
-            scipy.signal.welch())
+            array as parameter *window* (for details, see the docstring of
+            `scipy.signal.welch()`)
         3. compute the periodogram of each segment
         4. average the obtained periodograms to yield PSD estimate
-    These steps are implemented in scipy.signal, and this function is a wrapper
-    which provides a proper set of parameters to scipy.signal.welch(). Some
-    parameters for scipy.signal.welch(), such as *nfft*, *detrend*, *window*,
-    *return_onesided* and *scaling*, also works for this function.
+    These steps are implemented in `scipy.signal`, and this function is a
+    wrapper which provides a proper set of parameters to
+    `scipy.signal.welch()`. Some parameters for scipy.signal.welch(), such as
+    `nfft`, `detrend`, `window`, `return_onesided` and `scaling`, also works
+    for this function.
 
     Parameters
     ----------
-    data: AnalogSignal or AnalogSignalArray
-        time series data, of which PSD is estimated. When an AnalogSignalArray
-        is given, the function computes PSD estimates of single AnalogSignals
-        in the array
-    num_seg: int
-        number of segments. The length of segments is adjusted so that
+    data: Neo AnalogSignalArray or Quantity array or Numpy ndarray
+        Time series data, of which PSD is estimated. When a Quantity array or
+        Numpy ndarray is given, sampling frequency should be given through the
+        keyword argument `fs`, otherwise the default value (`fs=1.0`) is used.
+    num_seg: int, optional
+        Number of segments. The length of segments is adjusted so that
         overlapping segments cover the entire stretch of the given data. This
-        parameter is ignored if *len_seg* or *freq_res* is given. Default is 8
-    len_seg: int
-        length of segments. This parameter is ignored if *freq_res* is given.
-        Default is None
-    freq_res: Quantity or float
-        desired frequency resolution of the obtained PSD estimate. Default is
-        None
-    overlap: float
-        overlap between segments represented as a float number between 0 (no
-        overlap) and 1 (complete overlap). Default is 0.5 (half overlapped)
+        parameter is ignored if *len_seg* or *freq_res* is given. Default is 8.
+    len_seg: int, optional
+        Length of segments. This parameter is ignored if *freq_res* is given.
+        Default is None (determined from other parameters).
+    freq_res: Quantity or float, optional
+        Desired frequency resolution of the obtained PSD estimate in terms of
+        the interval between adjacent frequency bins. When given as a float, it
+        is taken as frequency in Hz. Default is None (determined from other
+        parameters).
+    overlap: float, optional
+        Overlap between segments represented as a float number between 0 (no
+        overlap) and 1 (complete overlap). Default is 0.5 (half-overlapped).
+    fs: Quantity array or float, optional
+        Specifies the sampling frequency of the input time series. When the
+        input is given as an AnalogSignalArray, the sampling frequency is taken
+        from its attribute and this parameter is ignored. Default is 1.0.
+    window, nfft, detrend, return_onesided, scaling, axis: optional
+        These arguments are directly passed on to scipy.signal.welch(). See the
+        respective descriptions in the docstring of `scipy.signal.welch()` for
+        usage.
 
     Returns
     -------
-    psd: Quantity array
-        estimated PSD. When an AnalogSignalArray is given as input, *psd* is an
-        array of the same shape as the input, which contains PSD estimates of
-        single AnalogSignals in the array
-    freqs Quantity array
-        frequencies associated with the power estimates in *psd*. *freqs* is
-        always a 1-dimensional array irrespective of whether the input is given
-        as AnalogSignal or AnalogSignalArray
+    freqs: Quantity array or Numpy ndarray
+        Frequencies associated with the power estimates in `psd`. `freqs` is
+        always a 1-dimensional array irrespective of the shape of the input
+        data. Quantity array is returned if `data` is AnalogSignalArray or
+        Quantity array. Otherwise Numpy ndarray containing frequency in Hz is
+        returned.
+    psd: Quantity array or Numpy ndarray
+        PSD estimates of the time series in `data`. Quantity array is returned
+        if `data` is AnalogSignalArray or Quantity array. Otherwise Numpy
+        ndarray is returned.
     """
 
     # initialize a parameter dict (to be given to scipy.signal.welch()) with
-    # the data array
-    params = {'x': np.asarray(data)}
+    # the data array and the parameters directly passed on to
+    # scipy.signal.welch()
+    params = {'x': np.asarray(data), 'window': window, 'nfft': nfft,
+              'detrend': detrend, 'return_onesided': return_onesided,
+              'scaling': scaling, 'axis': axis}
 
-    # if parameters supported by scipy.signal.welch() are given in *kargs*, add
-    # them to the dict. Some of the parameter values may be overridden
-    # afterwards
-    for key, val in kargs.items():
-        if key in ('fs', 'nperseg', 'detrend', 'window', 'noverlap', 'nfft',
-                   'return_onesided', 'scaling'):
-            params[key] = val
-        else:
-            raise ValueError("Unsupported keyword argument '{}'".format(key))
-
-    # specify sampling frequency if the data is given as AnalogSignal(Array)
-    if isinstance(data, neo.AnalogSignal) or \
-            isinstance(data, neo.AnalogSignalArray):
+    # if the data is given as AnalogSignalArray, use its attribute to specify
+    # the sampling frequency
+    if hasattr(data, 'sampling_rate'):
         params['fs'] = data.sampling_rate.rescale('Hz').magnitude
+    else:
+        params['fs'] = fs
 
     if overlap < 0:
         raise ValueError("overlap must be greater than or equal to 0")
@@ -94,29 +103,28 @@ def welchpsd(data, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
     if freq_res is not None:
         if freq_res <= 0:
             raise ValueError("freq_res must be positive")
-        Fs = data.sampling_rate.rescale('Hz').magnitude
         dF = freq_res.rescale('Hz').magnitude \
             if isinstance(freq_res, pq.quantity.Quantity) else freq_res
-        nperseg = int(Fs / dF)
-        if nperseg > data.shape[-1]:
+        nperseg = int(params['fs'] / dF)
+        if nperseg > data.shape[axis]:
             raise ValueError("freq_res is too high for the given data size")
     elif len_seg is not None:
         if len_seg <= 0:
             raise ValueError("len_seg must be a positive number")
-        elif data.shape[-1] < len_seg:
+        elif data.shape[axis] < len_seg:
             raise ValueError("len_seg must be shorter than the data length")
         nperseg = len_seg
     else:
         if num_seg <= 0:
             raise ValueError("num_seg must be a positive number")
-        elif data.shape[-1] < num_seg:
+        elif data.shape[axis] < num_seg:
             raise ValueError("num_seg must be smaller than the data length")
         # when only *num_seg* is given, *nperseg* is determined by solving the
         # following equation:
         #  num_seg * nperseg - (num_seg-1) * overlap * nperseg = data.shape[-1]
         #  -----------------   ===============================   ^^^^^^^^^^^
         # summed segment lengths        total overlap            data length
-        nperseg = int(data.shape[-1] / (num_seg - overlap * (num_seg - 1)))
+        nperseg = int(data.shape[axis] / (num_seg - overlap * (num_seg - 1)))
     params['nperseg'] = nperseg
     params['noverlap'] = int(nperseg * overlap)
 
@@ -130,4 +138,4 @@ def welchpsd(data, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
             psd = psd * data.units * data.units / pq.Hz
         freqs = freqs * pq.Hz
 
-    return psd, freqs
+    return freqs, psd

--- a/elephant/signal.py
+++ b/elephant/signal.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""
+docstring goes here.
+:copyright: Copyright 2015 by the Elephant team, see AUTHORS.txt.
+:license: Modified BSD, see LICENSE.txt for details.
+"""
+
+import numpy as np
+import scipy.signal
+import quantities as pq
+import neo
+
+
+def welchpsd(data, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
+             **kargs):
+    """
+    Estimates power spectrum density (PSD) of a given AnalogSignal using
+    Welch's method, which works in the following steps:
+        1. cut the given data into several overlapping segments. The degree of
+            overlap can be specified by parameter *overlap* (default is 0.5,
+            i.e. segments are overlapped by the half of their length).
+            The number and the length of the segments are determined according
+            to parameter *num_seg*, *len_seg* or *freq_res*. By default, the
+            data is cut into 8 segments.
+        2. apply a window function to each segment. Hanning window is used by
+            default. This can be changed by giving a window function or an
+            array as parameter *window* (for details, see the documentation of
+            scipy.signal.welch())
+        3. compute the periodogram of each segment
+        4. average the obtained periodograms to yield PSD estimate
+    These steps are implemented in scipy.signal, and this function is a wrapper
+    which provides a proper set of parameters to scipy.signal.welch(). Some
+    parameters for scipy.signal.welch(), such as *nfft*, *detrend*, *window*,
+    *return_onesided* and *scaling*, also works for this function.
+
+    Parameters
+    ----------
+    data: AnalogSignal or AnalogSignalArray
+        time series data, of which PSD is estimated. When an AnalogSignalArray
+        is given, the function computes PSD estimates of single AnalogSignals
+        in the array
+    num_seg: int
+        number of segments. The length of segments is adjusted so that
+        overlapping segments cover the entire stretch of the given data. This
+        parameter is ignored if *len_seg* or *freq_res* is given. Default is 8
+    len_seg: int
+        length of segments. This parameter is ignored if *freq_res* is given.
+        Default is None
+    freq_res: Quantity or float
+        desired frequency resolution of the obtained PSD estimate. Default is
+        None
+    overlap: float
+        overlap between segments represented as a float number between 0 (no
+        overlap) and 1 (complete overlap). Default is 0.5 (half overlapped)
+
+    Returns
+    -------
+    psd: Quantity array
+        estimated PSD. When an AnalogSignalArray is given as input, *psd* is an
+        array of the same shape as the input, which contains PSD estimates of
+        single AnalogSignals in the array
+    freqs Quantity array
+        frequencies associated with the power estimates in *psd*. *freqs* is
+        always a 1-dimensional array irrespective of whether the input is given
+        as AnalogSignal or AnalogSignalArray
+    """
+
+    # initialize a parameter dict (to be given to scipy.signal.welch()) with
+    # the data array
+    params = {'x': np.asarray(data)}
+
+    # if parameters supported by scipy.signal.welch() are given in *kargs*, add
+    # them to the dict. Some of the parameter values may be overridden
+    # afterwards
+    for key, val in kargs.items():
+        if key in ('fs', 'nperseg', 'detrend', 'window', 'noverlap', 'nfft',
+                   'return_onesided', 'scaling'):
+            params[key] = val
+        else:
+            raise ValueError("Unsupported keyword argument '{}'".format(key))
+
+    # specify sampling frequency if the data is given as AnalogSignal(Array)
+    if isinstance(data, neo.AnalogSignal) or \
+            isinstance(data, neo.AnalogSignalArray):
+        params['fs'] = data.sampling_rate.rescale('Hz').magnitude
+
+    if overlap < 0:
+        raise ValueError("overlap must be greater than or equal to 0")
+    elif 1 <= overlap:
+        raise ValueError("overlap must be less then 1")
+
+    # determine the length of segments (i.e. *nperseg*) according to given
+    # parameters
+    if freq_res is not None:
+        if freq_res <= 0:
+            raise ValueError("freq_res must be positive")
+        Fs = data.sampling_rate.rescale('Hz').magnitude
+        dF = freq_res.rescale('Hz').magnitude \
+            if isinstance(freq_res, pq.quantity.Quantity) else freq_res
+        nperseg = int(Fs / dF)
+        if nperseg > data.shape[-1]:
+            raise ValueError("freq_res is too high for the given data size")
+    elif len_seg is not None:
+        if len_seg <= 0:
+            raise ValueError("len_seg must be a positive number")
+        elif data.shape[-1] < len_seg:
+            raise ValueError("len_seg must be shorter than the data length")
+        nperseg = len_seg
+    else:
+        if num_seg <= 0:
+            raise ValueError("num_seg must be a positive number")
+        elif data.shape[-1] < num_seg:
+            raise ValueError("num_seg must be smaller than the data length")
+        # when only *num_seg* is given, *nperseg* is determined by solving the
+        # following equation:
+        #  num_seg * nperseg - (num_seg-1) * overlap * nperseg = data.shape[-1]
+        #  -----------------   ===============================   ^^^^^^^^^^^
+        # summed segment lengths        total overlap            data length
+        nperseg = int(data.shape[-1] / (num_seg - overlap * (num_seg - 1)))
+    params['nperseg'] = nperseg
+    params['noverlap'] = int(nperseg * overlap)
+
+    freqs, psd = scipy.signal.welch(**params)
+
+    # attach proper units to return values
+    if isinstance(data, pq.quantity.Quantity):
+        if 'scaling' in params and params['scaling'] is 'spectrum':
+            psd = psd * data.units * data.units
+        else:
+            psd = psd * data.units * data.units / pq.Hz
+        freqs = freqs * pq.Hz
+
+    return psd, freqs

--- a/elephant/test/test_signal.py
+++ b/elephant/test/test_signal.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+docstring goes here.
+:copyright: Copyright 2015 by the Elephant team, see AUTHORS.txt.
+:license: Modified BSD, see LICENSE.txt for details.
+"""
+
+import unittest
+
+import numpy as np
+import quantities as pq
+import neo.core as n
+
+import elephant.signal
+
+
+class WelchPSDTestCase(unittest.TestCase):
+    def test_welchpsd_errors(self):
+        # generate a dummy data
+        data = n.AnalogSignal(np.zeros(5000), sampling_period=0.001*pq.s,
+                              units='mV')
+
+        # check for unsupported parameter
+        self.assertRaises(ValueError, elephant.signal.welchpsd,
+                          data, unsupported_parameter=1)
+
+        # check for invalid parameter values
+        # - length of segments
+        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+                          len_seg=0)
+        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+                          len_seg=data.shape[-1] * 2)
+        # - number of segments
+        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+                          num_seg=0)
+        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+                          num_seg=data.shape[-1] * 2)
+        # - frequency resolution
+        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+                          freq_res=-1)
+        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+                          freq_res=data.sampling_rate/(data.shape[-1]+1))
+        # - overlap
+        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+                          overlap=-1.0)
+        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+                          overlap=1.1)
+
+    def test_welchpsd_behavior(self):
+        # generate data by adding white noise and a sinusoid
+        data_length = 5000
+        sampling_period = 0.001
+        signal_freq = 100.0
+        noise = np.random.normal(size=data_length)
+        signal = [np.sin(2*np.pi*signal_freq*t)
+                  for t in np.arange(0, data_length*sampling_period,
+                                     sampling_period)]
+        data = n.AnalogSignal(signal+noise,
+                              sampling_period=sampling_period*pq.s, units='mV')
+        dataarr = n.AnalogSignalArray(np.array([signal+noise,] * 5),
+                                      sampling_period=sampling_period*pq.s,
+                                      units='mV')
+
+        # consistency between different ways of specifying segment length
+        psd1, freqs1 = elephant.signal.welchpsd(data, len_seg=1000, overlap=0)
+        psd2, freqs2 = elephant.signal.welchpsd(data, num_seg=5, overlap=0)
+        self.assertTrue(np.all(psd1 == psd2))
+        self.assertTrue(np.all(freqs1 == freqs2))
+
+        # frequency resolution and consistency with data
+        freq_res = 1.0 * pq.Hz
+        psd, freqs = elephant.signal.welchpsd(data, freq_res=freq_res)
+        self.assertAlmostEqual(freq_res, freqs[1]-freqs[0])
+        self.assertEqual(freqs[psd.argmax()], signal_freq)
+
+        # same results for AnalogSignal and AnalogSignalArray
+        psd, freqs = elephant.signal.welchpsd(data)
+        psds, freqs = elephant.signal.welchpsd(dataarr)
+        for psd_from_arr in psds:
+            self.assertTrue(np.all(psd == psd_from_arr))
+
+
+def suite():
+    suite = unittest.makeSuite(WelchPSDTestCase, 'test')
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/elephant/test/test_signal.py
+++ b/elephant/test/test_signal.py
@@ -8,6 +8,7 @@ docstring goes here.
 import unittest
 
 import numpy as np
+import scipy.signal as spsig
 import quantities as pq
 import neo.core as n
 
@@ -15,38 +16,34 @@ import elephant.signal
 
 
 class WelchPSDTestCase(unittest.TestCase):
-    def test_welchpsd_errors(self):
+    def test_welch_psd_errors(self):
         # generate a dummy data
-        data = n.AnalogSignal(np.zeros(5000), sampling_period=0.001*pq.s,
+        data = n.AnalogSignalArray(np.zeros(5000), sampling_period=0.001*pq.s,
                               units='mV')
-
-        # check for unsupported parameter
-        self.assertRaises(ValueError, elephant.signal.welchpsd,
-                          data, unsupported_parameter=1)
 
         # check for invalid parameter values
         # - length of segments
-        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+        self.assertRaises(ValueError, elephant.signal.welch_psd, data,
                           len_seg=0)
-        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+        self.assertRaises(ValueError, elephant.signal.welch_psd, data,
                           len_seg=data.shape[-1] * 2)
         # - number of segments
-        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+        self.assertRaises(ValueError, elephant.signal.welch_psd, data,
                           num_seg=0)
-        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+        self.assertRaises(ValueError, elephant.signal.welch_psd, data,
                           num_seg=data.shape[-1] * 2)
         # - frequency resolution
-        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+        self.assertRaises(ValueError, elephant.signal.welch_psd, data,
                           freq_res=-1)
-        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+        self.assertRaises(ValueError, elephant.signal.welch_psd, data,
                           freq_res=data.sampling_rate/(data.shape[-1]+1))
         # - overlap
-        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+        self.assertRaises(ValueError, elephant.signal.welch_psd, data,
                           overlap=-1.0)
-        self.assertRaises(ValueError, elephant.signal.welchpsd, data,
+        self.assertRaises(ValueError, elephant.signal.welch_psd, data,
                           overlap=1.1)
 
-    def test_welchpsd_behavior(self):
+    def test_welch_psd_behavior(self):
         # generate data by adding white noise and a sinusoid
         data_length = 5000
         sampling_period = 0.001
@@ -55,29 +52,65 @@ class WelchPSDTestCase(unittest.TestCase):
         signal = [np.sin(2*np.pi*signal_freq*t)
                   for t in np.arange(0, data_length*sampling_period,
                                      sampling_period)]
-        data = n.AnalogSignal(signal+noise,
-                              sampling_period=sampling_period*pq.s, units='mV')
-        dataarr = n.AnalogSignalArray(np.array([signal+noise,] * 5),
+        data = n.AnalogSignalArray(np.array(signal+noise),
                                       sampling_period=sampling_period*pq.s,
                                       units='mV')
+        data_multidim = n.AnalogSignalArray(np.array([signal+noise] * 5),
+                                   sampling_period=sampling_period*pq.s,
+                                   units='mV')
 
         # consistency between different ways of specifying segment length
-        psd1, freqs1 = elephant.signal.welchpsd(data, len_seg=1000, overlap=0)
-        psd2, freqs2 = elephant.signal.welchpsd(data, num_seg=5, overlap=0)
-        self.assertTrue(np.all(psd1 == psd2))
-        self.assertTrue(np.all(freqs1 == freqs2))
+        freqs1, psd1 = elephant.signal.welch_psd(data, len_seg=data_length/5, overlap=0)
+        freqs2, psd2 = elephant.signal.welch_psd(data, num_seg=5, overlap=0)
+        self.assertTrue(np.all((psd1==psd2, freqs1==freqs2)))
 
         # frequency resolution and consistency with data
         freq_res = 1.0 * pq.Hz
-        psd, freqs = elephant.signal.welchpsd(data, freq_res=freq_res)
+        freqs, psd = elephant.signal.welch_psd(data, freq_res=freq_res)
         self.assertAlmostEqual(freq_res, freqs[1]-freqs[0])
         self.assertEqual(freqs[psd.argmax()], signal_freq)
+        freqs_np, psd_np = elephant.signal.welch_psd(data.magnitude, fs=1/sampling_period, freq_res=freq_res)
+        self.assertTrue(np.all((freqs==freqs_np, psd==psd_np)))
 
-        # same results for AnalogSignal and AnalogSignalArray
-        psd, freqs = elephant.signal.welchpsd(data)
-        psds, freqs = elephant.signal.welchpsd(dataarr)
-        for psd_from_arr in psds:
-            self.assertTrue(np.all(psd == psd_from_arr))
+        # multi-dimensional return value for multi-dimensional input array
+        freqs, psds = elephant.signal.welch_psd(data_multidim)
+        self.assertTrue(psds.shape[:-1] == data_multidim.shape[:-1])
+
+        # check of scipy.signal.welch() parameters
+        params = {'window': 'hamming', 'nfft': 1024, 'detrend': 'linear',
+                  'return_onesided': False, 'scaling': 'spectrum'}
+        for key, val in params.items():
+            freq, psd = elephant.signal.welch_psd(data, len_seg=1000, overlap=0, **{key: val})
+            freq_spsig, psd_spsig = spsig.welch(data, fs=1/sampling_period, nperseg=1000, noverlap=0, **{key: val})
+            self.assertTrue(np.all((freq==freq_spsig, psd==psd_spsig)))
+
+        freqs, psds = elephant.signal.welch_psd(data_multidim)
+        freqs_spsig, psds_spsig = elephant.signal.welch_psd(data_multidim.T, axis=0)
+        self.assertTrue(np.all((freq==freq_spsig, psd==psd_spsig)))
+
+    def test_welch_psd_input_types(self):
+        # generate a test data
+        sampling_period = 0.001
+        data = n.AnalogSignalArray(np.array(np.random.normal(size=5000)),
+                                   sampling_period=sampling_period*pq.s,
+                                   units='mV')
+
+        # outputs from AnalogSignalArray input are of Quantity type (standard usage)
+        freqs_neo, psd_neo = elephant.signal.welch_psd(data)
+        self.assertTrue(isinstance(freqs_neo, pq.quantity.Quantity))
+        self.assertTrue(isinstance(psd_neo, pq.quantity.Quantity))
+
+        # outputs from Quantity array input are of Quantity type
+        freqs_pq, psd_pq = elephant.signal.welch_psd(data.magnitude*data.units, fs=1/sampling_period)
+        self.assertTrue(np.all((freqs_neo==freqs_pq, psd_neo==psd_pq)))
+        self.assertTrue(isinstance(freqs_pq, pq.quantity.Quantity))
+        self.assertTrue(isinstance(psd_pq, pq.quantity.Quantity))
+
+        # outputs from Numpy ndarray input are NOT of Quantity type
+        freqs_np, psd_np = elephant.signal.welch_psd(data.magnitude, fs=1/sampling_period)
+        self.assertTrue(np.all((freqs_neo==freqs_np, psd_neo==psd_np)))
+        self.assertFalse(isinstance(freqs_np, pq.quantity.Quantity))
+        self.assertFalse(isinstance(psd_np, pq.quantity.Quantity))
 
 
 def suite():


### PR DESCRIPTION
This PR addes a power spectrum estimation function for AnalogSignal as signal.welchpsd().
It takes AnalogSignal (or AnalogSignalArray) as input, and returns power spectrum (or spectra) estimated by Welch's method.