### PR TITLE
complexity_pdf and unit_test

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -648,6 +648,63 @@ def time_histogram(spiketrains, binsize, t_start=None, t_stop=None,
                                  t_start=t_start)
 
 
+def complexity_pdf(spiketrains, binsize):
+    """
+    Complexity Distribution [1] of a list of :attr:`neo.SpikeTrain` objects.
+
+    Probability density computed from the complexity histogram which is the
+    histogram of the entries of the population histogram of clipped (binary)
+    spike trains computed with a bin width of binsize.
+    It provides for each complexity (== number of active neurons per bin) the
+    number of occurrences. The normalization of that histogram to 1 is the
+    probability density.
+
+    Parameters
+    ----------
+    spiketrains : List of neo.SpikeTrain objects
+    Spiketrains with a common time axis (same `t_start` and `t_stop`)
+    binsize : quantities.Quantity
+    Width of the histogram's time bins.
+
+    Returns
+    -------
+    time_hist : neo.AnalogSignalArray
+    A neo.AnalogSignalArray object containing the histogram values.
+    `AnalogSignal[j]` is the histogram computed between .
+
+    See also
+    --------
+    elephant.conversion.BinnedSpikeTrain
+
+    References
+    ----------
+    [1]Gruen, S., Abeles, M., & Diesmann, M. (2008). Impact of higher-order
+    correlations on coincidence distributions of massively parallel data.
+    In Dynamic Brain-from Neural Spikes to Behaviors (pp. 96-114).
+    Springer Berlin Heidelberg.
+
+    """
+    # Computing the population histogram with parameter binary=True to clip the
+    # spike trains before summing
+    pophist = time_histogram(spiketrains, binsize, binary=True)
+
+    # Computing the histogram of the entries of pophist (=Complexity histogram)
+    complexity_hist = np.histogram(
+        pophist.magnitude, bins=range(0, len(spiketrains)+2))[0]
+
+    # Normalization of the Complexity Histogram to 1 (probabilty distribution)
+    sum_complexity = float(sum(complexity_hist))
+    complexity_hist = [s/sum_complexity for s in complexity_hist]
+
+    # Convert the Complexity pdf to an neo.AnalogSignalArray
+    complexity_distribution = neo.AnalogSignalArray(
+        np.array(complexity_hist).reshape(len(complexity_hist), 1) *
+        pq.dimensionless, t_start=0*pq.dimensionless,
+        sampling_period=1*pq.dimensionless)
+
+    return complexity_distribution
+
+
 """Kernel Bandwidth Optimization.
 
 Python implementation by Subhasis Ray.

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -693,9 +693,7 @@ def complexity_pdf(spiketrains, binsize):
         pophist.magnitude, bins=range(0, len(spiketrains)+2))[0]
 
     # Normalization of the Complexity Histogram to 1 (probabilty distribution)
-    sum_complexity = float(sum(complexity_hist))
-    complexity_hist = [s/sum_complexity for s in complexity_hist]
-
+    complexity_hist = complexity_hist / complexity_hist.sum()
     # Convert the Complexity pdf to an neo.AnalogSignalArray
     complexity_distribution = neo.AnalogSignalArray(
         np.array(complexity_hist).reshape(len(complexity_hist), 1) *

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -349,7 +349,7 @@ class RateEstimationTestCase(unittest.TestCase):
         st_num_spikes = np.random.poisson(self.st_rate*(self.st_dur-2*self.st_margin))
         spike_train = np.random.rand(st_num_spikes) * (self.st_dur-2*self.st_margin) + self.st_margin
         spike_train.sort()
-        
+
         # convert spike train into neo objects
         self.spike_train = neo.SpikeTrain(spike_train*pq.s,
                                           t_start=self.st_tr[0]*pq.s,
@@ -526,6 +526,32 @@ class TimeHistogramTestCase(unittest.TestCase):
         self.assertRaises(ValueError, es.time_histogram, self.spiketrains,
                           binsize=pq.s, output=' ')
 
+
+class ComplexityPdfTestCase(unittest.TestCase):
+    def setUp(self):
+        self.spiketrain_a = neo.SpikeTrain(
+            [0.5, 0.7, 1.2, 2.3, 4.3, 5.5, 6.7] * pq.s, t_stop=10.0 * pq.s)
+        self.spiketrain_b = neo.SpikeTrain(
+            [0.5, 0.7, 1.2, 2.3, 4.3, 5.5, 8.0] * pq.s, t_stop=10.0 * pq.s)
+        self.spiketrain_c = neo.SpikeTrain(
+            [0.5, 0.7, 1.2, 2.3, 4.3, 5.5, 8.0] * pq.s, t_stop=10.0 * pq.s)
+        self.spiketrains = [
+            self.spiketrain_a, self.spiketrain_b, self.spiketrain_c]
+
+    def tearDown(self):
+        del self.spiketrain_a
+        self.spiketrain_a = None
+        del self.spiketrain_b
+        self.spiketrain_b = None
+
+    def test_complexity_pdf(self):
+        targ = np.array([0.92, 0.01, 0.01, 0.06])
+        complexity = es.complexity_pdf(self.spiketrains, binsize=0.1*pq.s)
+        assert_array_equal(targ, complexity[:, 0].magnitude)
+        self.assertEqual(1, complexity[:, 0].magnitude.sum())
+        self.assertEqual(len(self.spiketrains)+1, len(complexity))
+        self.assertIsInstance(complexity, neo.AnalogSignalArray)
+        self.assertEqual(complexity.units, 1*pq.dimensionless)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request adds to the statistics module the complexity_pdf() function, in which is computed the density function of the number of active neurons per bin, fixed a certain binsize. The relative unit_test is added to the tests.