### PR TITLE
changed travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   matrix:
     # This environment tests the newest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="true"
-      NUMPY_VERSION="1.8.1" SCIPY_VERSION="0.14.0" PANDAS_VERSION="0.14.0"
+      NUMPY_VERSION="1.9.0" SCIPY_VERSION="0.16.0" PANDAS_VERSION="0.16.0"
       COVERAGE="true"
     - DISTRIB="conda" PYTHON_VERSION="3.4" INSTALL_MKL="true"
       NUMPY_VERSION="1.8.1" SCIPY_VERSION="0.14.0" PANDAS_VERSION="0.14.0"


### PR DESCRIPTION
Seems it is time again to fix our build matrix. 
Question: Would it be fine to remove the hard coded version numbers and use the latest packages just only in the conda build ? This would only affect build no 1 and always test for the latest libs.  