### PR TITLE
Spike cross-correlation histogram

### DIFF
--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -9,6 +9,8 @@ This modules provides functions to calculate correlations between spike trains.
 """
 from __future__ import division
 import numpy as np
+import quantities as pq
+import neo
 
 
 def corrcoef(binned_sts, binary=False):
@@ -146,3 +148,197 @@ def corrcoef(binned_sts, binary=False):
             # Fill entry of correlation matrix
             C[i, j] = C[j, i] = cc_enum / cc_denom
     return C
+
+
+def cross_correlation_histogram(
+        st1, st2, window=None, normalize=False, border_correction=False,
+        binary=False, kernel=None):
+    """
+    Computes the cross-correlation histogram (CCH) between two binned spike
+    trains st1 and st2.
+
+    Parameters
+    ----------
+    st1,st2 : BinnedSpikeTrain
+        Binned spike trains to cross-correlate.
+    window : int or None (optional)
+        histogram half-length. If specified, the cross-correlation histogram
+        has a number of bins equal to 2*window+1 (up to the maximum length).
+        If not specified, the full crosscorrelogram is returned
+        Default: None
+    normalize : bool (optional)
+        whether to normalize the central value (corresponding to time lag
+        0 s) to 1; the other values are rescaled accordingly.
+        Default: False
+    border_correction : bool (optional)
+        whether to correct for the border effect. If True, the value of the
+        CCH at bin b (for b=-H,-H+1, ...,H, where H is the CCH half-length)
+        is multiplied by the correction factor:
+                            (H+1)/(H+1-|b|),
+        which linearly corrects for loss of bins at the edges.
+        Default: False
+    binary : bool (optional)
+        whether to binary spikes from the same spike train falling in the
+        same bin. If True, such spikes are considered as a single spike;
+        otherwise they are considered as different spikes.
+        Default: False.
+    kernel : array or None (optional)
+        A one dimensional array containing an optional smoothing kernel applied
+        to the resulting CCH. The length N of the kernel indicates the
+        smoothing window. The smoothing window cannot be larger than the
+        maximum lag of the CCH. The kernel is normalized to unit area before
+        being applied to the resulting CCH. Popular choices for the kernel are
+          * normalized boxcar kernel: numpy.ones(N)
+          * hamming: numpy.hamming(N)
+          * hanning: numpy.hanning(N)
+          * bartlett: numpy.bartlett(N)
+        If a kernel is used and normalize is True, the kernel is applied first,
+        and the result is normalize to the central bin. If None is specified,
+        the CCH is not smoothed.
+        Default: None
+
+        TODO:
+        * Normalize before or after smoothing -- is this good?
+
+    Returns
+    -------
+    cch : AnalogSignalArray
+        Containing the cross-correlation histogram between st1 and st2.
+
+        The central bin of the histogram represents correlation at zero
+        delay. Offset bins correspond to correlations at a delay equivalent
+        to the difference between the spike times of st1 and those of st2: an
+        entry at positive lags corresponds to a spike in st2 following a
+        spike in st1 bins to the right, and an entry at negative lags
+        corresponds to a spike in st1 following a spike in st2.
+
+        To illustrate this definition, consider the two spike trains:
+        st1: 0 0 0 0 1 0 0 0 0 0 0
+        st2: 0 0 0 0 0 0 0 1 0 0 0
+        Here, the CCH will have an entry of 1 at lag h=+3.
+
+        Consistent with the definition of AnalogSignalArrays, the time axis
+        represents the left bin borders of each histogram bin. For example,
+        the time axis might be:
+        np.array([-2.5 -1.5 -0.5 0.5 1.5]) * ms
+    bin_ids : ndarray of int
+        Contains the IDs of the individual histogram bins, where the central
+        bin has ID 0, bins the left have negative IDs and bins to the right
+        have positive IDs, e.g.,:
+        np.array([-3, -2, -1, 0, 1, 2, 3])
+
+    Example
+    -------
+        Plot the cross-correlation histogram between two Poisson spike trains
+
+        >>> binned_st1 = elephant.conversion.BinnedSpikeTrain(
+                elephant.spike_train_generation.homogeneous_poisson_process(
+                    10. * pq.Hz, t_start=0 * pq.ms, t_stop=2000 * pq.s),
+                binsize=1. * pq.ms)
+        >>> binned_st2 = elephant.conversion.BinnedSpikeTrain(
+                elephant.spike_train_generation.homogeneous_poisson_process(
+                    10. * pq.Hz, t_start=0 * pq.ms, t_stop=2000 * pq.s),
+                binsize=1. * pq.ms)
+
+        >>> cc_hist = cross_correlation_histogram(
+                binned_st1, binned_st2, window=20,
+                normalize=True, border_correction=False,
+                binary=False, kernel=None)
+
+        >>> plt.bar(
+                left=cc_hist[0].times.magnitude,
+                height=cc_hist[0][:, 0].magnitude,
+                width=cc_hist[0].sampling_period.magnitude)
+        >>> plt.xlabel('time (' + str(cc_hist[0].times.units) + ')')
+        >>> plt.ylabel('normalized cross-correlation histogram')
+        >>> plt.axis('tight')
+        >>> plt.show()
+
+    Alias
+    -----
+    cch
+    """
+    if st1.binsize != st2.binsize:
+        raise ValueError(
+            "Input spike trains must be binned with the same bin size")
+
+    # Retrieve unclipped matrix
+    st1_spmat = st1.to_sparse_array()
+    st2_spmat = st2.to_sparse_array()
+
+    # For each row, extract the nonzero column indices and the corresponding
+    # data in the matrix (for performance reasons)
+    st1_bin_idx_unique = st1_spmat.nonzero()[1]
+    st2_bin_idx_unique = st2_spmat.nonzero()[1]
+    if binary:
+        st1_bin_counts_unique = np.array(st1_spmat.data > 0, dtype=int)
+        st2_bin_counts_unique = np.array(st2_spmat.data > 0, dtype=int)
+    else:
+        st1_bin_counts_unique = st1_spmat.data
+        st2_bin_counts_unique = st2_spmat.data
+
+    # Define the half-length of the full crosscorrelogram
+    #
+    # TODO: What is correct here? Why +, not max? How can we have an entry
+    # beyond the maximum length of the array?
+    hist_half_length = np.max([st1.num_bins, st2.num_bins]) - 1
+    hist_length = 2 * hist_half_length + 1
+    # hist_length = st1.num_bins + st2.num_bins - 1
+    # hist_half_length = hist_length // 2
+    if window is None:
+        hist_bins = hist_half_length
+    else:
+        hist_bins = min(window, hist_half_length)
+
+    # Initialize the counts to an array of zeroes, and the bin IDs to integers
+    # spanning the time axis
+    counts = np.zeros(2 * hist_bins + 1)
+    bin_ids = np.arange(-hist_bins, hist_bins + 1)
+    # Compute the CCH at lags in -hist_bins,...,hist_bins only
+    for r, i in enumerate(st1_bin_idx_unique):
+        timediff = st2_bin_idx_unique - i
+        timediff_in_range = np.all(
+            [timediff >= -hist_bins, timediff <= hist_bins], axis=0)
+        timediff = (timediff[timediff_in_range]).reshape((-1,))
+        counts[timediff + hist_bins] += st1_bin_counts_unique[r] * \
+            st2_bin_counts_unique[timediff_in_range]
+
+    # Correct the values taking into account lacking contributes at the edges
+    if border_correction is True:
+        correction = float(hist_half_length + 1) / np.array(
+            hist_half_length + 1 - abs(np.arange(-hist_bins, hist_bins + 1)),
+            float)
+        counts = counts * correction
+
+    # Define the kernel for smoothing as an ndarray
+    if hasattr(kernel, '__iter__'):
+        if len(kernel) > hist_length:
+            raise ValueError(
+                'The length of the kernel cannot be larger than the '
+                'length %d of the resulting CCH.' % hist_length)
+        kernel = np.array(kernel, dtype=float)
+        kernel = 1. * kernel / sum(kernel)
+    elif kernel is not None:
+        raise ValueError('Invalid smoothing kernel.')
+
+    # Smooth the cross-correlation histogram with the kernel
+    if kernel is not None:
+        counts = np.convolve(counts, kernel, mode='same')
+
+    # Rescale the histogram so that the central bin has height 1, if requested
+    if normalize:
+        counts = np.array(counts, float) / float(counts[hist_bins])
+
+    # Transform the array count into an AnalogSignalArray
+    cch = neo.AnalogSignalArray(
+        signal=counts.reshape(counts.size, 1),
+        units=pq.dimensionless,
+        t_start=(bin_ids[0] - 0.5) * st1.binsize,
+        sampling_period=st1.binsize)
+
+    # Return only the hist_bins bins and counts before and after the central
+    # one
+    return cch, bin_ids
+
+# Alias for common abbreviation
+cch = cross_correlation_histogram

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -9,7 +9,7 @@ Unit tests for the spike_train_correlation module.
 import unittest
 
 import numpy as np
-from numpy.testing.utils import assert_array_equal
+from numpy.testing.utils import assert_array_equal, assert_array_almost_equal
 import quantities as pq
 import neo
 import elephant.conversion as conv
@@ -17,6 +17,7 @@ import elephant.spike_train_correlation as sc
 
 
 class corrcoeff_TestCase(unittest.TestCase):
+
     def setUp(self):
         # These two arrays must be such that they do not have coincidences
         # spanning across two neighbor bins assuming ms bins [0,1),[1,2),...
@@ -117,6 +118,139 @@ class corrcoeff_TestCase(unittest.TestCase):
         # Check result
         self.assertEqual(target, 1.)
 
+
+class cross_correlation_histogram_TestCase(unittest.TestCase):
+
+    def setUp(self):
+        # These two arrays must be such that they do not have coincidences
+        # spanning across two neighbor bins assuming ms bins [0,1),[1,2),...
+        self.test_array_1d_0 = [
+            1.3, 7.56, 15.87, 28.23, 30.9, 34.2, 38.2, 43.2]
+        self.test_array_1d_1 = [
+            1.02, 2.71, 18.82, 28.46, 28.79, 43.6]
+
+        # Build spike trains
+        self.st_0 = neo.SpikeTrain(
+            self.test_array_1d_0, units='ms', t_stop=50.)
+        self.st_1 = neo.SpikeTrain(
+            self.test_array_1d_1, units='ms', t_stop=50.)
+
+        # And binned counterparts
+        self.binned_st1 = conv.BinnedSpikeTrain(
+            [self.st_0], t_start=0 * pq.ms, t_stop=50. * pq.ms,
+            binsize=1 * pq.ms)
+        self.binned_st2 = conv.BinnedSpikeTrain(
+            [self.st_1], t_start=0 * pq.ms, t_stop=50. * pq.ms,
+            binsize=1 * pq.ms)
+        self.binned_st3 = conv.BinnedSpikeTrain(
+            [self.st_1], t_start=0 * pq.ms, t_stop=50. * pq.ms,
+            binsize=5 * pq.ms)
+
+    def test_cross_correlation_histogram(self):
+        '''
+        Test generic result of a cross-correlation histogram between two binned
+        spike trains.
+        '''
+        # Calculate CCH using Elephant (normal and binary version)
+        cch_clipped, bin_ids_clipped = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window=None, binary=True)
+        cch_unclipped, bin_ids_unclipped = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window=None, binary=False)
+
+        # Check normal correlation Note: Use numpy correlate to verify result.
+        # Note: numpy conventions for input array 1 and input array 2 are
+        # swapped compared to Elephant!
+        mat1 = self.binned_st1.to_array()[0]
+        mat2 = self.binned_st2.to_array()[0]
+        target_numpy = np.correlate(mat2, mat1, mode='full')
+        assert_array_equal(
+            target_numpy, np.squeeze(cch_unclipped.magnitude))
+
+        # Check correlation using binary spike trains
+        mat1 = np.array(self.binned_st1.to_bool_array()[0], dtype=int)
+        mat2 = np.array(self.binned_st2.to_bool_array()[0], dtype=int)
+        target_numpy = np.correlate(mat2, mat1, mode='full')
+        assert_array_equal(
+            target_numpy, np.squeeze(cch_clipped.magnitude))
+
+        # Check the time axis and bin IDs of the resulting AnalogSignalArray
+        assert_array_almost_equal(
+            (bin_ids_clipped - 0.5) * self.binned_st1.binsize,
+            cch_unclipped.times)
+        assert_array_almost_equal(
+            (bin_ids_clipped - 0.5) * self.binned_st1.binsize,
+            cch_clipped.times)
+
+    def test_normalize_option(self):
+        '''
+        Test result of a CCH between two binned spike trains with the
+        normalization turned on.
+        '''
+        # Calculate normalized and raw cch
+        cch_norm, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window=None, binary=False,
+            normalize=True)
+
+        # Check that length of CCH is uneven
+        cch_len = len(cch_norm)
+        self.assertEqual(np.mod(cch_len, 2), 1)
+
+        # Check that central bin is 1
+        center_bin = np.floor(cch_len / 2)
+        target_time = cch_norm.times.magnitude[center_bin]
+        target_value = cch_norm.magnitude[center_bin]
+
+        self.assertEqual(
+            target_time, -cch_norm.sampling_period.magnitude / 2.)
+        self.assertEqual(
+            target_value, 1)
+
+    def test_binsize(self):
+        '''Check that an exception is thrown if the two spike trains are not
+        binned with the same bin size.'''
+        self.assertRaises(
+            ValueError,
+            sc.cross_correlation_histogram, self.binned_st1, self.binned_st3)
+
+    def test_window(self):
+        '''Test if the window parameter is correctly interpreted.'''
+        _, bin_ids = sc.cch(
+            self.binned_st1, self.binned_st2, window=30)
+        assert_array_equal(bin_ids, np.arange(-30, 31, 1))
+
+        _, bin_ids = sc.cch(
+            self.binned_st1, self.binned_st2, normalize=True, window=30)
+        assert_array_equal(bin_ids, np.arange(-30, 31, 1))
+
+    def test_border_correction(self):
+        '''Test if the border correction for bins at the edges is correctly
+        performed'''
+        cch_corrected, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window=None, normalize=False,
+            border_correction=True, binary=False, kernel=None)
+        cch, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window=None, normalize=False,
+            border_correction=False, binary=False, kernel=None)
+        self.assertNotEqual(cch.all(), cch_corrected.all())
+
+    def test_kernel(self):
+        '''Test if the smoothing kernel is correctly defined, and wheter it is
+        applied properly.'''
+        smoothed_cch, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, kernel=np.ones(3))
+        cch, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, kernel=None)
+        self.assertNotEqual(smoothed_cch.all, cch.all)
+        with self.assertRaises(ValueError):
+            sc.cch(self.binned_st1, self.binned_st2, kernel=np.ones(100))
+        with self.assertRaises(ValueError):
+            sc.cch(self.binned_st1, self.binned_st2, kernel='BOX')
+
+    def test_exist_alias(self):
+        '''
+        Test if alias cch still exists.
+        '''
+        self.assertEqual(sc.cross_correlation_histogram, sc.cch)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
To complement and add to the discussion initiated by PR #39, this is an alternate draft implementation of the CCH function we have been preparing. Without having looked at #39 in detail yet, I think the main difference in terms of algorithm is that this implementation does not rely on creating a binary vector, but uses the information of the sparse matrix representation.