### PR TITLE
Minor fix in doc system to ensure Sphinx's autodoc finds elephant

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, '..')
 
 # -- General configuration -----------------------------------------------------
 

--- a/doc/rescan_module_tree
+++ b/doc/rescan_module_tree
@@ -1,4 +1,0 @@
-#!/bin/bash
-echo Rescanning elephant modules and rebuilding rst files...
-sphinx-apidoc -e -d 4 -f -o source ../elephant/ ../elephant/test
-


### PR DESCRIPTION
If Elephant was not in the system python path, Sphinx autodoc would not find the package to extract the information on functions and modules.

Added the Elephant base directory ('..') in the sphinx config file to ensure it is found.

Also, removed an old and outdated script that was used to manually generate the sphinx documentation using sphinx-apidoc, which is now no longer necessary.