### PR TITLE
Update spike_train_generation.py

### DIFF
--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -87,7 +87,7 @@ def _homogeneous_process(interval_generator, args, mean_rate, t_start, t_stop,
     if number < 100:
         number = min(5 + np.ceil(2 * n), 100)
     assert number > 4  # if positive, number cannot be less than 5
-    isi = rescale(interval_generator(*args, size=number))
+    isi = rescale(interval_generator(*args, size=int(number)))
     spikes = np.cumsum(isi)
     spikes += t_start
 


### PR DESCRIPTION
Covers issue https://github.com/NeuralEnsemble/elephant/issues/96 In `spike_train_generation.py ` function `_homogeneous_process` throws a warning that it expects an integer, but gets a non-integer. This leads back to the internally used function of `numpy.random.exponential` or `numpy.random.gamma`. Example:
```python
import numpy as np 
# with warning
np.random.exponential(3, size=25.0)
# no warning 
np.random.exponential(3, size=25)
``` 

Note: To fix the minor problem I directly edited the file inside the webview of github. That's why it created a branch and makes a PR from there. In case someone wonders.  