### PR TITLE
Bug fixing for isi function

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -51,7 +51,6 @@ def isi(spiketrain, axis=-1):
             np.sort(spiketrain.times.view(pq.Quantity)), axis=axis)
     else:
         intervals = np.diff(np.sort(spiketrain), axis=axis)
-    if hasattr(spiketrain, 'waveforms'):
         intervals = pq.Quantity(intervals.magnitude, units=spiketrain.units)
     return intervals
 

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -46,7 +46,11 @@ def isi(spiketrain, axis=-1):
     """
     if axis is None:
         axis = -1
-    intervals = np.diff(spiketrain, axis=axis)
+    if isinstance(spiketrain, neo.SpikeTrain):
+        intervals = np.diff(
+            np.sort(spiketrain.times.view(pq.Quantity)), axis=axis)
+    else:
+        intervals = np.diff(np.sort(spiketrain), axis=axis)
     if hasattr(spiketrain, 'waveforms'):
         intervals = pq.Quantity(intervals.magnitude, units=spiketrain.units)
     return intervals

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -51,7 +51,6 @@ def isi(spiketrain, axis=-1):
             np.sort(spiketrain.times.view(pq.Quantity)), axis=axis)
     else:
         intervals = np.diff(np.sort(spiketrain), axis=axis)
-        intervals = pq.Quantity(intervals.magnitude, units=spiketrain.units)
     return intervals
 
 

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -34,7 +34,8 @@ class isi_TestCase(unittest.TestCase):
         self.targ_array_1d = self.targ_array_2d_1[0, :]
 
     def test_isi_with_spiketrain(self):
-        st = neo.SpikeTrain(self.test_array_1d, units='ms', t_stop=10.0)
+        st = neo.SpikeTrain(
+            self.test_array_1d, units='ms', t_stop=10.0, t_start=0.29)
         target = pq.Quantity(self.targ_array_1d, 'ms')
         res = es.isi(st)
         assert_array_almost_equal(res, target, decimal=9)


### PR DESCRIPTION
Two small fixes to the isi function:
* If the input is neo.SpikeTrain wchich t_start is larger than the smallest isi, the function was returning an error, because np.diff(neo.SpikeTrain) returns a neo,SpikeTrain + changed the test to cover such corner case
* Sorted the times of the spikes in input (only if sorted it makes sense to take the diff to compute the isis)