### PR TITLE
Fix pandas_bridge and Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,12 @@ env:
   matrix:
     # This environment tests the newest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="true"
-      NUMPY_VERSION="1.8.1" SCIPY_VERSION="0.14.0" PANDAS_VERSION="0.14.0"
       COVERAGE="true"
     - DISTRIB="conda" PYTHON_VERSION="3.4" INSTALL_MKL="true"
-      NUMPY_VERSION="1.8.1" SCIPY_VERSION="0.14.0" PANDAS_VERSION="0.14.0"
       COVERAGE="true"
     # This environment tests minimal dependency versions
     - DISTRIB="conda_min" PYTHON_VERSION="2.7" INSTALL_MKL="true"
-      NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0" COVERAGE="true"
     - DISTRIB="conda_min" PYTHON_VERSION="3.4" INSTALL_MKL="true"
-      NUMPY_VERSION="1.8.1" SCIPY_VERSION="0.14.0" COVERAGE="true"
     # basic Ubuntu build environment, without optional dependencies
     - DISTRIB="ubuntu" PYTHON_VERSION="2.7" INSTALL_ATLAS="true"
       COVERAGE="true"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -31,7 +31,9 @@ if [[ "$DISTRIB" == "conda_min" ]]; then
     # Configure the conda environment and put it in the path using the
     # provided versions
     conda create -n testenv --yes python=$PYTHON_VERSION pip nose coverage \
-        numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION
+        numpy scipy
+        # numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION
+
     source activate testenv
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
@@ -60,7 +62,8 @@ elif [[ "$DISTRIB" == "conda" ]]; then
     # Configure the conda environment and put it in the path using the
     # provided versions
     conda create -n testenv --yes python=$PYTHON_VERSION pip nose coverage \
-        numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION pandas=$PANDAS_VERSION
+        numpy scipy pandas
+        # numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION pandas=$PANDAS_VERSION
     source activate testenv
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
@@ -86,8 +89,8 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
      source testenv/bin/activate
      pip install nose
      pip install coverage
-     pip install numpy==1.6.2
-     travis_wait pip install scipy==0.14.0 --verbose
+     pip install numpy
+     travis_wait pip install scipy --verbose
      pip install pandas
      pip install quantities
 

--- a/doc/reference/spike_train_correlation.rst
+++ b/doc/reference/spike_train_correlation.rst
@@ -1,6 +1,6 @@
-=================================
-Stochastic spike train generation
-=================================
+=======================
+Spike train correlation
+=======================
 
 .. testsetup::
 

--- a/elephant/test/test_pandas_bridge.py
+++ b/elephant/test/test_pandas_bridge.py
@@ -235,23 +235,23 @@ class SpiketrainToDataframeTestCase(unittest.TestCase):
         self.assertEqual(keys, res8.columns.names)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res2.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res3.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res4.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res5.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res6.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res7.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res8.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
     def test__spiketrain_to_dataframe__noparents(self):
         blk = fake_neo('Block', seed=0)
@@ -297,11 +297,11 @@ class SpiketrainToDataframeTestCase(unittest.TestCase):
         self.assertEqual(keys, res2.columns.names)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res2.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
     def test__spiketrain_to_dataframe__parents_childfirst(self):
         blk = fake_neo('Block', seed=0)
@@ -350,13 +350,13 @@ class SpiketrainToDataframeTestCase(unittest.TestCase):
         self.assertEqual(keys, res3.columns.names)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res2.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res3.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
     def test__spiketrain_to_dataframe__parents_parentfirst(self):
         blk = fake_neo('Block', seed=0)
@@ -392,10 +392,9 @@ class SpiketrainToDataframeTestCase(unittest.TestCase):
         self.assertEqual(keys, res1.columns.names)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
-
+            assert_index_equal(value, level, False, False)
 
 @unittest.skipUnless(HAVE_PANDAS, 'requires pandas')
 class EventToDataframeTestCase(unittest.TestCase):
@@ -489,23 +488,23 @@ class EventToDataframeTestCase(unittest.TestCase):
         self.assertEqual(keys, res8.columns.names)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res2.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res3.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res4.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res5.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res6.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res7.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res8.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
     def test__event_to_dataframe__noparents(self):
         blk = fake_neo('Block', seed=42)
@@ -551,11 +550,11 @@ class EventToDataframeTestCase(unittest.TestCase):
         self.assertEqual(keys, res2.columns.names)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res2.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
     def test__event_to_dataframe__parents_childfirst(self):
         blk = fake_neo('Block', seed=42)
@@ -608,13 +607,13 @@ class EventToDataframeTestCase(unittest.TestCase):
         self.assertEqual(keys, res3.columns.names)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res2.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res3.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
     def test__event_to_dataframe__parents_parentfirst(self):
         blk = fake_neo('Block', seed=42)
@@ -651,9 +650,9 @@ class EventToDataframeTestCase(unittest.TestCase):
         self.assertEqual(keys, res1.columns.names)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
 
 @unittest.skipUnless(HAVE_PANDAS, 'requires pandas')
@@ -772,23 +771,23 @@ class EpochToDataframeTestCase(unittest.TestCase):
         assert_array_equal(targindex, res8.index.levels)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res2.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res3.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res4.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res5.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res6.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res7.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res8.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
     def test__epoch_to_dataframe__noparents(self):
         blk = fake_neo('Block', seed=42)
@@ -845,11 +844,11 @@ class EpochToDataframeTestCase(unittest.TestCase):
         assert_array_equal(targindex, res2.index.levels)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res2.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
     def test__epoch_to_dataframe__parents_childfirst(self):
         blk = fake_neo('Block', seed=42)
@@ -915,13 +914,13 @@ class EpochToDataframeTestCase(unittest.TestCase):
         assert_array_equal(targindex, res3.index.levels)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res2.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res3.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
     def test__epoch_to_dataframe__parents_parentfirst(self):
         blk = fake_neo('Block', seed=42)
@@ -968,9 +967,9 @@ class EpochToDataframeTestCase(unittest.TestCase):
         assert_array_equal(targindex, res1.index.levels)
 
         for value, level in zip(values, res0.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
         for value, level in zip(values, res1.columns.levels):
-            assert_index_equal(value, level)
+            assert_index_equal(value, level, False, False)
 
 
 @unittest.skipUnless(HAVE_PANDAS, 'requires pandas')


### PR DESCRIPTION
This PR changes the `install.sh` and `travis.yml` filles to use the newest libraries (numpy, scipy, pandas) to avoid hard-coding the version numbers and problems with interoperability between the different library versions. 
Additionally I fixed errors in `test_pandas_bridge`.  In the newest(?) panda version `0.16.2` the parameter `names` is also checked, when using `assert_index_equal ` in the unittests. This throws an error (as described here https://github.com/NeuralEnsemble/elephant/issues/33), because in our case e.g., the strings  `t_start` and `t_stop` are checked for equality.  So I set the parameter `names` to `False` not to check for equality.  