### PR TITLE
hotfixing travis ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+dist: precise
 language: python
 sudo: false
-virtualenv:
-  system_site_packages: true
+
 addons:
    apt:
       packages:
@@ -12,6 +12,9 @@ addons:
       - gfortran
       - python-scipy
 
+python:
+  - 2.7.13     
+      
 env:
   matrix:
     # This environment tests the newest supported anaconda env

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -77,16 +77,17 @@ elif [[ "$DISTRIB" == "conda" ]]; then
     python -c "import pandas; import os; assert os.getenv('PANDAS_VERSION') == pandas.__version__"
 
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
-    deactivate
+    # deactivate
     # Create a new virtualenv using system site packages for numpy and scipy
-    virtualenv --system-site-packages testenv
-    source testenv/bin/activate
+    # virtualenv --system-site-packages testenv
+    # source testenv/bin/activate
     pip install nose
     pip install coverage
+    pip install quantities
     pip install numpy==$NUMPY_VERSION
     pip install scipy==$SCIPY_VERSION
     pip install six==$SIX_VERSION
-    pip install quantities
+ 
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then


### PR DESCRIPTION
This PR provides a hotfix to solve the problems we have with travis ci and is related to https://github.com/NeuralEnsemble/elephant/issues/114

Following points were adjusted in `travis.yml` and `install.sh`: 
* fall-back to `Ubuntu precise` instead of `Ubuntu trusty`, this is the main hotfix
* added explicit python version                          
* removed usage of system site packages               
* removed creation of virtual envs in the Ubuntu build
