### PR TITLE
fix for bin_edges bug

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -581,7 +581,8 @@ class BinnedSpikeTrain(object):
             are returned as a quantity array.
 
         """
-        return pq.Quantity(np.linspace(self.t_start, self.t_stop,
+        return pq.Quantity(np.linspace(self.t_start.magnitude,
+                                       self.t_stop.magnitude,
                                        self.num_bins + 1, endpoint=True),
                            units=self.binsize.units)
 


### PR DESCRIPTION
This PR is a fix for issue https://github.com/NeuralEnsemble/elephant/issues/90. 
As @btel suggested the magnitude of `t_start` and `t_stop` is given as parameters to the numpy linspace function and then the result is wrapped as a quantities array.  