### PR TITLE
Detect peaks in SpikeTrain and extract SpikeTrain with waveforms

### DIFF
--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -210,13 +210,15 @@ def peak_detection(signal, threshold=0.0 * mV, sign='above', format=None):
     else:
         # Select thr crossings lasting at least 2 dtps, np.diff(cutout) > 2
         # This avoids empty slices
-        border_start = np.where(np.diff(cutout) > 2)[0]
-        border_end = np.where(np.diff(cutout) > 2)[0] + 1
+        border_start = np.where(np.diff(cutout) > 1)[0]
+        border_end = np.where(np.diff(cutout) > 1)[0] + 1
         borders = np.concatenate((border_start, border_end))
         borders = np.append(0, borders)
         borders = np.append(borders, len(cutout)-1)
         borders = np.sort(borders)
         true_borders = cutout[borders]
+        right_borders = true_borders[1::2] + 1
+        true_borders = np.sort(np.append(true_borders[0::2], right_borders))
 
         # Workaround for bug that occurs when signal goes below thr for 1 dtp,
         # Workaround eliminates empy slices from np. split

--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -17,12 +17,13 @@ from neo import SpikeTrain
 import random
 from elephant.spike_train_surrogates import dither_spike_train
 
-def spike_extraction(signal, threshold = 0.0 * mV, sign = 'above',
-                     time_stamps = None, extr_interval = (-2 * ms, 4 * ms)):
+
+def spike_extraction(signal, threshold=0.0 * mV, sign='above',
+                     time_stamps=None, extr_interval=(-2 * ms, 4 * ms)):
     """
-    Return the peak times for all events that cross threshold and the waveforms.
-    Usually used for extracting spikes from a membrane potential to calculate
-    waveform properties
+    Return the peak times for all events that cross threshold and the
+    waveforms. Usually used for extracting spikes from a membrane
+    potential to calculate waveform properties.
     Similar to spike_train_generation.peak_detection.
 
     Parameters
@@ -30,53 +31,57 @@ def spike_extraction(signal, threshold = 0.0 * mV, sign = 'above',
     signal : neo AnalogSignal object
         'signal' is an analog signal.
     threshold : A quantity, e.g. in mV
-        'threshold' contains a value that must be reached for an event 
+        'threshold' contains a value that must be reached for an event
         to be detected.
     sign : 'above' or 'below'
         'sign' determines whether to count thresholding crossings
         that cross above or below the threshold.
-    spike_train: None, quantity array or Object with .times interface
-        if 'spike_train' is a quantity array or exposes a quantity array 
-        exposes the .times interface, it provides the time_stamps 
-        around which the waveform is extracted. If it is None, the function 
-        peak_detection is used to calculate the time_stamps from signal.
+    time_stamps: None, quantity array or Object with .times interface
+        if 'spike_train' is a quantity array or exposes a quantity array
+        exposes the .times interface, it provides the time_stamps
+        around which the waveform is extracted. If it is None, the
+        function peak_detection is used to calculate the time_stamps
+        from signal.
     extr_interval: unpackable time quantities, len == 2
-        'extr_interval' specifies the time interval around the time_stamps
-        where the waveform is extracted. The default is an interval of 6 * ms.
+        'extr_interval' specifies the time interval around the
+        time_stamps where the waveform is extracted. The default is an
+        interval of 6 * ms.
 
     Returns
     -------
     result_st : neo SpikeTrain object
-        'result_st' contains the time_stamps of each of the spikes and the 
-        waveforms in result_st.waveforms.
+        'result_st' contains the time_stamps of each of the spikes and
+        the waveforms in result_st.waveforms.
     """
-    #Get spike time_stamps from calling peak_detection of from a passed spike_train
+    # Get spike time_stamps
     if time_stamps is None:
-        time_stamps = peak_detection(signal, threshold, sign = sign)
+        time_stamps = peak_detection(signal, threshold, sign=sign)
     elif hasattr(time_stamps, 'times'):
         time_stamps = time_stamps.times
     elif type(time_stamps) is Quantity:
