### PR TITLE
Fix for the documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ sys.path.insert(0, '..')
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx',
-              'sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.mathjax',
+              'sphinx.ext.todo', 'sphinx.ext.imgmath',
               'sphinx.ext.viewcode', 'numpydoc']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -8,6 +8,7 @@ Function Reference by Module
    reference/statistics
    reference/signal_processing
    reference/spectral
+   reference/current_source_density
    reference/kernels
    reference/spike_train_dissimilarity
    reference/sta
@@ -18,7 +19,6 @@ Function Reference by Module
    reference/spike_train_generation
    reference/spike_train_surrogates
    reference/conversion
-   reference/csd
    reference/neo_tools
    reference/pandas_bridge
 

--- a/doc/reference/current_source_density.rst
+++ b/doc/reference/current_source_density.rst
@@ -1,0 +1,6 @@
+===============================
+Current source density analysis
+===============================
+
+.. automodule:: elephant.current_source_density
+   :members:

--- a/doc/reference/spike_train_dissimilarity.rst
+++ b/doc/reference/spike_train_dissimilarity.rst
@@ -1,5 +1,5 @@
 =================================================
-Spike Train Dissimilarity / Spike Train Synchrony
+Spike train dissimilarity / spike train synchrony
 =================================================
 
 


### PR DESCRIPTION
This PR introduces two fixes to the elephant documentation.

First, it fixes a build error on readthedocs due to a new Sphinx version that no longer allows the mathjax extension to be loaded.

Second, it fixes the CSD module not showing in the reference.