### PR TITLE
Added the cross_correlation_histogram() function and relative test

### DIFF
--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -9,6 +9,9 @@ This modules provides functions to calculate correlations between spike trains.
 """
 from __future__ import division
 import numpy as np
+import neo
+import warnings
+import quantities as pq
 
 
 def covariance(binned_sts, binary=False):
@@ -246,3 +249,356 @@ def __calculate_correlation_or_covariance(binned_sts, binary, corrcoef_norm):
             # Fill entry of correlation matrix
             C[i, j] = C[j, i] = enumerator / denominator
     return np.squeeze(C)
+
+
+def cross_correlation_histogram(
+        binned_st1, binned_st2, window='full', border_correction=False, binary=False,
+        kernel=None, method='speed'):
+    """
+    Computes the cross-correlation histogram (CCH) between two binned spike
+    trains binned_st1 and binned_st2.
+
+    Parameters
+    ----------
+    binned_st1, binned_st2 : BinnedSpikeTrain
+        Binned spike trains to cross-correlate. The two spike trains must have
+        same t_start and t_stop
+    window : string or list (optional)
+        ‘full’: This returns the crosscorrelation at each point of overlap,
+        with an output shape of (N+M-1,). At the end-points of the
+        cross-correlogram, the signals do not overlap completely, and
+        boundary effects may be seen.
+        ‘valid’: Mode valid returns output of length max(M, N) - min(M, N) + 1.
+        The cross-correlation product is only given for points where the
+        signals overlap completely.
+        Values outside the signal boundary have no effect.
+        Default: 'full'
+        list of integer of of quantities (window[0]=minimum, window[1]=maximum
+        lag): The  entries of window can be integer (number of bins) or
+        quantities (time units of the lag), in the second case they have to be
+        a multiple of the binsize
+        Default: 'Full'
+    border_correction : bool (optional)
+        whether to correct for the border effect. If True, the value of the
+        CCH at bin b (for b=-H,-H+1, ...,H, where H is the CCH half-length)
+        is multiplied by the correction factor:
+                            (H+1)/(H+1-|b|),
+        which linearly corrects for loss of bins at the edges.
+        Default: False
+    binary : bool (optional)
+        whether to binary spikes from the same spike train falling in the
+        same bin. If True, such spikes are considered as a single spike;
+        otherwise they are considered as different spikes.
+        Default: False.
+    kernel : array or None (optional)
+        A one dimensional array containing an optional smoothing kernel applied
+        to the resulting CCH. The length N of the kernel indicates the
+        smoothing window. The smoothing window cannot be larger than the
+        maximum lag of the CCH. The kernel is normalized to unit area before
+        being applied to the resulting CCH. Popular choices for the kernel are
+          * normalized boxcar kernel: numpy.ones(N)
+          * hamming: numpy.hamming(N)
+          * hanning: numpy.hanning(N)
+          * bartlett: numpy.bartlett(N)
+        If None is specified, the CCH is not smoothed.
+        Default: None
+    method : string (optional)
+        Defines the algorithm to use. "speed" uses numpy.correlate to calculate
+        the correlation between two binned spike trains using a non-sparse data
+        representation. Due to various optimizations, it is the fastest
+        realization. In contrast, the option "memory" uses an own
+        implementation to calculate the correlation based on sparse matrices,
+        which is more memory efficient but slower than the "speed" option.
+        Default: "speed"
+
+    Returns
+    -------
+    cch : AnalogSignalArray
+        Containing the cross-correlation histogram between binned_st1 and binned_st2.
+
+        The central bin of the histogram represents correlation at zero
+        delay. Offset bins correspond to correlations at a delay equivalent
+        to the difference between the spike times of binned_st1 and those of binned_st2: an
+        entry at positive lags corresponds to a spike in binned_st2 following a
+        spike in binned_st1 bins to the right, and an entry at negative lags
+        corresponds to a spike in binned_st1 following a spike in binned_st2.
+
+        To illustrate this definition, consider the two spike trains:
+        binned_st1: 0 0 0 0 1 0 0 0 0 0 0
+        binned_st2: 0 0 0 0 0 0 0 1 0 0 0
+        Here, the CCH will have an entry of 1 at lag h=+3.
+
+        Consistent with the definition of AnalogSignalArrays, the time axis
+        represents the left bin borders of each histogram bin. For example,
+        the time axis might be:
+        np.array([-2.5 -1.5 -0.5 0.5 1.5]) * ms
+    bin_ids : ndarray of int
+        Contains the IDs of the individual histogram bins, where the central
+        bin has ID 0, bins the left have negative IDs and bins to the right
+        have positive IDs, e.g.,:
+        np.array([-3, -2, -1, 0, 1, 2, 3])
+
+    Example
+    -------
+        Plot the cross-correlation histogram between two Poisson spike trains
+        >>> import elephant
+        >>> import matplotlib.pyplot as plt
+        >>> import quantities as pq
+
+        >>> binned_st1 = elephant.conversion.BinnedSpikeTrain(
+                elephant.spike_train_generation.homogeneous_poisson_process(
+                    10. * pq.Hz, t_start=0 * pq.ms, t_stop=5000 * pq.ms),
+                binsize=5. * pq.ms)
+        >>> binned_st2 = elephant.conversion.BinnedSpikeTrain(
+                elephant.spike_train_generation.homogeneous_poisson_process(
+                    10. * pq.Hz, t_start=0 * pq.ms, t_stop=5000 * pq.ms),
+                binsize=5. * pq.ms)
+
+        >>> cc_hist = elephant.spike_train_correlation.cross_correlation_histogram(
+                binned_st1, binned_st2, window=[-30,30],
+                border_correction=False,
+                binary=False, kernel=None, method='memory')
+
+        >>> plt.bar(
+                left=cc_hist[0].times.magnitude,
+                height=cc_hist[0][:, 0].magnitude,
+                width=cc_hist[0].sampling_period.magnitude)
+        >>> plt.xlabel('time (' + str(cc_hist[0].times.units) + ')')
+        >>> plt.ylabel('cross-correlation histogram')
+        >>> plt.axis('tight')
+        >>> plt.show()
+
+    Alias
+    -----
+    cch
+    """
+    def _border_correction(counts, max_num_bins, l, r):
+        # Correct the values taking into account lacking contributes
+        # at the edges
+        correction = float(max_num_bins + 1) / np.array(
+            max_num_bins + 1 - abs(
+                np.arange(l, r + 1)), float)
+        return counts * correction
+
+    def _kernel_smoothing(counts, kern, l, r):
+        # Define the kern for smoothing as an ndarray
+        if hasattr(kern, '__iter__'):
+            if len(kern) > np.abs(l) + np.abs(r) + 1:
+                raise ValueError(
+                    'The length of the kernel cannot be larger than the '
+                    'length %d of the resulting CCH.' % (
+                        np.abs(l) + np.abs(r) + 1))
+            kern = np.array(kern, dtype=float)
+            kern = 1. * kern / sum(kern)
+        # Check kern parameter
+        else:
+            raise ValueError('Invalid smoothing kernel.')
+
+        # Smooth the cross-correlation histogram with the kern
+        return np.convolve(counts, kern, mode='same')
+
+    def _cch_memory(binned_st1, binned_st2, win, border_corr, binary, kern):
+
+        # Retrieve unclipped matrix
+        st1_spmat = binned_st1.to_sparse_array()
+        st2_spmat = binned_st2.to_sparse_array()
+        binsize = binned_st1.binsize
+        max_num_bins = max(binned_st1.num_bins, binned_st2.num_bins)
+
+        # Set the time window in which is computed the cch
+        if not isinstance(win, str):
+            # Window parameter given in number of bins (integer)
+            if isinstance(win[0], int) and isinstance(win[1], int):
+                # Check the window parameter values
+                if win[0] >= win[1] or win[0] <= -max_num_bins \
+                        or win[1] >= max_num_bins:
+                    raise ValueError(
+                        "The window exceeds the length of the spike trains")
+                # Assign left and right edges of the cch
+                l, r = win[0], win[1]
+            # Window parameter given in time units
+            else:
+                # Check the window parameter values
+                if win[0].rescale(binsize.units).magnitude % \
+                    binsize.magnitude != 0 or win[1].rescale(
+                        binsize.units).magnitude % binsize.magnitude != 0:
+                    raise ValueError(
+                        "The window has to be a multiple of the binsize")
+                if win[0] >= win[1] or win[0] <= -max_num_bins * binsize \
+                        or win[1] >= max_num_bins * binsize:
+                    raise ValueError("The window exceeds the length of the"
+                                     " spike trains")
+                # Assign left and right edges of the cch
+                l, r = int(win[0].rescale(binsize.units) / binsize), int(
+                    win[1].rescale(binsize.units) / binsize)
+        # Case without explicit window parameter
+        elif window == 'full':
+            # cch computed for all the possible entries
+            # Assign left and right edges of the cch
+            r = binned_st2.num_bins - 1
+            l = - binned_st1.num_bins + 1
+            # cch compute only for the entries that completely overlap
+        elif window == 'valid':
+            # cch computed only for valid entries
+            # Assign left and right edges of the cch
+            r = max(binned_st2.num_bins - binned_st1.num_bins, 0)
+            l = min(binned_st2.num_bins - binned_st1.num_bins, 0)
+        # Check the mode parameter
+        else:
+            raise KeyError("Invalid window parameter")
+
+        # For each row, extract the nonzero column indices
+        # and the corresponding # data in the matrix (for performance reasons)
+        st1_bin_idx_unique = st1_spmat.nonzero()[1]
+        st2_bin_idx_unique = st2_spmat.nonzero()[1]
+
+        # Case with binary entries
+        if binary:
+            st1_bin_counts_unique = np.array(st1_spmat.data > 0, dtype=int)
+            st2_bin_counts_unique = np.array(st2_spmat.data > 0, dtype=int)
+        # Case with all values
+        else:
+            st1_bin_counts_unique = st1_spmat.data
+            st2_bin_counts_unique = st2_spmat.data
+
+        # Initialize the counts to an array of zeroes,
+        # and the bin IDs to integers
+        # spanning the time axis
+        counts = np.zeros(np.abs(l) + np.abs(r) + 1)
+        bin_ids = np.arange(l, r + 1)
+        # Compute the CCH at lags in l,...,r only
+        for idx, i in enumerate(st1_bin_idx_unique):
+            il = np.searchsorted(st2_bin_idx_unique, l + i)
+            ir = np.searchsorted(st2_bin_idx_unique, r + i, side='right')
+            timediff = st2_bin_idx_unique[il:ir] - i
+            assert ((timediff >= l) & (timediff <= r)).all(), 'Not all the '
+            'entries of cch lie in the window'
+            counts[timediff + np.abs(l)] += (st1_bin_counts_unique[idx] *
+                                             st2_bin_counts_unique[il:ir])
+            st2_bin_idx_unique = st2_bin_idx_unique[il:]
+            st2_bin_counts_unique = st2_bin_counts_unique[il:]
+        # Border correction
+        if border_corr is True:
+            counts = _border_correction(counts, max_num_bins, l, r)
+        if kern is not None:
+            # Smoothing
+            counts = _kernel_smoothing(counts, kern, l, r)
+        # Transform the array count into an AnalogSignalArray
+        cch_result = neo.AnalogSignalArray(
+            signal=counts.reshape(counts.size, 1),
+            units=pq.dimensionless,
+            t_start=(bin_ids[0] - 0.5) * binned_st1.binsize,
+            sampling_period=binned_st1.binsize)
+        # Return only the hist_bins bins and counts before and after the
+        # central one
+        return cch_result, bin_ids
+
+    def _cch_speed(binned_st1, binned_st2, win, border_corr, binary, kern):
+
+        # Retrieve the array of the binne spik train
+        st1_arr = binned_st1.to_array()[0, :]
+        st2_arr = binned_st2.to_array()[0, :]
+        binsize = binned_st1.binsize
+
+        # Convert the to binary version
+        if binary:
+            st1_arr = np.array(st1_arr > 0, dtype=int)
+            st2_arr = np.array(st2_arr > 0, dtype=int)
+        max_num_bins = max(len(st1_arr), len(st2_arr))
+
+        # Cross correlate the spiketrains
+
+        # Case explicit temporal window
+        if not isinstance(win, str):
+            # Window parameter given in number of bins (integer)
+            if isinstance(win[0], int) and isinstance(win[1], int):
+                # Check the window parameter values
+                if win[0] >= win[1] or win[0] <= -max_num_bins \
+                        or win[1] >= max_num_bins:
+                    raise ValueError(
+                        "The window exceed the length of the spike trains")
+                # Assign left and right edges of the cch
+                l, r = win
+            # Window parameter given in time units
+            else:
+                # Check the window parameter values
+                if win[0].rescale(binsize.units).magnitude % \
+                    binsize.magnitude != 0 or win[1].rescale(
+                        binsize.units).magnitude % binsize.magnitude != 0:
+                    raise ValueError(
+                        "The window has to be a multiple of the binsize")
+                if win[0] >= win[1] or win[0] <= -max_num_bins * binsize \
+                        or win[1] >= max_num_bins * binsize:
+                    raise ValueError("The window exceed the length of the"
+                                     " spike trains")
+                # Assign left and right edges of the cch
+                l, r = int(win[0].rescale(binsize.units) / binsize), int(
+                    win[1].rescale(binsize.units) / binsize)
+
+            # Zero padding
+            st1_arr = np.pad(
+                st1_arr, (int(np.abs(np.min([l, 0]))), np.max([r, 0])),
+                mode='constant')
+            cch_mode = 'valid'
+        else:
+            # Assign the edges of the cch for the different mode parameters
+            if win == 'full':
+                # Assign left and right edges of the cch
+                r = binned_st2.num_bins - 1
+                l = - binned_st1.num_bins + 1
+            # cch compute only for the entries that completely overlap
+            elif win == 'valid':
+                # Assign left and right edges of the cch
+                r = max(binned_st2.num_bins - binned_st1.num_bins, 0)
+                l = min(binned_st2.num_bins - binned_st1.num_bins, 0)
+            cch_mode = win
+
+        # Cross correlate the spike trains
+        counts = np.correlate(st2_arr, st1_arr, mode=cch_mode)
+        bin_ids = np.r_[l:r + 1]
+        # Border correction
+        if border_corr is True:
+            counts = _border_correction(counts, max_num_bins, l, r)
+        if kern is not None:
+            # Smoothing
+            counts = _kernel_smoothing(counts, kern, l, r)
+        # Transform the array count into an AnalogSignalArray
+        cch_result = neo.AnalogSignalArray(
+            signal=counts.reshape(counts.size, 1),
+            units=pq.dimensionless,
+            t_start=(bin_ids[0] - 0.5) * binned_st1.binsize,
+            sampling_period=binned_st1.binsize)
+        # Return only the hist_bins bins and counts before and after the
+        # central one
+        return cch_result, bin_ids
+
+    # Check that the spike trains are binned with the same temporal
+    # resolution
+    if not binned_st1.matrix_rows == 1:
+        raise AssertionError("Spike train must be one dimensional")
+    if not binned_st2.matrix_rows == 1:
+        raise AssertionError("Spike train must be one dimensional")
+    if not binned_st1.binsize == binned_st2.binsize:
+        raise AssertionError("Bin sizes must be equal")
+
+    # Check t_start and t_stop identical (to drop once that the
+    # pad functionality wil be available in the BinnedSpikeTrain classe)
+    if not binned_st1.t_start == binned_st2.t_start:
+        raise AssertionError("Spike train must have same t start")
+    if not binned_st1.t_stop == binned_st2.t_stop:
+        raise AssertionError("Spike train must have same t stop")
+
+    if method == "memory":
+        cch_result, bin_ids = _cch_memory(
+            binned_st1, binned_st2, window, border_correction, binary,
+            kernel)
+    elif method == "speed":
+
+        cch_result, bin_ids = _cch_speed(
+            binned_st1, binned_st2, window, border_correction, binary,
+            kernel)
+
+    return cch_result, bin_ids
+
+# Alias for common abbreviation
+cch = cross_correlation_histogram

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -9,7 +9,7 @@ Unit tests for the spike_train_correlation module.
 import unittest
 
 import numpy as np
-from numpy.testing.utils import assert_array_equal
+from numpy.testing.utils import assert_array_equal, assert_array_almost_equal
 import quantities as pq
 import neo
 import elephant.conversion as conv
@@ -220,6 +220,342 @@ class corrcoeff_TestCase(unittest.TestCase):
         self.assertEqual(target.ndim, 0)
         self.assertEqual(target, 1.)
 
+
+class cross_correlation_histogram_TestCase(unittest.TestCase):
+
+    def setUp(self):
+        # These two arrays must be such that they do not have coincidences
+        # spanning across two neighbor bins assuming ms bins [0,1),[1,2),...
+        self.test_array_1d_1 = [
+            1.3, 7.56, 15.87, 28.23, 30.9, 34.2, 38.2, 43.2]
+        self.test_array_1d_2 = [
+            1.02, 2.71, 18.82, 28.46, 28.79, 43.6]
+
+        # Build spike trains
+        self.st_1 = neo.SpikeTrain(
+            self.test_array_1d_1, units='ms', t_stop=50.)
+        self.st_2 = neo.SpikeTrain(
+            self.test_array_1d_2, units='ms', t_stop=50.)
+
+        # And binned counterparts
+        self.binned_st1 = conv.BinnedSpikeTrain(
+            [self.st_1], t_start=0 * pq.ms, t_stop=50. * pq.ms,
+            binsize=1 * pq.ms)
+        self.binned_st2 = conv.BinnedSpikeTrain(
+            [self.st_2], t_start=0 * pq.ms, t_stop=50. * pq.ms,
+            binsize=1 * pq.ms)
+        # Binned sts to check errors raising
+        self.st_check_binsize = conv.BinnedSpikeTrain(
+            [self.st_1], t_start=0 * pq.ms, t_stop=50. * pq.ms,
+            binsize=5 * pq.ms)
+        self.st_check_t_start = conv.BinnedSpikeTrain(
+            [self.st_1], t_start=1 * pq.ms, t_stop=50. * pq.ms,
+            binsize=1 * pq.ms)
+        self.st_check_t_stop = conv.BinnedSpikeTrain(
+            [self.st_1], t_start=0 * pq.ms, t_stop=40. * pq.ms,
+            binsize=1 * pq.ms)
+        self.st_check_dimension = conv.BinnedSpikeTrain(
+            [self.st_1, self.st_2], t_start=0 * pq.ms, t_stop=50. * pq.ms,
+            binsize=1 * pq.ms)
+
+    def test_cross_correlation_histogram(self):
+        '''
+        Test generic result of a cross-correlation histogram between two binned
+        spike trains.
+        '''
+        # Calculate CCH using Elephant (normal and binary version) with
+        # mode equal to 'full' (whole spike trains are correlated)
+        cch_clipped, bin_ids_clipped = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='full',
+            binary=True)
+        cch_unclipped, bin_ids_unclipped = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='full', binary=False)
+
+        cch_clipped_mem, bin_ids_clipped_mem = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='full',
+            binary=True, method='memory')
+        cch_unclipped_mem, bin_ids_unclipped_mem = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='full',
+            binary=False, method='memory')
+        # Check consistency two methods
+        assert_array_equal(
+            np.squeeze(cch_clipped.magnitude), np.squeeze(
+                cch_clipped_mem.magnitude))
+        assert_array_equal(
+            np.squeeze(cch_clipped.times), np.squeeze(
+                cch_clipped_mem.times))
+        assert_array_equal(
+            np.squeeze(cch_unclipped.magnitude), np.squeeze(
+                cch_unclipped_mem.magnitude))
+        assert_array_equal(
+            np.squeeze(cch_unclipped.times), np.squeeze(
+                cch_unclipped_mem.times))
+        assert_array_almost_equal(bin_ids_clipped, bin_ids_clipped_mem)
+        assert_array_almost_equal(bin_ids_unclipped, bin_ids_unclipped_mem)
+
+        # Check normal correlation Note: Use numpy correlate to verify result.
+        # Note: numpy conventions for input array 1 and input array 2 are
+        # swapped compared to Elephant!
+        mat1 = self.binned_st1.to_array()[0]
+        mat2 = self.binned_st2.to_array()[0]
+        target_numpy = np.correlate(mat2, mat1, mode='full')
+        assert_array_equal(
+            target_numpy, np.squeeze(cch_unclipped.magnitude))
+
+        # Check correlation using binary spike trains
+        mat1 = np.array(self.binned_st1.to_bool_array()[0], dtype=int)
+        mat2 = np.array(self.binned_st2.to_bool_array()[0], dtype=int)
+        target_numpy = np.correlate(mat2, mat1, mode='full')
+        assert_array_equal(
+            target_numpy, np.squeeze(cch_clipped.magnitude))
+
+        # Check the time axis and bin IDs of the resulting AnalogSignalArray
+        assert_array_almost_equal(
+            (bin_ids_clipped - 0.5) * self.binned_st1.binsize,
+            cch_unclipped.times)
+        assert_array_almost_equal(
+            (bin_ids_clipped - 0.5) * self.binned_st1.binsize,
+            cch_clipped.times)
+
+        # Calculate CCH using Elephant (normal and binary version) with
+        # mode equal to 'valid' (only completely overlapping intervals of the
+        # spike trains are correlated)
+        cch_clipped, bin_ids_clipped = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='valid',
+            binary=True)
+        cch_unclipped, bin_ids_unclipped = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='valid',
+            binary=False)
+        cch_clipped_mem, bin_ids_clipped_mem = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='valid',
+            binary=True, method='memory')
+        cch_unclipped_mem, bin_ids_unclipped_mem = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='valid',
+            binary=False, method='memory')
+
+        # Check consistency two methods
+        assert_array_equal(
+            np.squeeze(cch_clipped.magnitude), np.squeeze(
+                cch_clipped_mem.magnitude))
+        assert_array_equal(
+            np.squeeze(cch_clipped.times), np.squeeze(
+                cch_clipped_mem.times))
+        assert_array_equal(
+            np.squeeze(cch_unclipped.magnitude), np.squeeze(
+                cch_unclipped_mem.magnitude))
+        assert_array_equal(
+            np.squeeze(cch_unclipped.times), np.squeeze(
+                cch_unclipped_mem.times))
+        assert_array_equal(bin_ids_clipped, bin_ids_clipped_mem)
+        assert_array_equal(bin_ids_unclipped, bin_ids_unclipped_mem)
+
+        # Check normal correlation Note: Use numpy correlate to verify result.
+        # Note: numpy conventions for input array 1 and input array 2 are
+        # swapped compared to Elephant!
+        mat1 = self.binned_st1.to_array()[0]
+        mat2 = self.binned_st2.to_array()[0]
+        target_numpy = np.correlate(mat2, mat1, mode='valid')
+        assert_array_equal(
+            target_numpy, np.squeeze(cch_unclipped.magnitude))
+
+        # Check correlation using binary spike trains
+        mat1 = np.array(self.binned_st1.to_bool_array()[0], dtype=int)
+        mat2 = np.array(self.binned_st2.to_bool_array()[0], dtype=int)
+        target_numpy = np.correlate(mat2, mat1, mode='valid')
+        assert_array_equal(
+            target_numpy, np.squeeze(cch_clipped.magnitude))
+
+        # Check the time axis and bin IDs of the resulting AnalogSignalArray
+        assert_array_equal(
+            (bin_ids_clipped - 0.5) * self.binned_st1.binsize,
+            cch_unclipped.times)
+        assert_array_equal(
+            (bin_ids_clipped - 0.5) * self.binned_st1.binsize,
+            cch_clipped.times)
+
+        # Check for wrong window parameter setting
+        self.assertRaises(
+            KeyError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window='dsaij')
+        self.assertRaises(
+            KeyError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window='dsaij', method='memory')
+
+    def test_raising_error_wrong_inputs(self):
+        '''Check that an exception is thrown if the two spike trains are not
+        fullfilling the requirement of the function'''
+        # Check the binsizes are the same
+        self.assertRaises(
+            AssertionError,
+            sc.cross_correlation_histogram, self.binned_st1,
+            self.st_check_binsize)
+        # Check different t_start and t_stop
+        self.assertRaises(
+            AssertionError, sc.cross_correlation_histogram,
+            self.st_check_t_start, self.binned_st2)
+        self.assertRaises(
+            AssertionError, sc.cross_correlation_histogram,
+            self.st_check_t_stop, self.binned_st2)
+        # Check input are one dimensional
+        self.assertRaises(
+            AssertionError, sc.cross_correlation_histogram,
+            self.st_check_dimension, self.binned_st2)
+        self.assertRaises(
+            AssertionError, sc.cross_correlation_histogram,
+            self.binned_st2, self.st_check_dimension)
+
+    def test_window(self):
+        '''Test if the window parameter is correctly interpreted.'''
+        cch_win, bin_ids = sc.cch(
+            self.binned_st1, self.binned_st2, window=[-30, 30])
+        cch_win_mem, bin_ids_mem = sc.cch(
+            self.binned_st1, self.binned_st2, window=[-30, 30])
+
+        assert_array_equal(bin_ids, np.arange(-30, 31, 1))
+        assert_array_equal(
+            (bin_ids - 0.5) * self.binned_st1.binsize, cch_win.times)
+
+        assert_array_equal(bin_ids_mem, np.arange(-30, 31, 1))
+        assert_array_equal(
+            (bin_ids_mem - 0.5) * self.binned_st1.binsize, cch_win.times)
+
+        assert_array_equal(cch_win, cch_win_mem)
+        cch_unclipped, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='full', binary=False)
+        assert_array_equal(cch_win, cch_unclipped[19:80])
+
+        cch_win, bin_ids = sc.cch(
+            self.binned_st1, self.binned_st2, window=[-25*pq.ms, 25*pq.ms])
+        cch_win_mem, bin_ids_mem = sc.cch(
+            self.binned_st1, self.binned_st2, window=[-25*pq.ms, 25*pq.ms],
+            method='memory')
+
+        assert_array_equal(bin_ids, np.arange(-25, 26, 1))
+        assert_array_equal(
+            (bin_ids - 0.5) * self.binned_st1.binsize, cch_win.times)
+
+        assert_array_equal(bin_ids_mem, np.arange(-25, 26, 1))
+        assert_array_equal(
+            (bin_ids_mem - 0.5) * self.binned_st1.binsize, cch_win.times)
+
+        assert_array_equal(cch_win, cch_win_mem)
+
+        _, bin_ids = sc.cch(
+            self.binned_st1, self.binned_st2, window=[20, 30])
+        _, bin_ids_mem = sc.cch(
+            self.binned_st1, self.binned_st2, window=[20, 30], method='memory')
+
+        assert_array_equal(bin_ids, np.arange(20, 31, 1))
+        assert_array_equal(bin_ids_mem, np.arange(20, 31, 1))
+
+        _, bin_ids = sc.cch(
+            self.binned_st1, self.binned_st2, window=[-30, -20])
+
+        _, bin_ids_mem = sc.cch(
+            self.binned_st1, self.binned_st2, window=[-30, -20],
+            method='memory')
+
+        assert_array_equal(bin_ids, np.arange(-30, -19, 1))
+        assert_array_equal(bin_ids_mem, np.arange(-30, -19, 1))
+
+        # Cehck for wrong assignments to the window parameter
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-60, 50])
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-60, 50], method='memory')
+
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-50, 60])
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-50, 60], method='memory')
+
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-25.5*pq.ms, 25*pq.ms])
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-25.5*pq.ms, 25*pq.ms], method='memory')
+
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-25*pq.ms, 25.5*pq.ms])
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-25*pq.ms, 25.5*pq.ms], method='memory')
+
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-60*pq.ms, 50*pq.ms])
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-60*pq.ms, 50*pq.ms], method='memory')
+
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-50*pq.ms, 60*pq.ms])
+        self.assertRaises(
+            ValueError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-50*pq.ms, 60*pq.ms], method='memory')
+
+    def test_border_correction(self):
+        '''Test if the border correction for bins at the edges is correctly
+        performed'''
+        cch_corrected, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='full',
+            border_correction=True, binary=False, kernel=None)
+        cch_corrected_mem, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='full',
+            border_correction=True, binary=False, kernel=None, method='memory')
+        cch, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='full',
+            border_correction=False, binary=False, kernel=None)
+        cch_mem, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, window='full',
+            border_correction=False, binary=False, kernel=None,
+            method='memory')
+
+        self.assertNotEqual(cch.all(), cch_corrected.all())
+        self.assertNotEqual(cch_mem.all(), cch_corrected_mem.all())
+
+    def test_kernel(self):
+        '''Test if the smoothing kernel is correctly defined, and wheter it is
+        applied properly.'''
+        smoothed_cch, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, kernel=np.ones(3))
+        smoothed_cch_mem, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, kernel=np.ones(3),
+            method='memory')
+
+        cch, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, kernel=None)
+        cch_mem, _ = sc.cross_correlation_histogram(
+            self.binned_st1, self.binned_st2, kernel=None, method='memory')
+
+        self.assertNotEqual(smoothed_cch.all, cch.all)
+        self.assertNotEqual(smoothed_cch_mem.all, cch_mem.all)
+
+        self.assertRaises(
+            ValueError, sc.cch, self.binned_st1, self.binned_st2,
+            kernel=np.ones(100))
+        self.assertRaises(
+            ValueError, sc.cch, self.binned_st1, self.binned_st2,
+            kernel=np.ones(100), method='memory')
+
+        self.assertRaises(
+            ValueError, sc.cch, self.binned_st1, self.binned_st2, kernel='BOX')
+        self.assertRaises(
+            ValueError, sc.cch, self.binned_st1, self.binned_st2, kernel='BOX',
+            method='memory')
+
+    def test_exist_alias(self):
+        '''
+        Test if alias cch still exists.
+        '''
+        self.assertEqual(sc.cross_correlation_histogram, sc.cch)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request add the function cross_correlation_histogram() to compute the cross correlation between two binned spike trains. It merge the two pull requests https://github.com/NeuralEnsemble/elephant/pull/40 and https://github.com/NeuralEnsemble/elephant/pull/39 and relative comments.
I would like in particular have some feedback from @mdenker  and @btel, that create the original pull requests. There are still some open points in respect to the previous comments:
* input binned spike trains vs. spike trains in continuous time
* automatic section of the parameter that now is called `method` to  switch between speed version or low memory consuming
* whether to trim the spike trains when the `window` parameter is specified or just cut off the cross-correlation histogram 