### PR TITLE
matrix env for mpi testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ env:
     - DISTRIB="ubuntu" PYTHON_VERSION="2.7" INSTALL_ATLAS="true"
       NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14.0" SIX_VERSION="1.10.0"
       COVERAGE="true"
+    # This environment tests for mpi
+    - DISTRIB="mpi" PYTHON_VERSION="3.5" INSTALL_MKL="false"
+      NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.16.1" SIX_VERSION="1.10.0"
+      MPI_VERSION="2.0.0" COVERAGE="true"
+
 install: source continuous_integration/install.sh
 script: bash continuous_integration/test_script.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
     # This environment tests for mpi
     - DISTRIB="mpi" PYTHON_VERSION="3.5" INSTALL_MKL="false"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.16.1" SIX_VERSION="1.10.0"
-      MPI_VERSION="2.0.0" COVERAGE="true"
+      MPI_VERSION="2.0.0" COVERAGE="true" MPI="true"
 
 install: source continuous_integration/install.sh
 script: bash continuous_integration/test_script.sh

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -76,6 +76,38 @@ elif [[ "$DISTRIB" == "conda" ]]; then
 
     python -c "import pandas; import os; assert os.getenv('PANDAS_VERSION') == pandas.__version__"
 
+elif [[ "$DISTRIB" == "mpi" ]]; then
+    # Deactivate the travis-provided virtual environment and setup a
+    # conda-based environment instead
+    deactivate
+
+    # Use the miniconda installer for faster download / install of conda
+    # itself
+    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
+        -O miniconda.sh
+    chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+    export PATH=/home/travis/miniconda/bin:$PATH
+    conda config --set always_yes yes
+    conda update --yes conda
+
+    # Configure the conda environment and put it in the path using the
+    # provided versions
+    conda create -n testenv --yes python=$PYTHON_VERSION pip nose coverage six=$SIX_VERSION \
+        numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION scikit-learn mpi4py=$MPI_VERSION
+    source activate testenv
+
+    if [[ "$INSTALL_MKL" == "true" ]]; then
+        # Make sure that MKL is used
+        conda install --yes --no-update-dependencies mkl
+    else
+        # Make sure that MKL is not used
+        conda remove --yes --features mkl || echo "MKL not installed"
+    fi
+
+    if [[ "$COVERAGE" == "true" ]]; then
+        pip install coveralls
+    fi
+
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # deactivate
     # Create a new virtualenv using system site packages for numpy and scipy

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -14,7 +14,7 @@ python -c "import scipy; print('scipy %s' % scipy.__version__)"
 
 if [[ "$COVERAGE" == "true" ]]; then
     if [[ "$MPI" == "true" ]]; then
-	mpiexec -n 2 nosetests --with-coverage --cover-package=elephant
+	mpiexec -n 1 nosetests --with-coverage --cover-package=elephant
     else
 	nosetests --with-coverage --cover-package=elephant
     fi

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -13,7 +13,7 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 
 if [[ "$COVERAGE" == "true" ]]; then
-    if [["$MPI == true" ]]; then
+    if [["$MPI == "true" ]]; then
 	mpiexec -n 2 nosetests --with-coverage --cover-package=elephant
     else
 	nosetests --with-coverage --cover-package=elephant

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -13,7 +13,7 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 
 if [[ "$COVERAGE" == "true" ]]; then
-    if [["$MPI" == "true" ]]; then
+    if [[ "$MPI" == "true" ]]; then
 	mpiexec -n 2 nosetests --with-coverage --cover-package=elephant
     else
 	nosetests --with-coverage --cover-package=elephant

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -13,7 +13,7 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 
 if [[ "$COVERAGE" == "true" ]]; then
-    if [["$MPI == "true" ]]; then
+    if [["$MPI" == "true" ]]; then
 	mpiexec -n 2 nosetests --with-coverage --cover-package=elephant
     else
 	nosetests --with-coverage --cover-package=elephant

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -13,7 +13,11 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 
 if [[ "$COVERAGE" == "true" ]]; then
-    nosetests --with-coverage --cover-package=elephant
+    if [["$MPI == true" ]]; then
+	mpiexec -n 2 nosetests --with-coverage --cover-package=elephant
+    else
+	nosetests --with-coverage --cover-package=elephant
+    fi
 else
     nosetests
 fi


### PR DESCRIPTION
This PR adds an additional environment to the matrix in `travis.yml` and corresponding changes in `install.sh`. With this env we should be able to test for mpi via `mpi4py`.  