### PR TITLE
Fix *CSD methods/tests

### DIFF
--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -95,7 +95,7 @@ def estimate_csd(lfp, coords=None, method=None,
     Returns
     -------
     Estimated CSD
-       neo.AnalogSignal Object
+       neo.AnalogSignal object
        annotated with the spatial coordinates
 
     Raises
@@ -235,7 +235,7 @@ def generate_lfp(csd_profile, ele_xx, ele_yy=None, ele_zz=None,
 
         Returns
         -------
-        LFP : list(neo.AnalogSignal type objects)
+        LFP : neo.AnalogSignal object
            The potentials created by the csd profile at the electrode positions
            The electrode postions are attached as RecordingChannel's coordinate
     """

--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -112,8 +112,6 @@ def estimate_csd(lfp, coords=None, method=None,
         raise TypeError('Parameter `lfp` must be a neo.AnalogSignal object')
     if coords is None:
         coords = lfp.channel_index.coordinates
-        # for ii in lfp:
-        #     coords.append(ii.channel_index.coordinate.rescale(pq.mm))
     else:
         scaled_coords = []
         for coord in coords:

--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -186,7 +186,7 @@ def estimate_csd(lfp, coords=None, method=None,
         lfp = neo.AnalogSignal(np.asarray(lfp).T, units=lfp.units,
                                     sampling_rate=lfp.sampling_rate)
         csd_method = getattr(icsd, method)  # fetch class from icsd.py file
-        csd_estimator = csd_method(lfp=lfp.magnitude.T * lfp.units,
+        csd_estimator = csd_method(lfp=lfp.magnitude * lfp.units,
                                    coord_electrode=coords.flatten(),
                                    **kwargs)
         csd_pqarr = csd_estimator.get_csd()
@@ -323,8 +323,7 @@ def generate_lfp(csd_profile, ele_xx, ele_yy=None, ele_zz=None,
     ch = neo.ChannelIndex(index=range(len(pots)))
     for ii in range(len(pots)):
         lfp.append(pots[ii])
-    # lfp = neo.AnalogSignal(lfp, sampling_rate=1000*pq.Hz, units='mV')
-    asig = neo.AnalogSignal(lfp, sampling_rate=pq.kHz, units='mV')
+    asig = neo.AnalogSignal(np.array(lfp).T, sampling_rate=pq.kHz, units='mV')
     ch.coordinates = ele_pos
     ch.analogsignals.append(asig)
     ch.create_relationship()

--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -68,7 +68,7 @@ def estimate_csd(lfp, coords=None, method=None,
 
     Parameters
     ----------
-    lfp : list(neo.AnalogSignal type objects)
+    lfp : neo.AnalogSignal
         positions of electrodes can be added as neo.RecordingChannel
         coordinate or sent externally as a func argument (See coords)
     coords : [Optional] corresponding spatial coordinates of the electrodes
@@ -109,8 +109,7 @@ def estimate_csd(lfp, coords=None, method=None,
         Invalid cv_param argument passed
     """
     if not isinstance(lfp, neo.AnalogSignal):
-        raise TypeError('Parameter `lfp` must be a list(neo.AnalogSignal \
-                         type objects')
+        raise TypeError('Parameter `lfp` must be a neo.AnalogSignal object')
     if coords is None:
         coords = lfp.channel_index.coordinates
         # for ii in lfp:
@@ -126,7 +125,7 @@ def estimate_csd(lfp, coords=None, method=None,
         coords = scaled_coords
     if method is None:
         raise ValueError('Must specify a method of CSD implementation')
-    if len(coords) != len(lfp):
+    if len(coords) != lfp.shape[1]:
         raise ValueError('Number of signals and coords is not same')
     for ii in coords:  # CHECK for Dimensionality of electrodes
         if len(ii) > 3:
@@ -148,7 +147,7 @@ def estimate_csd(lfp, coords=None, method=None,
         kernel_method = getattr(KCSD, method)  # fetch the class 'KCSD1D'
         lambdas = kwargs.pop('lambdas', None)
         Rs = kwargs.pop('Rs', None)
-        k = kernel_method(np.array(coords), input_array, **kwargs)
+        k = kernel_method(np.array(coords), input_array.T, **kwargs)
         if process_estimate:
             k.cross_validate(lambdas, Rs)
         estm_csd = k.values()

--- a/elephant/test/test_csd.py
+++ b/elephant/test/test_csd.py
@@ -29,21 +29,21 @@ class LFP_TestCase(unittest.TestCase):
         ele_pos = utils.generate_electrodes(dim=1).reshape(5, 1)
         lfp = csd.generate_lfp(utils.gauss_1d_dipole, ele_pos)
         self.assertEqual(ele_pos.shape[1], 1)
-        self.assertEqual(ele_pos.shape[0], len(lfp))
+        self.assertEqual(ele_pos.shape[0], lfp.shape[1])
 
     def test_lfp2d_electrodes(self):
         ele_pos = utils.generate_electrodes(dim=2)
         xx_ele, yy_ele = ele_pos
         lfp = csd.generate_lfp(utils.large_source_2D, xx_ele, yy_ele)
         self.assertEqual(len(ele_pos), 2)
-        self.assertEqual(xx_ele.shape[0], len(lfp))
+        self.assertEqual(xx_ele.shape[0], lfp.shape[1])
 
     def test_lfp3d_electrodes(self):
         ele_pos = utils.generate_electrodes(dim=3, res=3)
         xx_ele, yy_ele, zz_ele = ele_pos
         lfp = csd.generate_lfp(utils.gauss_3d_dipole, xx_ele, yy_ele, zz_ele)
         self.assertEqual(len(ele_pos), 3)
-        self.assertEqual(xx_ele.shape[0], len(lfp))
+        self.assertEqual(xx_ele.shape[0], lfp.shape[1])
 
 
 class CSD1D_TestCase(unittest.TestCase):
@@ -83,7 +83,7 @@ class CSD1D_TestCase(unittest.TestCase):
         result = self.csd_method(self.lfp, method=method)
         self.assertEqual(result.t_start, 0.0 * pq.s)
         self.assertEqual(result.sampling_rate, 1000 * pq.Hz)
-        self.assertEqual(len(result.times), 1)
+        self.assertEqual(result.shape[0], 1)
 
     def test_inputs_deltasplineicsd(self):
         methods = ['DeltaiCSD', 'SplineiCSD']
@@ -94,7 +94,7 @@ class CSD1D_TestCase(unittest.TestCase):
                                      **self.params[method])
             self.assertEqual(result.t_start, 0.0 * pq.s)
             self.assertEqual(result.sampling_rate, 1000 * pq.Hz)
-            self.assertEqual(len(result.times), 1)
+            self.assertEqual(result.times.shape[0], 1)
 
     def test_inputs_stepicsd(self):
         method = 'StepiCSD'
@@ -107,7 +107,7 @@ class CSD1D_TestCase(unittest.TestCase):
                                  **self.params[method])
         self.assertEqual(result.t_start, 0.0 * pq.s)
         self.assertEqual(result.sampling_rate, 1000 * pq.Hz)
-        self.assertEqual(len(result.times), 1)
+        self.assertEqual(result.times.shape[0], 1)
 
     def test_inuts_kcsd(self):
         method = 'KCSD1D'

--- a/elephant/test/test_kcsd.py
+++ b/elephant/test/test_kcsd.py
@@ -30,7 +30,7 @@ class KCSD1D_TestCase(unittest.TestCase):
         temp_signals = []
         for ii in range(len(self.pots)):
             temp_signals.append(self.pots[ii])
-        self.an_sigs = neo.AnalogSignal(temp_signals * pq.mV,
+        self.an_sigs = neo.AnalogSignal(np.array(temp_signals).T * pq.mV,
                                        sampling_rate=1000 * pq.Hz)
         chidx = neo.ChannelIndex(range(len(self.pots)))
         chidx.analogsignals.append(self.an_sigs)
@@ -80,7 +80,7 @@ class KCSD2D_TestCase(unittest.TestCase):
         temp_signals = []
         for ii in range(len(self.pots)):
             temp_signals.append(self.pots[ii])
-        self.an_sigs = neo.AnalogSignal(temp_signals * pq.mV,
+        self.an_sigs = neo.AnalogSignal(np.array(temp_signals).T * pq.mV,
                                        sampling_rate=1000 * pq.Hz)
         chidx = neo.ChannelIndex(range(len(self.pots)))
         chidx.analogsignals.append(self.an_sigs)
@@ -144,7 +144,7 @@ class KCSD3D_TestCase(unittest.TestCase):
         temp_signals = []
         for ii in range(len(self.pots)):
             temp_signals.append(self.pots[ii])
-        self.an_sigs = neo.AnalogSignal(temp_signals * pq.mV,
+        self.an_sigs = neo.AnalogSignal(np.array(temp_signals).T * pq.mV,
                                        sampling_rate=1000 * pq.Hz)
         chidx = neo.ChannelIndex(range(len(self.pots)))
         chidx.analogsignals.append(self.an_sigs)


### PR DESCRIPTION
Fixes some issues related to `neo.AnalogSignal` assumes signal shape `(# timesteps, # nchannels)`