### PR TITLE
added a feature to the rate_estimation function...

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -21,11 +21,12 @@ contribution, and may not be the current affiliation of a contributor.
 * Pietro Quaglio [1]
 * Richard Meyes [1]
 * Vahid Rostami [1]
+* Subhasis Ray [5]
 
 1. Institute of Neuroscience and Medicine (INM-6), Computational and Systems Neuroscience & Institute for Advanced Simulation (IAS-6), Theoretical Neuroscience, Jülich Research Centre and JARA, Jülich, Germany
 2. Unité de Neurosciences, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France
 3. Electronic Visions Group, Kirchhoff-Institute for Physics, University of Heidelberg, Germany
 4. Brain-Mind Institute, Ecole Polytechnique Fédérale de Lausanne, Switzerland
-
+5. To be added
 
 If we've somehow missed you off the list we're very sorry - please let us know.

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -27,6 +27,6 @@ contribution, and may not be the current affiliation of a contributor.
 2. Unité de Neurosciences, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France
 3. Electronic Visions Group, Kirchhoff-Institute for Physics, University of Heidelberg, Germany
 4. Brain-Mind Institute, Ecole Polytechnique Fédérale de Lausanne, Switzerland
-5. To be added
+5. NIH–NICHD, Laboratory of Cellular and Synaptic Physiology, Bethesda, Maryland 20892
 
 If we've somehow missed you off the list we're very sorry - please let us know.

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -406,8 +406,9 @@ def make_kernel(form, sigma, sampling_period, direction=1):
     return kernel, norm, m_idx
 
 
-def instantaneous_rate(spiketrain, sampling_period, form, sigma, m_idx=None,
-                       t_start=None, t_stop=None, acausal=True, trim=False):
+def instantaneous_rate(spiketrain, sampling_period, form,
+                       sigma=None, t_start=None, t_stop=None,
+                       acausal=True, trim=False):
 
     """
     Estimate instantaneous firing rate by kernel convolution.
@@ -425,12 +426,14 @@ def instantaneous_rate(spiketrain, sampling_period, form, sigma, m_idx=None,
         TRI (triangle), GAU (gaussian), EPA (epanechnikov), EXP (exponential),
         ALP (alpha function). EXP and ALP are asymmetric kernel forms and
         assume optional parameter `direction`.
-    sigma : Quantity
+    sigma : string or Quantity
         Standard deviation of the distribution associated with kernel shape.
         This parameter defines the time resolution of the kernel estimate
         and makes different kernels comparable (cf. [1] for symmetric kernels).
         This is used here as an alternative definition to the cut-off
         frequency of the associated linear filter.
+        Default value is 'auto'. In this case, the optimized kernel width for
+        the rate estimation is calculated according to [1].
     t_start : Quantity (Optional)
         start time of the interval used to compute the firing rate, if None
         assumed equal to spiketrain.t_start
@@ -466,11 +469,29 @@ def instantaneous_rate(spiketrain, sampling_period, form, sigma, m_idx=None,
         estimate. The unit of this property is the same as the resolution that
         is given as an argument to the function.
 
+    Raises
+    ------
+    TypeError:
+        If argument value for the parameter `sigma` is not a quantity object
+        or string 'auto'.
+
     See also
     --------
-
     elephant.statistics.make_kernel
+
+    References
+    ----------
+    ..[1] H. Shimazaki, S. Shinomoto, J Comput Neurosci (2010) 29:171–182.
     """
+    if sigma == 'auto':
+        unit = spiketrain.units
+        kernel_width = sskernel(spiketrain.magnitude, tin=None,
+                                bootstrap=True)['optw']
+        sigma = kernel_width*unit
+    elif not isinstance(sigma, pq.Quantity):
+        raise TypeError('sigma must be either a quantities object or "auto".'
+                        ' Found: %s, value %s' %(type(sigma), str(sigma)))
+
     kernel, norm, m_idx = make_kernel(form=form, sigma=sigma,
                                       sampling_period=sampling_period)
     units = pq.CompoundUnit("%s*s" % str(sampling_period.rescale('s').magnitude))
