### PR TITLE
fixed potential bug with higher numpy versions

### DIFF
--- a/elephant/unitary_event_analysis.py
+++ b/elephant/unitary_event_analysis.py
@@ -564,7 +564,7 @@ def gen_pval_anal(
             if len(n_emp) > 1:
                 raise ValueError(
                     'in surrogate method the p_value can be calculated only for one pattern!')
-            return np.sum(exp_dist[n_emp[0]:])
+            return np.sum(exp_dist[int(n_emp[0]):])
 
     return pval, n_exp
 


### PR DESCRIPTION
As of `numpy v13+` slicing with floats is not supported anymore. This PR fixes such a bug in the `unitary_event_analysis` module. 