-        raise TypeError("time_stamps must be None, a quantity array or expose" +
-        " a quantity array through the .times interface")
+        raise TypeError("time_stamps must be None, a quantity array or" +
+                        " expose the.times interface")
 
     if len(time_stamps) == 0:
-         return SpikeTrain(time_stamps, units = signal.times.units,
-                   t_start = signal.t_start, t_stop = signal.t_stop,
-                   waveforms = np.array([]), sampling_rate = signal.sampling_rate)
+        return SpikeTrain(time_stamps, units=signal.times.units,
+                          t_start=signal.t_start, t_stop=signal.t_stop,
+                          waveforms=np.array([]),
+                          sampling_rate=signal.sampling_rate)
 
-    #Unpack the extraction interval from tuple or array
+    # Unpack the extraction interval from tuple or array
     extr_left, extr_right = extr_interval
     if extr_left > extr_right:
         raise ValueError("extr_interval[0] must be < extr_interval[1]")
 
     if any(np.diff(time_stamps) < extr_interval[1]):
-        print("WARNING: Waveforms overlap. This can cause errors during further analysis!")
+        print("WARNING: Waveforms overlap")
 
     data_left = ((extr_left * signal.sampling_rate).simplified).magnitude
 
     data_right = ((extr_right * signal.sampling_rate).simplified).magnitude
 
-    data_stamps = (((time_stamps - signal.t_start) * signal.sampling_rate).simplified).magnitude
+    data_stamps = (((time_stamps - signal.t_start) *
+                    signal.sampling_rate).simplified).magnitude
 
     data_stamps = data_stamps.astype(int)
 
