### PR TITLE
Excluded some old code/non-relevant code from coverage.

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -313,7 +313,8 @@ def cv2(v):
 
 # sigma2kw and kw2sigma only needed for oldfct_instantaneous_rate!
 # to finally be taken out of Elephant
-def sigma2kw(form):
+
+def sigma2kw(form): # pragma: no cover
     warnings.simplefilter('always', DeprecationWarning)
     warnings.warn("deprecated", DeprecationWarning, stacklevel=2)
     if form.upper() == 'BOX':
@@ -332,14 +333,14 @@ def sigma2kw(form):
     return coeff
 
 
-def kw2sigma(form):
+def kw2sigma(form): # pragma: no cover
     warnings.simplefilter('always', DeprecationWarning)
     warnings.warn("deprecated", DeprecationWarning, stacklevel=2)
     return 1/sigma2kw(form)
 
 
 # to finally be taken out of Elephant
-def make_kernel(form, sigma, sampling_period, direction=1):
+def make_kernel(form, sigma, sampling_period, direction=1): # pragma: no cover
     """
     Creates kernel functions for convolution.
 
@@ -506,7 +507,7 @@ def make_kernel(form, sigma, sampling_period, direction=1):
 # to finally be taken out of Elephant
 def oldfct_instantaneous_rate(spiketrain, sampling_period, form,
                        sigma='auto', t_start=None, t_stop=None,
-                       acausal=True, trim=False):
+                       acausal=True, trim=False): # pragma: no cover
     """
     Estimate instantaneous firing rate by kernel convolution.
 

--- a/elephant/test/make_spike_extraction_test_data.py
+++ b/elephant/test/make_spike_extraction_test_data.py
@@ -1,4 +1,4 @@
-def main():
+def main(): # pragma: no cover
   from brian2 import start_scope,mvolt,ms,NeuronGroup,StateMonitor,run
   import matplotlib.pyplot as plt
   import neo


### PR DESCRIPTION
Some functions in `statistics,py` are deprecated and should not contribute to coverage (will be removed soon).

The file `make_spiketrain_extraction_test_data` is only contained for reference to indicate how the fixed test data for the spike_train_extraction_module was generated originally, and should also not be covered.