### PR TITLE
Fix waveform extraction for protruding time windows

### DIFF
--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -97,15 +97,17 @@ def spike_extraction(signal, threshold=0.0 * mV, sign='above',
 
     # len(np.shape(waveforms)) == 1 if waveforms do not have the same width.
     # this can occur when extr_interval indexes beyond the signal.
-    # Workaround: delete spikes shorter than the maximum length with
+    # Workaround: set incomplete waveforms to arrays of None
     if len(np.shape(waveforms)) == 1:
         max_len = (np.array([len(x) for x in waveforms])).max()
-        to_delete = np.array([idx for idx, x in enumerate(waveforms)
+        incomplete_wfs = np.array([idx for idx, x in enumerate(waveforms)
                              if len(x) < max_len])
-        waveforms = np.delete(waveforms, to_delete, axis=0)
+        for incomplete_wf in incomplete_wfs:
+            waveforms[incomplete_wf] = np.full((max_len), None) * signal.units
+        # waveforms = np.delete(waveforms, to_delete, axis=0)
         waveforms = np.array([x for x in waveforms])
         warnings.warn("Waveforms " +
-                      ("{:d}, " * len(to_delete)).format(*to_delete) +
+                      ("{:d}, " * len(incomplete_wfs)).format(*incomplete_wfs) +
                       "exceeded signal and had to be deleted. " +
                       "Change extr_interval to keep.")
 

--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -99,11 +99,14 @@ def spike_extraction(signal, threshold=0.0 * mV, sign='above',
     # this can occur when extr_interval indexes beyond the signal.
     # Workaround: set incomplete waveforms to arrays of None
     if len(np.shape(waveforms)) == 1:
-        max_len = (np.array([len(x) for x in waveforms])).max()
+        arraylengths = np.array([len(x) for x in waveforms])
+        max_len = (arraylengths).max()
+        max_len_arg = arraylengths.argmax()
         incomplete_wfs = np.array([idx for idx, x in enumerate(waveforms)
                              if len(x) < max_len])
         for incomplete_wf in incomplete_wfs:
-            waveforms[incomplete_wf] = np.full((max_len), None) * signal.units
+            waveforms[incomplete_wf] = np.full(waveforms[max_len_arg].shape,
+                                               None) * signal.units
         # waveforms = np.delete(waveforms, to_delete, axis=0)
         waveforms = np.array([x for x in waveforms])
         warnings.warn("Waveforms " +

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -10,6 +10,7 @@ from __future__ import division
 import unittest
 import os
 import warnings
+import math
 
 import neo
 import numpy as np
@@ -126,7 +127,10 @@ class AnalogSignalSpikeExtractionTestCase(unittest.TestCase):
                 np.array_equal(spike_train.waveforms[0][0].magnitude,
                                self.first_spike))
 
-        
+    def test_protruding_waveform_extraction_window(self):
+        stgen.spike_extraction(self.vm.reshape(-1),
+                               extr_interval = (-50*ms, 50*ms))
+
 
 class HomogeneousPoissonProcessTestCase(unittest.TestCase):
 

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -131,6 +131,10 @@ class AnalogSignalSpikeExtractionTestCase(unittest.TestCase):
         stgen.spike_extraction(self.vm.reshape(-1),
                                extr_interval = (-50*ms, 50*ms))
 
+        # Testing with multidimensional array
+        stgen.spike_extraction(self.vm,
+                               extr_interval = (-50*ms, 50*ms))
+
 
 class HomogeneousPoissonProcessTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Previously, waveforms of spikes which were too close to the beginning or end of the analogsignal were just deleted, resulting in inconsistent number of spiketimes in comparison to the extracted waveforms. This lead to an Error raised by the SpikeTrain.
With this PR, incomplete waveforms are replaced by arrays of Nones, therefore restoring the consistency of the spike times array and the waveform array.