@@ -484,9 +505,6 @@ def instantaneous_rate(spiketrain, sampling_period, form, sigma, m_idx=None,
         t_stop = spiketrain.t_stop
     else:
         t_stop = t_stop.rescale(spiketrain.units)
-
-    if m_idx is None:
-        m_idx = kernel.size / 2
 
     time_vector = np.zeros(int((t_stop - t_start)) + 1)
 
@@ -629,3 +647,220 @@ def time_histogram(spiketrains, binsize, t_start=None, t_stop=None,
                                  sampling_period=binsize, units=bin_hist.units,
                                  t_start=t_start)
 
+
+"""Kernel Bandwidth Optimization.
+Copyright (c) 2014 Subhasis Ray
+License: GPL v3
+
+Original matlab code (sskernel.m) here:
+http://2000.jukuin.keio.ac.jp/shimazaki/res/kernel.html
+
+This was translated into Python by Subhasis Ray, NCBS. Tue Jun 10
+23:01:43 IST 2014
+
+"""
+def nextpow2(x):
+    """ Return the smallest integral power of 2 that >= x """
+    n = 2
+    while n < x:
+        n = 2*n
+    return n
+
+def fftkernel(x, w):
+    """
+
+    y = fftkernel(x,w)
+
+    Function `fftkernel' applies the Gauss kernel smoother to an input
+    signal using FFT algorithm.
+
+    Input argument
+    x:    Sample signal vector.
+    w: 	Kernel bandwidth (the standard deviation) in unit of
+    the sampling resolution of x.
+
+    Output argument
+    y: 	Smoothed signal.
+
+    MAY 5/23, 2012 Author Hideaki Shimazaki
+    RIKEN Brain Science Insitute
+    http://2000.jukuin.keio.ac.jp/shimazaki
+
+    Ported to Python: Subhasis Ray, NCBS. Tue Jun 10 10:42:38 IST 2014
+
+    """
+    L = len(x)
+    Lmax = L + 3 * w
+    n = nextpow2(Lmax)
+    X = np.fft.fft(x, n)
+    f = np.arange(0, n, 1.0)/n
+    f = np.concatenate((-f[:n/2], f[n/2:0:-1]))
+    K = np.exp(-0.5*(w*2*np.pi*f)**2)
+    y = np.fft.ifft(X * K, n)
+    y = y[:L].copy()
+    return y
+
+def logexp(x):
+    if x < 1e2 :
+        y = np.log(1 + np.exp(x))
+    else:
+        y = x
+    return y
+
+def ilogexp(x):
+    if x < 1e2:
+        y = np.log(np.exp(x) - 1)
+    else:
+        y = x
+    return y
+
+def cost_function(x, N, w, dt):
+    """
+
+    The cost function
+    Cn(w) = sum_{i,j} int k(x - x_i) k(x - x_j) dx - 2 sum_{i~=j} k(x_i - x_j)
+
+     """
+    yh = np.abs(fftkernel(x, w / dt))  # density
+    #formula for density
+    C = np.sum(yh ** 2) * dt - 2 * np.sum(yh * x) * dt + 2 / np.sqrt(2 * np.pi) / w / N
+    C = C * N * N
+    # formula for rate
+    # C = dt*sum( yh.^2 - 2*yh.*y_hist + 2/sqrt(2*pi)/w*y_hist )
+    return C, yh
+
+def sskernel(spiketimes, tin=None, w=None, bootstrap=False):
+    """
+
+    Calculates optimal fixed kernel bandwidth.
+
+    spiketimes: sequence of spike times (sorted to be ascending).
+
+    tin: (optional) time points at which the kernel bandwidth is to be estimated.
+
+    w: (optional) vector of kernel bandwidths. If specified, optimal
+    bandwidth is selected from this.
+
+    bootstrap (optional): whether to calculate the 95% confidence
+    interval. (default False)
+
+    Returns
+
+    A dictionary containing the following key value pairs:
+
+    'y': estimated density,
+    't': points at which estimation was computed,
+    'optw': optimal kernel bandwidth,
+    'w': kernel bandwidths examined,
+    'C': cost functions of w,
+    'confb95': (lower bootstrap confidence level, upper bootstrap confidence level),
+    'yb': bootstrap samples.
+
+
+    Ref: Shimazaki, Hideaki, and Shigeru Shinomoto. 2010. Kernel
+    Bandwidth Optimization in Spike Rate Estimation. Journal of
+    Computational Neuroscience 29 (1-2):
+    171-82. doi:10.1007/s10827-009-0180-4.
+
+    """
+
+    if tin is None:
+        time = np.max(spiketimes) - np.min(spiketimes)
+        isi = np.diff(spiketimes)
+        isi = isi[isi > 0].copy()
+        dt = np.min(isi)
+        tin = np.linspace(np.min(spiketimes),
+                          np.max(spiketimes),
+                          min(int(time / dt + 0.5), 1000)) # The 1000 seems somewhat arbitrary
+        t = tin
+    else:
+        time = np.max(tin) - np.min(tin)
+        spiketimes = spiketimes[(spiketimes >= np.min(tin)) &
+                                (spiketimes <= np.max(tin))].copy()
+        isi = np.diff(spiketimes)
+        isi = isi[isi > 0].copy()
+        dt = np.min(isi)
+        if dt > np.min(np.diff(tin)):
+            t = np.linspace(np.min(tin), np.max(tin),
+                            min(int(time/dt + 0.5), 1000))
+        else:
+            t = tin
+    dt = np.min(np.diff(tin))
+    yhist, bins = np.histogram(spiketimes, np.r_[t - dt/2, t[-1] + dt/2])
+    N = np.sum(yhist)
+    yhist = yhist / (N * dt) # density
+    optw = None
+    y = None
+    if w is not None:
+        C = np.zeros(len(w))
+        Cmin = np.inf
+        for k, w_ in enumerate(w):
+            C[k], yh = cost_function(yhist, N, w_, dt)
+            if C[k] < Cmin:
+                Cmin = C[k]
+                optw = w_
+                y = yh
+    else:
+        # Golden section search on a log-exp scale
+        wmin = 2 * dt
+        wmax = max(spiketimes) - min(spiketimes)
+        imax = 20 # max iterations
+        w = np.zeros(imax)
+        C = np.zeros(imax)
+        tolerance = 1e-5
+        phi = 0.5 * (np.sqrt(5) + 1) # The Golden ratio
+        a = ilogexp(wmin)
+        b = ilogexp(wmax)
+        c1 = (phi - 1) * a + (2 - phi) * b
+        c2 = (2 - phi) * a + (phi - 1) * b
+        f1, y1 = cost_function(yhist, N, logexp(c1), dt)
+        f2, y2 = cost_function(yhist, N, logexp(c2), dt)
+        k = 0
+        while (np.abs(b - a) > (tolerance * (np.abs(c1) + np.abs(c2))))\
+              and (k < imax):
+            if f1 < f2:
+                b = c2
+                c2 = c1
+                c1 = (phi - 1) * a + (2 - phi) * b
+                f2 = f1
+                f1, y1 = cost_function(yhist, N, logexp(c1), dt)
+                w[k] = logexp(c1)
+                C[k] = f1
+                optw = logexp(c1)
+                y = y1 / (np.sum(y1 * dt))
+            else:
+                a = c1
+                c1 = c2
+                c2 = (2 - phi) * a + (phi - 1) * b
+                f1 = f2
+                f2, y2 = cost_function(yhist, N, logexp(c2), dt)
+                w[k] = logexp(c2)
+                C[k] = f2
+                optw = logexp(c2)
+                y = y2 / np.sum(y2 * dt)
+            k = k + 1
+    # Bootstrap confidence intervals
+    confb95 = None
+    yb = None
+    if bootstrap:
+        nbs = 1000
+        yb = np.zeros((nbs, len(tin)))
+        for ii in range(nbs):
+            idx = np.floor(np.random.rand(N) * N).astype(int)
+            xb = spiketimes[idx]
+            y_histb, bins = np.histogram(xb, np.r_[t - dt/2, t[-1]+dt/2]) / dt / N
+            yb_buf = fftkernel(y_histb, optw / dt).real
+            yb_buf = yb_buf / np.sum(yb_buf * dt)
+            yb[ii,:] = np.interp(tin, t, yb_buf)
+        ybsort = np.sort(yb, axis=0)
+        y95b = ybsort[np.floor(0.05 * nbs).astype(int), :]
+        y95u = ybsort[np.floor(0.95 * nbs).astype(int), :]
+        confb95 = (y95b, y95u)
+    ret = np.interp(tin, t, y)
+    return {'y': ret,
+            't': tin,
+            'optw': optw,
+            'w': w,
+            'C': C,
+            'confb95': confb95,
+            'yb': yb}

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -407,7 +407,7 @@ def make_kernel(form, sigma, sampling_period, direction=1):
 
 
 def instantaneous_rate(spiketrain, sampling_period, form,
-                       sigma=None, t_start=None, t_stop=None,
+                       sigma='auto', t_start=None, t_stop=None,
                        acausal=True, trim=False):
 
     """

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -649,8 +649,8 @@ def time_histogram(spiketrains, binsize, t_start=None, t_stop=None,
 
 
 """Kernel Bandwidth Optimization.
-Copyright (c) 2014 Subhasis Ray
-License: GPL v3
+
+Python implementation by Subhasis Ray.
 
 Original matlab code (sskernel.m) here:
 http://2000.jukuin.keio.ac.jp/shimazaki/res/kernel.html

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -458,7 +458,7 @@ class RateEstimationTestCase(unittest.TestCase):
                 num_spikes = len(self.spike_train)
                 auc = spint.cumtrapz(y=rate_estimate.magnitude[:, 0], x=rate_estimate.times.rescale('s').magnitude)[-1]
 
-                self.assertAlmostEqual(num_spikes, auc)
+                self.assertAlmostEqual(num_spikes, auc, delta=0.01*num_spikes)
 
         self.assertRaises(TypeError, es.instantaneous_rate, self.spike_train,
                           form='GAU', sampling_period=kernel_resolution,


### PR DESCRIPTION
...that calculates the optimized kernel width when the kernel width is specified as 'auto' rather than a fixed value. The method for the optimization of the kernel width was published by H. Shimazaki and S. Shinomoto in 2010 (H. Shimazaki, S. Shinomoto, J Comput Neurosci (2010) 29:171–182.). The Python Implementation is provided as a ready-to-use open source file that can be found on this website: http://toyoizumilab.brain.riken.jp/hideaki/res/kernel.html.
This pull request provides a portable version of the above kernel optimization function compatible with neo and the already existing rate estimation function of elephant.