@@ -84,27 +89,32 @@ def spike_extraction(signal, threshold = 0.0 * mV, sign = 'above',
 
     borders_right = data_stamps + data_right
 
-    borders = np.dstack((borders_left, borders_right)).flatten()   
+    borders = np.dstack((borders_left, borders_right)).flatten()
 
-    waveforms = np.array(np.split(np.array(signal), borders)[1::2]) * signal.units
-    
-    #len(np.shape(waveforms)) == 1 if the waveforms do not have the same width.
-    #this can occur when extr_interval indexes beyond the signal.
-    #Workaround: delete spikes shorter than the maximum length with 
+    waveforms = np.array(
+                np.split(np.array(signal), borders)[1::2]) * signal.units
+
+    # len(np.shape(waveforms)) == 1 if waveforms do not have the same width.
+    # this can occur when extr_interval indexes beyond the signal.
+    # Workaround: delete spikes shorter than the maximum length with
     if len(np.shape(waveforms)) == 1:
         max_len = (np.array([len(x) for x in waveforms])).max()
-        to_delete = np.array([idx for idx, x in enumerate(waveforms) if len(x) < max_len])
-        waveforms = np.delete(waveforms, to_delete, axis = 0)
+        to_delete = np.array([idx for idx, x in enumerate(waveforms)
+                             if len(x) < max_len])
+        waveforms = np.delete(waveforms, to_delete, axis=0)
         waveforms = np.array([x for x in waveforms])
-        print("WARNING: Waveforms " + ("{:d}, " * len(to_delete)).format(*to_delete) +
-        "exceeded signal and had to be deleted. Change extr_interval to keep.")
+        print("WARNING: Waveforms " +
+              ("{:d}, " * len(to_delete)).format(*to_delete) +
+              "exceeded signal and had to be deleted" +
+              "Change extr_interval to keep.")
 
-    waveforms = waveforms[:,np.newaxis,:]
+    waveforms = waveforms[:, np.newaxis, :]
 
-    return SpikeTrain(time_stamps, units = signal.times.units,
-                       t_start = signal.t_start, t_stop = signal.t_stop,
-                       sampling_rate = signal.sampling_rate, waveforms = waveforms,
-                       left_sweep = extr_left)
+    return SpikeTrain(time_stamps, units=signal.times.units,
+                      t_start=signal.t_start, t_stop=signal.t_stop,
+                      sampling_rate=signal.sampling_rate, waveforms=waveforms,
+                      left_sweep=extr_left)
+
 
 def threshold_detection(signal, threshold=0.0 * mV, sign='above'):
     """
@@ -159,31 +169,32 @@ def threshold_detection(signal, threshold=0.0 * mV, sign='above'):
                            t_start=signal.t_start, t_stop=signal.t_stop)
     return result_st
 
-def peak_detection(signal, threshold = 0.0 * mV, sign = 'above', format = None):
+
+def peak_detection(signal, threshold=0.0 * mV, sign='above', format=None):
     """
     Return the peak times for all events that cross threshold.
     Usually used for extracting spike times from a membrane potential.
-    Similar to spike_train_generation.threshold_detection. Returns 
+    Similar to spike_train_generation.threshold_detection. Returns
 
     Parameters
     ----------
     signal : neo AnalogSignal object
         'signal' is an analog signal.
     threshold : A quantity, e.g. in mV
-        'threshold' contains a value that must be reached 
+        'threshold' contains a value that must be reached
         for an event to be detected.
     sign : 'above' or 'below'
-        'sign' determines whether to count thresholding crossings that cross 
-        above or below the threshold.
+        'sign' determines whether to count thresholding crossings that
+        cross above or below the threshold.
     format : None or 'raw'
-        Whether to return as SpikeTrain (None)
-        or as a plain array of times ('raw').
+        Whether to return as SpikeTrain (None) or as a plain array
+        of times ('raw').
 
     Returns
     -------
     result_st : neo SpikeTrain object
-        'result_st' contains the spike times of each of the events (spikes)
-        extracted from the signal.
+        'result_st' contains the spike times of each of the events
+        (spikes) extracted from the signal.
     """
     assert threshold is not None, "A threshold must be provided"
 
@@ -194,28 +205,27 @@ def peak_detection(signal, threshold = 0.0 * mV, sign = 'above', format = None):
         cutout = np.where(signal < threshold)[0]
         peak_func = np.argmin
 
-    #cutout = np.sort(np.concatenate((cutout - 1, cutout + 1)))
-
     if len(cutout) <= 0:
         events_base = np.zeros(0)
     else:
-        #Select thr crossings lasting at least 2 dtps, np.diff(cutout) > 2
-        #This avoids empty slices
+        # Select thr crossings lasting at least 2 dtps, np.diff(cutout) > 2
+        # This avoids empty slices
         border_start = np.where(np.diff(cutout) > 2)[0]
         border_end = np.where(np.diff(cutout) > 2)[0] + 1
         borders = np.concatenate((border_start, border_end))
-        borders = np.append(0,borders)
+        borders = np.append(0, borders)
         borders = np.append(borders, len(cutout)-1)
         borders = np.sort(borders)
         true_borders = cutout[borders]
-        
-        #Workaround for a bug that occurs when signal goes below thr for 1 dtp,
-        #Workaround eliminates equal borders and thereby empy slices from np. split
-        backward_mask = np.absolute(np.ediff1d(true_borders, to_begin = 1)) > 0
-        forward_mask = np.absolute(np.ediff1d(true_borders[::-1], to_begin = 1)[::-1]) > 0
+
+        # Workaround for bug that occurs when signal goes below thr for 1 dtp,
+        # Workaround eliminates empy slices from np. split
+        backward_mask = np.absolute(np.ediff1d(true_borders, to_begin=1)) > 0
+        forward_mask = np.absolute(np.ediff1d(true_borders[::-1],
+                                              to_begin=1)[::-1]) > 0
         true_borders = true_borders[backward_mask * forward_mask]
         split_signal = np.split(np.array(signal), true_borders)[1::2]
-        
+
         maxima_idc_split = np.array([peak_func(x) for x in split_signal])
 
         max_idc = maxima_idc_split + true_borders[0::2]
@@ -229,12 +239,12 @@ def peak_detection(signal, threshold = 0.0 * mV, sign = 'above', format = None):
         events_base = np.array([event.base for event in events])  # Workaround
     if format is None:
         result_st = SpikeTrain(events_base, units=signal.times.units,
-                           t_start=signal.t_start, t_stop=signal.t_stop)
+                               t_start=signal.t_start, t_stop=signal.t_stop)
     elif 'raw':
         result_st = events_base
     else:
         raise ValueError("Format argument must be None or 'raw'")
-    
+
     return result_st
 
 

--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -16,6 +16,7 @@ from quantities import ms, mV, Hz, Quantity, dimensionless
 from neo import SpikeTrain
 import random
 from elephant.spike_train_surrogates import dither_spike_train
+import warnings
 
 
 def spike_extraction(signal, threshold=0.0 * mV, sign='above',
@@ -74,7 +75,7 @@ def spike_extraction(signal, threshold=0.0 * mV, sign='above',
         raise ValueError("extr_interval[0] must be < extr_interval[1]")
 
     if any(np.diff(time_stamps) < extr_interval[1]):
-        print("WARNING: Waveforms overlap")
+        warnings.warn("Waveforms overlap.", UserWarning)
 
     data_left = ((extr_left * signal.sampling_rate).simplified).magnitude
 
@@ -103,10 +104,10 @@ def spike_extraction(signal, threshold=0.0 * mV, sign='above',
                              if len(x) < max_len])
         waveforms = np.delete(waveforms, to_delete, axis=0)
         waveforms = np.array([x for x in waveforms])
-        print("WARNING: Waveforms " +
-              ("{:d}, " * len(to_delete)).format(*to_delete) +
-              "exceeded signal and had to be deleted" +
-              "Change extr_interval to keep.")
+        warnings.warn("Waveforms " +
+                      ("{:d}, " * len(to_delete)).format(*to_delete) +
+                      "exceeded signal and had to be deleted. " +
+                      "Change extr_interval to keep.")
 
     waveforms = waveforms[:, np.newaxis, :]
 

--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -32,20 +32,20 @@ def spike_extraction(signal, threshold=0.0 * mV, sign='above',
         'signal' is an analog signal.
     threshold : A quantity, e.g. in mV
         'threshold' contains a value that must be reached for an event
-        to be detected.
+        to be detected. Default: 0.0 * mV.
     sign : 'above' or 'below'
         'sign' determines whether to count thresholding crossings
-        that cross above or below the threshold.
+        that cross above or below the threshold. Default: 'above'.
     time_stamps: None, quantity array or Object with .times interface
         if 'spike_train' is a quantity array or exposes a quantity array
         exposes the .times interface, it provides the time_stamps
         around which the waveform is extracted. If it is None, the
         function peak_detection is used to calculate the time_stamps
-        from signal.
+        from signal. Default: None.
     extr_interval: unpackable time quantities, len == 2
         'extr_interval' specifies the time interval around the
         time_stamps where the waveform is extracted. The default is an
-        interval of 6 * ms.
+        interval of '6 ms'. Default: (-2 * ms, 4 * ms).
 
     Returns
     -------
@@ -128,7 +128,7 @@ def threshold_detection(signal, threshold=0.0 * mV, sign='above'):
         'signal' is an analog signal.
     threshold : A quantity, e.g. in mV
         'threshold' contains a value that must be reached
-        for an event to be detected.
+        for an event to be detected. Default: 0.0 * mV.
     sign : 'above' or 'below'
         'sign' determines whether to count thresholding crossings
         that cross above or below the threshold.
@@ -174,7 +174,7 @@ def peak_detection(signal, threshold=0.0 * mV, sign='above', format=None):
     """
     Return the peak times for all events that cross threshold.
     Usually used for extracting spike times from a membrane potential.
-    Similar to spike_train_generation.threshold_detection. Returns
+    Similar to spike_train_generation.threshold_detection.
 
     Parameters
     ----------
@@ -185,10 +185,10 @@ def peak_detection(signal, threshold=0.0 * mV, sign='above', format=None):
         for an event to be detected.
     sign : 'above' or 'below'
         'sign' determines whether to count thresholding crossings that
-        cross above or below the threshold.
+        cross above or below the threshold. Default: 'above'.
     format : None or 'raw'
         Whether to return as SpikeTrain (None) or as a plain array
-        of times ('raw').
+        of times ('raw'). Default: None.
 
     Returns
     -------
@@ -204,6 +204,8 @@ def peak_detection(signal, threshold=0.0 * mV, sign='above', format=None):
     elif sign in 'below':
         cutout = np.where(signal < threshold)[0]
         peak_func = np.argmin
+    else:
+        raise ValueError("sign must be 'above' or 'below'")
 
     if len(cutout) <= 0:
         events_base = np.zeros(0)
@@ -211,7 +213,7 @@ def peak_detection(signal, threshold=0.0 * mV, sign='above', format=None):
         # Select thr crossings lasting at least 2 dtps, np.diff(cutout) > 2
         # This avoids empty slices
         border_start = np.where(np.diff(cutout) > 1)[0]
-        border_end = np.where(np.diff(cutout) > 1)[0] + 1
+        border_end = border_start + 1
         borders = np.concatenate((border_start, border_end))
         borders = np.append(0, borders)
         borders = np.append(borders, len(cutout)-1)

--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -71,6 +71,84 @@ def threshold_detection(signal, threshold=0.0 * mV, sign='above'):
                            t_start=signal.t_start, t_stop=signal.t_stop)
     return result_st
 
