### PR TITLE
included library six into required packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,18 @@ env:
     # This environment tests the newest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="true"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.16.1" PANDAS_VERSION="0.16.2"
-      COVERAGE="true"
+      SIX_VERSION="1.10.0" COVERAGE="true"
     - DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.16.1" PANDAS_VERSION="0.16.2"
-      COVERAGE="true"
+      SIX_VERSION="1.10.0" COVERAGE="true"
     # This environment tests minimal dependency versions
     - DISTRIB="conda_min" PYTHON_VERSION="2.7" INSTALL_MKL="false"
-      NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14.0" COVERAGE="true"
+      SIX_VERSION="1.10.0" NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14.0" COVERAGE="true"
     - DISTRIB="conda_min" PYTHON_VERSION="3.4" INSTALL_MKL="false"
-      NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14.0" COVERAGE="true"
+      SIX_VERSION="1.10.0" NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14.0" COVERAGE="true"
     # basic Ubuntu build environment
     - DISTRIB="ubuntu" PYTHON_VERSION="2.7" INSTALL_ATLAS="true"
-      NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14.0"
+      NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14.0" SIX_VERSION="1.10.0"
       COVERAGE="true"
 install: source continuous_integration/install.sh
 script: bash continuous_integration/test_script.sh

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -29,8 +29,8 @@ if [[ "$DISTRIB" == "conda_min" ]]; then
 
     # Configure the conda environment and put it in the path using the
     # provided versions
-    conda create -n testenv --yes python=$PYTHON_VERSION pip nose coverage six \
-        numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION
+    conda create -n testenv --yes python=$PYTHON_VERSION pip nose coverage \
+        six=$SIX_VERSION numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION
     source activate testenv
     conda install libgfortran=1
 
@@ -58,7 +58,7 @@ elif [[ "$DISTRIB" == "conda" ]]; then
 
     # Configure the conda environment and put it in the path using the
     # provided versions
-    conda create -n testenv --yes python=$PYTHON_VERSION pip nose coverage six \
+    conda create -n testenv --yes python=$PYTHON_VERSION pip nose coverage six=$SIX_VERSION \
         numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION pandas=$PANDAS_VERSION scikit-learn
     source activate testenv
     conda install libgfortran=1
@@ -86,7 +86,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     pip install coverage
     pip install numpy==$NUMPY_VERSION
     pip install scipy==$SCIPY_VERSION
-    pip install six
+    pip install six==$SIX_VERSION
     pip install quantities
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ long_description = open("README.rst").read()
 install_requires = ['neo>0.3.3',
                     'numpy>=1.8.2',
                     'quantities>=0.10.1',
-                    'scipy>=0.14.0']
+                    'scipy>=0.14.0',
+                    'six']
 extras_require = {'pandas': ['pandas>=0.14.1'],
                   'docs': ['numpydoc>=0.5',
                            'sphinx>=1.2.2'],

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = ['neo>0.3.3',
                     'numpy>=1.8.2',
                     'quantities>=0.10.1',
                     'scipy>=0.14.0',
-                    'six']
+                    'six>=1.10.0']
 extras_require = {'pandas': ['pandas>=0.14.1'],
                   'docs': ['numpydoc>=0.5',
                            'sphinx>=1.2.2'],


### PR DESCRIPTION
[SIX](https://pypi.python.org/pypi/six) is a library to ensure compatibility between Python 2 and 3. When installing `Elephant` it is not installed but the package is used already, e.g., in `spectral.py`. It could be useful in other modules, too. For instance in `asset.py` I would like to use the `xrange` function provided by `SIX`to be compatible with Python 2 and 3 and instead remove the [patch](https://github.com/NeuralEnsemble/elephant/blob/master/elephant/asset.py#L60) we have there.