### PR TITLE
enable instantaneous_rate() for lists of spike trains

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -734,21 +734,7 @@ def instantaneous_rate(spiketrain, sampling_period, kernel='auto',
     """
     # Merge spike trains if list of spike trains given:
     if isinstance(spiketrain, list):
-        # Check consistency of spike trains
-        for st in spiketrain:
-            if not isinstance(st, SpikeTrain):
-                raise TypeError(
-                    "spiketrain must be instance of :class:`SpikeTrain` of Neo!\n"
-                    "    Found: %s, value %s" % (type(st), str(st)))
-            if t_start is None and not st.t_start == spiketrain[0].t_start:
-                raise ValueError(
-                        "the spike trains must have the same t_start!")
-            if t_stop is None and not st.t_stop == spiketrain[0].t_stop:
-                raise ValueError(
-                        "the spike trains must have the same t_stop!")
-            if not st.units == spiketrain[0].units:
-                raise ValueError(
-                        "the spike trains must have the same units!")
+        _check_consistency_of_spiketrainlist(spiketrain, t_start=t_start, t_stop=t_stop)
         if t_start is None:
             t_start = spiketrain[0].t_start
         if t_stop is None:
@@ -1245,3 +1231,21 @@ def sskernel(spiketimes, tin=None, w=None, bootstrap=False):
             'C': C,
             'confb95': confb95,
             'yb': yb}
+
+
+def _check_consistency_of_spiketrainlist(spiketrainlist, t_start=None, t_stop=None):
+    for spiketrain in spiketrainlist:
+        if not isinstance(spiketrain, SpikeTrain):
+            raise TypeError(
+                "spike train must be instance of :class:`SpikeTrain` of Neo!\n"
+                "    Found: %s, value %s" % (type(spiketrain), str(spiketrain)))
+        if t_start is None and not spiketrain.t_start == spiketrainlist[0].t_start:
+            raise ValueError(
+                "the spike trains must have the same t_start!")
+        if t_stop is None and not spiketrain.t_stop == spiketrainlist[0].t_stop:
+            raise ValueError(
+                "the spike trains must have the same t_stop!")
+        if not spiketrain.units == spiketrainlist[0].units:
+            raise ValueError(
+                "the spike trains must have the same units!")
+    return None

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -658,7 +658,7 @@ def instantaneous_rate(spiketrain, sampling_period, kernel='auto',
 
     Parameters
     -----------
-    spiketrain : 'neo.SpikeTrain'
+    spiketrain : neo.SpikeTrain or list of neo.SpikeTrain objects
         Neo object that contains spike times, the unit of the time stamps
         and t_start and t_stop of the spike train.
     sampling_period : Time Quantity
@@ -732,6 +732,15 @@ def instantaneous_rate(spiketrain, sampling_period, kernel='auto',
     ..[1] H. Shimazaki, S. Shinomoto, J Comput Neurosci (2010) 29:171–182.
 
     """
+    # Call function recursively if spiketrain is a list of spike trains
+    if isinstance(spiketrain, list):
+        rates = []
+        for st in spiketrain:
+            rate = instantaneous_rate(st, sampling_period=sampling_period, kernel=kernel,
+                                      cutoff=cutoff, t_start=t_start, t_stop=t_start, trim=trim)
+            rates += [rate]
+        return rates
+
     # Checks of input variables:
     if not isinstance(spiketrain, SpikeTrain):
         raise TypeError(
@@ -752,7 +761,7 @@ def instantaneous_rate(spiketrain, sampling_period, kernel='auto',
         kernel_width = sskernel(spiketrain.magnitude, tin=None,
                                 bootstrap=True)['optw']
         unit = spiketrain.units
-        sigma = 1/(2.0 * 2.7) * kernel_width * unit
+        sigma = 1 / (2.0 * 2.7) * kernel_width * unit
         # factor 2.0 connects kernel width with its half width,
         # factor 2.7 connects half width of Gaussian distribution with
         #             99% probability mass with its standard deviation.
@@ -767,13 +776,13 @@ def instantaneous_rate(spiketrain, sampling_period, kernel='auto',
         raise TypeError("cutoff must be float or integer!")
 
     if not (t_start is None or (isinstance(t_start, pq.Quantity) and
-            t_start.dimensionality.simplified ==
-            pq.Quantity(1, "s").dimensionality)):
+                                t_start.dimensionality.simplified ==
+                                pq.Quantity(1, "s").dimensionality)):
         raise TypeError("t_start must be a time quantity!")
 
     if not (t_stop is None or (isinstance(t_stop, pq.Quantity) and
-            t_stop.dimensionality.simplified ==
-            pq.Quantity(1, "s").dimensionality)):
+                               t_stop.dimensionality.simplified ==
+                               pq.Quantity(1, "s").dimensionality)):
         raise TypeError("t_stop must be a time quantity!")
 
     if not (isinstance(trim, bool)):

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -497,6 +497,26 @@ class RateEstimationTestCase(unittest.TestCase):
                                      x=rate_estimate.times.rescale('s').magnitude)[-1]
                 self.assertAlmostEqual(num_spikes, auc, delta=0.05*num_spikes)
 
+    def test_instantaneous_rate_spiketrainlist(self):
+        st_num_spikes = np.random.poisson(self.st_rate*(self.st_dur-2*self.st_margin))
+        spike_train2 = np.random.rand(st_num_spikes) * (self.st_dur - 2 * self.st_margin) + self.st_margin
+        spike_train2.sort()
+        spike_train2 = neo.SpikeTrain(spike_train2 * pq.s,
+                                          t_start=self.st_tr[0] * pq.s,
+                                          t_stop=self.st_tr[1] * pq.s)
+        st_rate_1 = es.instantaneous_rate(self.spike_train,
+                                          sampling_period=0.01*pq.s,
+                                          kernel=self.kernel)
+        st_rate_2 = es.instantaneous_rate(spike_train2,
+                                          sampling_period=0.01*pq.s,
+                                          kernel=self.kernel)
+        combined_rate = es.instantaneous_rate([self.spike_train, spike_train2],
+                                              sampling_period=0.01*pq.s,
+                                              kernel=self.kernel)
+        summed_rate = st_rate_1 + st_rate_2  # equivalent for identical kernels
+        for a, b in zip(combined_rate.magnitude, summed_rate.magnitude):
+            self.assertAlmostEqual(a, b, delta=0.0001)
+
 
 class TimeHistogramTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #133 by checking if the input `spiketrain` is of type `list` and calling the function `instantaneous_rate()` for each element of the list. In this case the function returns a list of analog signals.