+def peak_detection(signal, threshold = 0.0 * mV, sign = 'above', format = None):
+    """
+    Return the peak times for all events that cross threshold.
+    Usually used for extracting spike times from a membrane potential.
+    Similar to spike_train_generation.threshold_detection. Returns 
+
+    Parameters
+    ----------
+    signal : neo AnalogSignal object
+        'signal' is an analog signal.
+    threshold : A quantity, e.g. in mV
+        'threshold' contains a value that must be reached 
+        for an event to be detected.
+    sign : 'above' or 'below'
+        'sign' determines whether to count thresholding crossings that cross 
+        above or below the threshold.
+    format : None or 'raw'
+        Whether to return as SpikeTrain (None)
+        or as a plain array of times ('raw').
+
+    Returns
+    -------
+    result_st : neo SpikeTrain object
+        'result_st' contains the spike times of each of the events (spikes)
+        extracted from the signal.
+    """
+    assert threshold is not None, "A threshold must be provided"
+
+    if sign is 'above':
+        cutout = np.where(signal > threshold)[0]
+        peak_func = np.argmax
+    elif sign in 'below':
+        cutout = np.where(signal < threshold)[0]
+        peak_func = np.argmin
+
+    #cutout = np.sort(np.concatenate((cutout - 1, cutout + 1)))
+
+    if len(cutout) <= 0:
+        events_base = np.zeros(0)
+    else:
+        #Select thr crossings lasting at least 2 dtps, np.diff(cutout) > 2
+        #This avoids empty slices
+        border_start = np.where(np.diff(cutout) > 2)[0]
+        border_end = np.where(np.diff(cutout) > 2)[0] + 1
+        borders = np.concatenate((border_start, border_end))
+        borders = np.append(0,borders)
+        borders = np.append(borders, len(cutout)-1)
+        borders = np.sort(borders)
+        true_borders = cutout[borders]
+        
+        #Workaround for a bug that occurs when signal goes below thr for 1 dtp,
+        #Workaround eliminates equal borders and thereby empy slices from np. split
+        backward_mask = np.absolute(np.ediff1d(true_borders, to_begin = 1)) > 0
+        forward_mask = np.absolute(np.ediff1d(true_borders[::-1], to_begin = 1)[::-1]) > 0
+        true_borders = true_borders[backward_mask * forward_mask]
+        split_signal = np.split(np.array(signal), true_borders)[1::2]
+        
+        maxima_idc_split = np.array([peak_func(x) for x in split_signal])
+
+        max_idc = maxima_idc_split + true_borders[0::2]
+
+        events = signal.times[max_idc]
+        events_base = events.base
+
+    if events_base is None:
+        # This occurs in some Python 3 builds due to some
+        # bug in quantities.
+        events_base = np.array([event.base for event in events])  # Workaround
+    if format is None:
+        result_st = SpikeTrain(events_base, units=signal.times.units,
+                           t_start=signal.t_start, t_stop=signal.t_stop)
+    elif 'raw':
+        result_st = events_base
+    else:
+        raise ValueError("Format argument must be None or 'raw'")
+    
+    return result_st
+
 
 def _homogeneous_process(interval_generator, args, mean_rate, t_start, t_stop,
                          as_array):

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy.testing.utils import assert_array_almost_equal
 from scipy.stats import kstest, expon
 from quantities import ms, second, Hz, kHz, mV, dimensionless
