### PR TITLE
fix pandas_bridge test

### DIFF
--- a/elephant/test/test_pandas_bridge.py
+++ b/elephant/test/test_pandas_bridge.py
@@ -25,6 +25,19 @@ else:
     import elephant.pandas_bridge as ep
     HAVE_PANDAS = True
 
+if HAVE_PANDAS:
+    # Currying, otherwise the unittest will break with pandas>=0.16.0
+    # parameter check_names is introduced in a newer versions than 0.14.0
+    # this test is written for pandas 0.14.0
+    def assert_index_equal(left, right):
+        try:
+            # pandas>=0.16.0
+            return pd.util.testing.assert_index_equal(left, right,
+                                                      check_names=False)
+        except TypeError:
+            # pandas older version
+            return pd.util.testing.assert_index_equal(left, right)
+
 
 @unittest.skipUnless(HAVE_PANDAS, 'requires pandas')
 class MultiindexFromDictTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR fixes issue https://github.com/NeuralEnsemble/elephant/issues/33. The error described in the unittest of `test_panda_bridge.py` appeared when the newest panda version was used. 
I used the currying method to have a function which responds to the available panda version and which uses an according correct test function. 

The matrix test environment in the install script remains the same. 