### PR TITLE
Fix unsized spike train and np.allclose issues in testing

### DIFF
--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -59,7 +59,12 @@ def threshold_detection(signal, threshold=0.0*mV, sign='above'):
         time = signal.times
         events = time[cutout][take]
         
-    result_st = SpikeTrain(events.base,units=signal.times.units,
+    events_base = events.base
+    if events_base is None: # This occurs in some Python 3 builds due to some
+                            # bug in quantities.  
+        events_base = np.array([event.base for event in events]) # Workaround
+    
+    result_st = SpikeTrain(events_base,units=signal.times.units,
                            t_start=signal.t_start,t_stop=signal.t_stop)
     return result_st
 

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -45,6 +45,14 @@ class AnalogSignalSpikeExtractionTestCase(unittest.TestCase):
         data = iom2.read()
         vm = data[0].segments[0].analogsignals[0]
         spike_train = stgen.threshold_detection(vm)
+        try:
+            len(spike_train)
+        except TypeError: # Handles an error in Neo related to some zero length
+                          # spike trains being treated as unsized objects.
+            print("We had a type error...")
+            spike_train = neo.core.SpikeTrain([],t_start=spike_train.t_start,
+                                                 t_stop=spike_train.t_stop,
+                                                 units=spike_train.units)
 
         # Correct values determined previously.  
         true_spike_train = [0.0123, 0.0354, 0.0712, 0.1191, 

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -9,6 +9,7 @@ docstring goes here.
 from __future__ import division
 import unittest
 import os
+import warnings
 
 import neo
 import numpy as np
@@ -49,7 +50,9 @@ class AnalogSignalSpikeExtractionTestCase(unittest.TestCase):
             len(spike_train)
         except TypeError: # Handles an error in Neo related to some zero length
                           # spike trains being treated as unsized objects.
-            print("We had a type error...")
+            warnings.warn(("The spike train may be an unsized object. This may be related "
+                            "to an issue in Neo with some zero-length SpikeTrain objects. "
+                            "Bypassing this by creating an empty SpikeTrain object."))
             spike_train = neo.core.SpikeTrain([],t_start=spike_train.t_start,
                                                  t_stop=spike_train.t_stop,
                                                  units=spike_train.units)

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -59,10 +59,12 @@ class AnalogSignalSpikeExtractionTestCase(unittest.TestCase):
                             0.1694, 0.22, 0.2711]
         
         # Does threshold_detection gives the correct number of spikes?
-        assert len(spike_train) == len(true_spike_train) 
+        self.assertEqual(len(spike_train),len(true_spike_train))
         # Does threshold_detection gives the correct times for the spikes?    
-        assert np.allclose(spike_train,spike_train) 
-        
+        try:
+            self.assertTrue(np.allclose(spike_train,spike_train))
+        except AttributeError: # If numpy version too old to have allclose
+            self.assertTrue(np.array_equal(spike_train,spike_train))
 
 class HomogeneousPoissonProcessTestCase(unittest.TestCase):
 


### PR DESCRIPTION
@alperyeg 
Replaces #59 and #60.  Must be used with #57 to work in Python 3.  