-
+import matplotlib.pyplot as plt
 import elephant.spike_train_generation as stgen
 from elephant.statistics import isi
 
@@ -69,30 +69,36 @@ class AnalogSignalSpikeExtractionTestCase(unittest.TestCase):
         except AttributeError: # If numpy version too old to have allclose
             self.assertTrue(np.array_equal(spike_train,spike_train))
 
+
 class AnalogSignalPeakDetectionTestCase(unittest.TestCase):
-    
+
     def setUp(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
-        npz_file_loc = os.path.join(curr_dir,'spike_extraction_test_data.npz')
+        npz_file_loc = os.path.join(curr_dir, 'spike_extraction_test_data.npz')
         iom2 = neo.io.PyNNNumpyIO(npz_file_loc)
         data = iom2.read()
         self.vm = data[0].segments[0].analogsignals[0]
-        self.true_time_stamps = [0.0124,  0.0354,  0.0713,  0.1192,  0.1695,  
+        self.true_time_stamps = [0.0124,  0.0354,  0.0713,  0.1192,  0.1695,
                                  0.2201,  0.2711] * second
-        
-    def test_peak_detection(self):
-        #Test with default arguments
+
+    def test_peak_detection_time_stamps(self):
+        # Test with default arguments
         result = stgen.peak_detection(self.vm)
+        print(result)
+        plt.plot(self.vm)
         self.assertEqual(len(self.true_time_stamps), len(result))
         self.assertIsInstance(result, neo.core.SpikeTrain)
+
         try:
             assert_array_almost_equal(result, self.true_time_stamps)
         except AttributeError:
-            self.assertTrue(np.array_equal(spike_train, self.true_time_stamps))
-    def test_peak_detection(self):
-        #Test that the result is an empty SpikeTrain when threshold is too high
-        result = stgen.peak_detection(self.vm, threshold = 30 * mV)
+            self.assertTrue(np.array_equal(result, self.true_time_stamps))
+
+    def test_peak_detection_threshold(self):
+        # Test for empty SpikeTrain when threshold is too high
+        result = stgen.peak_detection(self.vm, threshold=30 * mV)
         self.assertEqual(len(result), 0)
+
 
 class HomogeneousPoissonProcessTestCase(unittest.TestCase):
 

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -84,8 +84,6 @@ class AnalogSignalPeakDetectionTestCase(unittest.TestCase):
     def test_peak_detection_time_stamps(self):
         # Test with default arguments
         result = stgen.peak_detection(self.vm)
-        print(result)
-        plt.plot(self.vm)
         self.assertEqual(len(self.true_time_stamps), len(result))
         self.assertIsInstance(result, neo.core.SpikeTrain)
 

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -28,7 +28,7 @@ def pdiff(a, b):
     return abs((a - b)/a)
 
 
-class AnalogSignalSpikeExtractionTestCase(unittest.TestCase):
+class AnalogSignalThresholdDetectionTestCase(unittest.TestCase):
 
     def setUp(self):
         pass
@@ -96,6 +96,37 @@ class AnalogSignalPeakDetectionTestCase(unittest.TestCase):
         result = stgen.peak_detection(self.vm, threshold=30 * mV)
         self.assertEqual(len(result), 0)
 
+class AnalogSignalSpikeExtractionTestCase(unittest.TestCase):
+    
+    def setUp(self):
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        npz_file_loc = os.path.join(curr_dir, 'spike_extraction_test_data.npz')
+        iom2 = neo.io.PyNNNumpyIO(npz_file_loc)
+        data = iom2.read()
+        self.vm = data[0].segments[0].analogsignals[0]
+        self.first_spike = np.array([-0.04084546, -0.03892033, -0.03664779,
+                                     -0.03392689, -0.03061474, -0.02650277,
+                                     -0.0212756, -0.01443531, -0.00515365,
+                                     0.00803962, 0.02797951, -0.07,
+                                     -0.06974495, -0.06950466, -0.06927778,
+                                     -0.06906314, -0.06885969, -0.06866651,
+                                     -0.06848277, -0.06830773, -0.06814071,
+                                     -0.06798113, -0.06782843, -0.06768213,
+                                     -0.06754178, -0.06740699, -0.06727737,
+                                     -0.06715259, -0.06703235, -0.06691635])
+    
+    def test_spike_extraction_waveform(self):
+        spike_train = stgen.spike_extraction(self.vm,
+                                             extr_interval = (-1*ms, 2*ms))
+        try:
+            assert_array_almost_equal(spike_train.waveforms[0][0].magnitude,
+                                      self.first_spike)
+        except AttributeError:
+            self.assertTrue(
+                np.array_equal(spike_train.waveforms[0][0].magnitude,
+                               self.first_spike))
+
+        
 
 class HomogeneousPoissonProcessTestCase(unittest.TestCase):
 

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -69,6 +69,31 @@ class AnalogSignalSpikeExtractionTestCase(unittest.TestCase):
         except AttributeError: # If numpy version too old to have allclose
             self.assertTrue(np.array_equal(spike_train,spike_train))
 
+class AnalogSignalPeakDetectionTestCase(unittest.TestCase):
+    
+    def setUp(self):
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        npz_file_loc = os.path.join(curr_dir,'spike_extraction_test_data.npz')
+        iom2 = neo.io.PyNNNumpyIO(npz_file_loc)
+        data = iom2.read()
+        self.vm = data[0].segments[0].analogsignals[0]
+        self.true_time_stamps = [0.0124,  0.0354,  0.0713,  0.1192,  0.1695,  
+                                 0.2201,  0.2711] * second
+        
+    def test_peak_detection(self):
+        #Test with default arguments
+        result = stgen.peak_detection(self.vm)
+        self.assertEqual(len(self.true_time_stamps), len(result))
+        self.assertIsInstance(result, neo.core.SpikeTrain)
+        try:
+            assert_array_almost_equal(result, self.true_time_stamps)
+        except AttributeError:
+            self.assertTrue(np.array_equal(spike_train, self.true_time_stamps))
+    def test_peak_detection(self):
+        #Test that the result is an empty SpikeTrain when threshold is too high
+        result = stgen.peak_detection(self.vm, threshold = 30 * mV)
+        self.assertEqual(len(result), 0)
+
 class HomogeneousPoissonProcessTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -16,7 +16,6 @@ import numpy as np
 from numpy.testing.utils import assert_array_almost_equal
 from scipy.stats import kstest, expon
 from quantities import ms, second, Hz, kHz, mV, dimensionless
-import matplotlib.pyplot as plt
 import elephant.spike_train_generation as stgen
 from elephant.statistics import isi
 


### PR DESCRIPTION
Added two functions: peak_detection detects events by threshold similar to threshold_detection but returns a SpikeTrain where the time stamps represent the peak of the event.
spike_extraction returns a SpikeTrain where the .waveform attribute contains the waveforms of the spikes.
Both functions are essential in my analysis of action potential and EPSC properties from intracellular recordings. I've been working with them on real in-vitro data.
I wrote test cases for peak_detection on the sample data. Test cases for spike_extraction will follow.
