### PR TITLE
downwards compatibility for numpy

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -579,8 +579,9 @@ class BinnedSpikeTrain(object):
             are returned as a quantity array.
 
         """
-        return np.linspace(self.t_start, self.t_stop,
-                           self.num_bins + 1, endpoint=True)
+        return pq.Quantity(np.linspace(self.t_start, self.t_stop,
+                                       self.num_bins + 1, endpoint=True),
+                           units=self.binsize.units)
 
     @property
     def bin_centers(self):
@@ -777,12 +778,16 @@ class BinnedSpikeTrain(object):
            SpikeTrain object or from a list of SpikeTrain objects.
 
         """
+        from distutils.version import StrictVersion
         # column
         filled = []
         # row
         indices = []
         # data
         counts = []
+        # to be downwards compatible compare numpy versions, if the used
+        # version is smaller than v1.9 use different functions
+        smaller_version = StrictVersion(np.__version__) < '1.9.0'
         for idx, elem in enumerate(spiketrains):
             ev = elem.view(pq.Quantity)
             scale = np.array(((ev - self.t_start).rescale(
@@ -791,7 +796,11 @@ class BinnedSpikeTrain(object):
                                ev <= self.t_stop.rescale(self.binsize.units))
             filled_tmp = scale[l]
             filled_tmp = filled_tmp[filled_tmp < self.num_bins]
-            f, c = np.unique(filled_tmp, return_counts=True)
+            if smaller_version:
+                f = np.unique(filled_tmp)
+                c = np.bincount(f.searchsorted(filled_tmp))
+            else:
+                f, c = np.unique(filled_tmp, return_counts=True)
             filled.extend(f)
             counts.extend(c)
             indices.extend([idx] * len(f))
@@ -800,3 +809,4 @@ class BinnedSpikeTrain(object):
                                            self.matrix_columns),
                                     dtype=int)
         self._sparse_mat_u = csr_matrix
+


### PR DESCRIPTION
Second part of my pull requests.

I added downwards compatibility for numpy in the conversion module. Before I was using a function which was introduced in numpy v1.9. Since we want to support also smaller versions I thought this may be a good idea to include. This code fragment will be called once the BinnedSpikeTrain is to going to be created.

Again, all test shouldn't run through. 