### PR TITLE
Cross-correlation function for analog signals

### DIFF
--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -221,7 +221,7 @@ def cross_correlation_function(signal, ch_pairs, dt=1., env=False, nlags=None):
     # multiply in Fourier space, and transform back. Correct for bias due 
     # to zero-padding
     xcorr = np.zeros((Nt, Nch))
-    for i in xrange(Nch):
+    for i in range(Nch):
         xcorr[:,i] = scipy.signal.fftconvolve(x[:,i], y[::-1,i], mode='same')
     bias = npm.repmat((Nt-abs(tau/dt)), Nch, 1).T
     xcorr = xcorr / bias

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -142,59 +142,68 @@ def cross_correlation_function(signal, ch_pairs, env=False, nlags=None):
     """
     Computes unbiased estimator of the cross-correlation function.
 
-    Calculates the unbiased estimator of the cross-correlation function
-    R(tau) = 1/(N-|k|) R'(tau), where R'(tau) = E[x(t)*y(t+tau)] in a
-    pairwise manner, i.e. signal[ch_pairs[0,0]] vs signal2[ch_pairs[0,1]],
-    signal[ch_pairs[1,0]] vs signal2[ch_pairs[1,1]], and so on (see also
-    Hall & River (2009) Spectral Analysis of Signals, Spectral Element Method
-    in Structural Dynamics, Eq. 2.2.3). The cross-correlation function is
-    obtained by scipy's fftconvolve. Time series in signal are zscored
-    beforehand. Alternatively returns the Hilbert envelope of R(tau), which is
-    useful to determine the correlation length of oscillatory signals.
+    Calculates the unbiased estimator of the cross-correlation function [1]_
+    
+    .. math::
+             R(\\tau) = \\frac{1}{N-|k|} R'(\\tau) \\ ,
+    
+    where :math:`R'(\\tau) = \\left<x(t)y(t+\\tau)\\right>` in a pairwise 
+    manner, i.e. `signal[ch_pairs[0,0]]` vs `signal2[ch_pairs[0,1]]`,
+    `signal[ch_pairs[1,0]]` vs `signal2[ch_pairs[1,1]]`, and so on. The
+    cross-correlation function is obtained by `scipy.signal.fftconvolve`.
+    Time series in signal are zscored beforehand. Alternatively returns the
+    Hilbert envelope of :math:`R(\\tau)`, which is useful to determine the 
+    correlation length of oscillatory signals.
 
     Parameters
     -----------
-    signal : neo.AnalogSignal (nt x nch)
+    signal : neo.AnalogSignal (`nt` x `nch`)
         Signal with nt number of samples that contains nch LFP channels
-    ch_pairs : list (or array with shape (n,2))
+    ch_pairs : list (or array with shape `(n,2)`)
         list with n channel pairs for which to compute cross-correlation,
         each element of list must contain 2 channel indices
-    env: bool
+    env : bool
         Return Hilbert envelope of cross-correlation function
         Default: False
-    nlags: int
+    nlags : int
         Defines number of lags for cross-correlation function. Float will be
-        rounded to nearest integer. Number of samples of output is 2*nlags+1.
+        rounded to nearest integer. Number of samples of output is `2*nlags+1`.
         If None, number of samples of output is equal to number of samples of
-        input signal, namely nt
+        input signal, namely `nt`
         Default: None
 
     Returns
     -------
-    cross_corr : neo.AnalogSgnal (2*nlag+1 x n)
+    cross_corr : neo.AnalogSgnal (`2*nlag+1` x `n`)
         Pairwise cross-correlation functions for channel pairs given by
-        `ch_pairs`. If env=True, the output is the Hilbert envelope of the
+        `ch_pairs`. If `env=True`, the output is the Hilbert envelope of the
         pairwise cross-correlation function. This is helpful to compute the
         correlation length for oscillating cross-correlation functions
 
-    Example:
-        dt = 0.02
-        N = 2018
-        f = 0.5
-        t = np.arange(N)*dt
-        x = np.zeros((N,2))
-        x[:,0] = 0.2 * np.sin(2.*np.pi*f*t)
-        x[:,1] = 5.3 * np.cos(2.*np.pi*f*t)
-        # Generate neo.AnalogSignals from x
-        signal = neo.AnalogSignal(x, units='mV', t_start=0.*pq.ms,
-            sampling_rate=1/dt*pq.Hz, dtype=float)
-        rho = elephant.signal_processing.cross_correlation_function(
-            signal, [0,1], nlags=150)
-        env = elephant.signal_processing.cross_correlation_function(
-            signal, [0,1], nlags=150, env=True)
-        plt.plot(rho.times, rho)
-        plt.plot(env.times, env) # should be equal to one
-        plt.show()
+    Examples
+    --------
+        >>> dt = 0.02
+        >>> N = 2018
+        >>> f = 0.5
+        >>> t = np.arange(N)*dt
+        >>> x = np.zeros((N,2))
+        >>> x[:,0] = 0.2 * np.sin(2.*np.pi*f*t)
+        >>> x[:,1] = 5.3 * np.cos(2.*np.pi*f*t)
+        >>> # Generate neo.AnalogSignals from x
+        >>> signal = neo.AnalogSignal(x, units='mV', t_start=0.*pq.ms,
+        >>>     sampling_rate=1/dt*pq.Hz, dtype=float)
+        >>> rho = elephant.signal_processing.cross_correlation_function(
+        >>>     signal, [0,1], nlags=150)
+        >>> env = elephant.signal_processing.cross_correlation_function(
+        >>>     signal, [0,1], nlags=150, env=True)
+        >>> plt.plot(rho.times, rho)
+        >>> plt.plot(env.times, env) # should be equal to one
+        >>> plt.show()
+
+    References
+    ----------
+    .. [1] Hall & River (2009) "Spectral Analysis of Signals, Spectral Element
+       Method in Structural Dynamics", Eq. 2.2.3
     """
 
     # Make ch_pairs a 2D array

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -192,7 +192,7 @@ def cross_correlation_function(signal, ch_pairs, env=False, nlags=None):
                 signal, [0,1], nlags=150)
         env = elephant.signal_processing.cross_correlation_function(
                 signal, [0,1], nlags=150, env=True)
-        plt.plot(rho.tmes, rho)
+        plt.plot(rho.times, rho)
         plt.plot(env.times, env) # should be equal to one
         plt.show()
     """

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -12,7 +12,6 @@ import numpy as np
 import scipy.signal
 import quantities as pq
 import neo
-import numpy.matlib as npm
 
 
 def zscore(signal, inplace=True):

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -180,6 +180,17 @@ def cross_correlation_function(signal, ch_pairs, env=False, nlags=None):
         pairwise cross-correlation function. This is helpful to compute the
         correlation length for oscillating cross-correlation functions
 
+    Raises
+    ------
+    ValueError
+        If the input signal is not a neo.AnalogSignal.
+    ValueError
+        If `ch_pairs` is not a list of channel pair indices with shape `(n,2)`.
+    KeyError
+        If keyword `env` is not a boolean.
+    KeyError
+        If `nlags` is not an integer or float larger than 0.
+
     Examples
     --------
         >>> dt = 0.02

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -229,7 +229,7 @@ def cross_correlation_function(signal, ch_pairs, dt=1., env=False, nlags=None):
     # Calculate envelope of cross-correlation function with Hilber transform.
     # This is useful for transient oscillatory signals.
     if env:
-        for i in xrange(Nch):
+        for i in range(Nch):
             xcorr[:,i] = np.abs(scipy.signal.hilbert(xcorr[:,i]))
     
     # Cut off lags outside desired range

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -192,7 +192,9 @@ def cross_correlation_function(signal, ch_pairs, dt=1., env=False, nlags=None):
         plt.show()
     """
     # Make ch_pairs an 2D array
-    pairs = np.expand_dims(np.array(ch_pairs), axis=0)
+    pairs = np.array(ch_pairs)
+    if pairs.ndim == 1:
+        pairs = pairs[:, np.newaxis]
     
     # Check input
     a, b = np.shape(pairs)

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -28,8 +28,9 @@ class XCorrelationTestCase(unittest.TestCase):
         E.g., f=0.1 and N=2018 only has an accuracy on the order decimal=1
         '''
         # Sine with phase shift phi vs cosine for different frequencies
-        dt = 0.02
-        freq = np.linspace(0.5, 15, 8)
+        dt = 0.02 * pq.s
+        nlags = 30
+        freq = np.linspace(0.5, 15, 8) * pq.Hz
         N = 2018
         t = np.arange(N)*dt
         phi = np.pi/6.
@@ -41,18 +42,18 @@ class XCorrelationTestCase(unittest.TestCase):
             x[:,3] = 1875.35 * np.cos(2.*np.pi*f*t)
             # Generate neo.AnalogSignals from x and y
             signal = neo.AnalogSignal(x, units='mV', t_start=0.*pq.ms, 
-                                      sampling_rate=1/dt*pq.Hz, dtype=float)
-            rho, tau = elephant.signal_processing.cross_correlation_function(
-                    signal, [[0, 2], [1, 3]], dt=dt, nlags=N/4.6)
-            env, _ = elephant.signal_processing.cross_correlation_function(
-                    signal, [[0, 2], [1, 3]], dt=dt, nlags=N/4.6, env=True)
+                                      sampling_rate=1/dt, dtype=float)
+            rho = elephant.signal_processing.cross_correlation_function(
+                    signal, [[0, 2], [1, 3]], nlags=nlags)
+            env = elephant.signal_processing.cross_correlation_function(
+                    signal, [[0, 2], [1, 3]], nlags=nlags, env=True)
             # Test if vector of lags tau has correct length
-            assert len(tau)==2*int(np.round(N/4.6))+1
+            assert len(rho.times)==2*int(nlags)+1
             # Cross-correlation of sine and cosine should be sine
             assert_array_almost_equal(
-                    rho[:,0], np.sin(2.*np.pi*f*tau+phi), decimal=2)
+                    rho.magnitude[:,0], np.sin(2.*np.pi*f*rho.times+phi), decimal=2)
             assert_array_almost_equal(
-                    rho[:,1], np.sin(2.*np.pi*f*tau+2*phi), decimal=2)
+                    rho.magnitude[:,1], np.sin(2.*np.pi*f*rho.times+2*phi), decimal=2)
             # Envelope should be one for sinusoidal function
             assert_array_almost_equal(env, np.ones_like(env), decimal=2)
 

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -45,9 +45,9 @@ class XCorrelationTestCase(unittest.TestCase):
             signal = neo.AnalogSignal(x, units='mV', t_start=0.*pq.ms, 
                                       sampling_rate=1/dt*pq.Hz, dtype=float)
             rho, tau = elephant.signal_processing.cross_correlation_function(
-                    signal, [0, 1], [2, 3], dt=dt, nlags=N/4.6)
+                    signal, [[0, 2], [1, 3]], dt=dt, nlags=N/4.6)
             env, _ = elephant.signal_processing.cross_correlation_function(
-                    signal, [0, 1], [2, 3], dt=dt, nlags=N/4.6, env=True)
+                    signal, [[0, 2], [1, 3]], dt=dt, nlags=N/4.6, env=True)
             # Test if vector of lags tau has correct length (nlags working correctly)
             assert len(tau)==2*int(np.round(N/4.6))+1
             # Cross-correlation of sine and cosine should be sine

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -15,9 +15,7 @@ import scipy.signal as spsig
 import scipy.stats
 from numpy.testing.utils import assert_array_almost_equal
 import quantities as pq
-
 import elephant.signal_processing
-
 from numpy.ma.testutils import assert_array_equal, assert_allclose
 
 
@@ -26,8 +24,8 @@ class XCorrelationTestCase(unittest.TestCase):
     def test_cross_correlation(self):
         '''
         Test cross-correlation function for two sinusoids
-        Note, that accuracy depends on N and min(f). E.g., f=0.1 and N=2018 only
-        has an accuracy on the order decimal=1
+        Note, that accuracy depends on N and min(f).
+        E.g., f=0.1 and N=2018 only has an accuracy on the order decimal=1
         '''
         # Sine with phase shift phi vs cosine for different frequencies
         dt = 0.02
@@ -48,12 +46,14 @@ class XCorrelationTestCase(unittest.TestCase):
                     signal, [[0, 2], [1, 3]], dt=dt, nlags=N/4.6)
             env, _ = elephant.signal_processing.cross_correlation_function(
                     signal, [[0, 2], [1, 3]], dt=dt, nlags=N/4.6, env=True)
-            # Test if vector of lags tau has correct length (nlags working correctly)
+            # Test if vector of lags tau has correct length
             assert len(tau)==2*int(np.round(N/4.6))+1
             # Cross-correlation of sine and cosine should be sine
-            assert_array_almost_equal(rho[:,0], np.sin(2.*np.pi*f*tau+phi), decimal=2)
-            assert_array_almost_equal(rho[:,1], np.sin(2.*np.pi*f*tau+2*phi), decimal=2)
-            # Envelope should be one for sinusoidal function (env working correctly)
+            assert_array_almost_equal(
+                    rho[:,0], np.sin(2.*np.pi*f*tau+phi), decimal=2)
+            assert_array_almost_equal(
+                    rho[:,1], np.sin(2.*np.pi*f*tau+2*phi), decimal=2)
+            # Envelope should be one for sinusoidal function
             assert_array_almost_equal(env, np.ones_like(env), decimal=2)
 
 

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -40,11 +40,11 @@ class XCorrelationTestCase(unittest.TestCase):
             signal[:, 0] = np.sin(2.*np.pi*freq*self.time)
             signal[:, 1] = np.cos(2.*np.pi*freq*self.time)
             # Convert signal to neo.AnalogSignal
-            signal = neo.AnalogSignal(signal, units='mV', t_start=0.*pq.ms,
+            signal_neo = neo.AnalogSignal(signal, units='mV', t_start=0.*pq.ms,
                                       sampling_rate=self.sampling_rate,
                                       dtype=float)
             rho = elephant.signal_processing.cross_correlation_function(
-                signal, [0, 1])
+                signal_neo, [0, 1])
             # Cross-correlation of sine and cosine should be sine
             assert_array_almost_equal(
                 rho.magnitude[:, 0], np.sin(2.*np.pi*freq*rho.times), decimal=2)

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -20,6 +20,15 @@ from numpy.ma.testutils import assert_array_equal, assert_allclose
 
 
 class XCorrelationTestCase(unittest.TestCase):
+    '''
+    Class t several tests of cross_correlation_function
+    '''
+    # Set parameters
+    sampling_period = 0.02*pq.s
+    sampling_rate = 1./sampling_period
+    n_samples = 2018
+    time = np.arange(n_samples)*sampling_period
+    freq = 1.*pq.Hz
 
     def test_cross_correlation_freqs(self):
         '''
@@ -27,82 +36,72 @@ class XCorrelationTestCase(unittest.TestCase):
         Note, that accuracy depends on N and min(f).
         E.g., f=0.1 and N=2018 only has an accuracy on the order decimal=1
         '''
-        dt = 0.02 * pq.s
-        freq = np.linspace(0.5, 15, 8) * pq.Hz
-        N = 2018
-        t = np.arange(N)*dt
-        x = np.zeros((N,2))
-        for f in freq:
-            x[:,0] = np.sin(2.*np.pi*f*t)
-            x[:,1] = np.cos(2.*np.pi*f*t)
-            # Generate neo.AnalogSignals from x and y
-            signal = neo.AnalogSignal(x, units='mV', t_start=0.*pq.ms, 
-                                      sampling_rate=1./dt, dtype=float)
+        freq_arr = np.linspace(0.5, 15, 8) * pq.Hz
+        signal = np.zeros((self.n_samples, 2))
+        for freq in freq_arr:
+            signal[:, 0] = np.sin(2.*np.pi*freq*self.time)
+            signal[:, 1] = np.cos(2.*np.pi*freq*self.time)
+            # Convert signal to neo.AnalogSignal
+            signal = neo.AnalogSignal(signal, units='mV', t_start=0.*pq.ms,
+                                      sampling_rate=self.sampling_rate,
+                                      dtype=float)
             rho = elephant.signal_processing.cross_correlation_function(
-                    signal, [0, 1])
+                signal, [0, 1])
             # Cross-correlation of sine and cosine should be sine
             assert_array_almost_equal(
-                    rho.magnitude[:,0], np.sin(2.*np.pi*f*rho.times), decimal=2)
+                rho.magnitude[:, 0], np.sin(2.*np.pi*freq*rho.times), decimal=2)
 
     def test_cross_correlation_nlags(self):
         '''
         Sine vs cosine for specific nlags
         '''
-        dt = 0.02 * pq.s
         nlags = 30
-        f = 1. * pq.Hz
-        N = 2018
-        t = np.arange(N)*dt
-        x = np.zeros((N,2))
-        x[:,0] = 0.2 * np.sin(2.*np.pi*f*t)
-        x[:,1] = 5.3 * np.cos(2.*np.pi*f*t)
-        # Generate neo.AnalogSignals from x and y
-        signal = neo.AnalogSignal(x, units='mV', t_start=0.*pq.ms, 
-                                  sampling_rate=1/dt, dtype=float)
+        signal = np.zeros((self.n_samples, 2))
+        signal[:, 0] = 0.2 * np.sin(2.*np.pi*self.freq*self.time)
+        signal[:, 1] = 5.3 * np.cos(2.*np.pi*self.freq*self.time)
+        # Convert signal to neo.AnalogSignal
+        signal = neo.AnalogSignal(signal, units='mV', t_start=0.*pq.ms,
+                                  sampling_rate=self.sampling_rate,
+                                  dtype=float)
         rho = elephant.signal_processing.cross_correlation_function(
-                signal, [0, 1], nlags=nlags)
+            signal, [0, 1], nlags=nlags)
         # Test if vector of lags tau has correct length
-        assert len(rho.times)==2*int(nlags)+1
+        assert len(rho.times) == 2*int(nlags)+1
 
     def test_cross_correlation_phi(self):
         '''
         Sine with phase shift phi vs cosine
         '''
-        dt = 0.02 * pq.s
-        f = 1. * pq.Hz
-        N = 2018
-        t = np.arange(N)*dt
         phi = np.pi/6.
-        x = np.zeros((N,2))
-        x[:,0] = 0.2 * np.sin(2.*np.pi*f*t+phi)
-        x[:,1] = 5.3 * np.cos(2.*np.pi*f*t)
-        # Generate neo.AnalogSignals from x and y
-        signal = neo.AnalogSignal(x, units='mV', t_start=0.*pq.ms, 
-                                  sampling_rate=1/dt, dtype=float)
+        signal = np.zeros((self.n_samples, 2))
+        signal[:, 0] = 0.2 * np.sin(2.*np.pi*self.freq*self.time+phi)
+        signal[:, 1] = 5.3 * np.cos(2.*np.pi*self.freq*self.time)
+        # Convert signal to neo.AnalogSignal
+        signal = neo.AnalogSignal(signal, units='mV', t_start=0.*pq.ms,
+                                  sampling_rate=self.sampling_rate,
+                                  dtype=float)
         rho = elephant.signal_processing.cross_correlation_function(
-                signal, [0, 1])
+            signal, [0, 1])
         # Cross-correlation of sine and cosine should be sine + phi
         assert_array_almost_equal(
-                rho.magnitude[:,0], np.sin(2.*np.pi*f*rho.times+phi), decimal=2)
+            rho.magnitude[:, 0], np.sin(2.*np.pi*self.freq*rho.times+phi),
+            decimal=2)
 
     def test_cross_correlation_env(self):
         '''
         Envelope of sine vs cosine
         '''
         # Sine with phase shift phi vs cosine for different frequencies
-        dt = 0.02 * pq.s
-        nlags = 800 # nlags need to be a little smaller than N/2 b/c border effects 
-        f = 1. * pq.Hz
-        N = 2018
-        t = np.arange(N)*dt
-        x = np.zeros((N,2))
-        x[:,0] = 0.2 * np.sin(2.*np.pi*f*t)
-        x[:,1] = 5.3 * np.cos(2.*np.pi*f*t)
-        # Generate neo.AnalogSignals from x and y
-        signal = neo.AnalogSignal(x, units='mV', t_start=0.*pq.ms, 
-                                  sampling_rate=1/dt, dtype=float)
+        nlags = 800 # nlags need to be smaller than N/2 b/c border effects
+        signal = np.zeros((self.n_samples, 2))
+        signal[:, 0] = 0.2 * np.sin(2.*np.pi*self.freq*self.time)
+        signal[:, 1] = 5.3 * np.cos(2.*np.pi*self.freq*self.time)
+        # Convert signal to neo.AnalogSignal
+        signal = neo.AnalogSignal(signal, units='mV', t_start=0.*pq.ms,
+                                  sampling_rate=self.sampling_rate,
+                                  dtype=float)
         env = elephant.signal_processing.cross_correlation_function(
-                signal, [0, 1], nlags=nlags, env=True)
+            signal, [0, 1], nlags=nlags, env=True)
         # Envelope should be one for sinusoidal function
         assert_array_almost_equal(env, np.ones_like(env), decimal=2)
 

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -20,9 +20,7 @@ from numpy.ma.testutils import assert_array_equal, assert_allclose
 
 
 class XCorrelationTestCase(unittest.TestCase):
-    '''
-    Class t several tests of cross_correlation_function
-    '''
+
     # Set parameters
     sampling_period = 0.02*pq.s
     sampling_rate = 1./sampling_period


### PR DESCRIPTION
Added a function "cross_correlation_function" in signal_processing.py that calculates the pairwise cross-correlation of selected channels within a neo.AnalogSignal. Optionally calculates the envelope of the cross-correlation function, which is helpful to determine the correlation length of an oscillatory signal.

The two signals, e.g. LFP, are zero padded to minimize boundary effects, transformed into Fourier domain, multiplied and transformed back into time domain. The signals are afterwards corrected (unbiased estimator) for zero-padding.

This function should not be confused with cross_corr_coeff option in cross_correlation_histogram function within spiketrain_correlation.py. The latter only works for CCH obtained from spiketrains and assumes Poissonian statistics (Equation (5.10) in "Analysis of parallel spike trains", 2010, Gruen & Rotter, Vol 7).

The input is 
- signal: neo.AnalogSignal
- channel1/2: int, list, tuple, array; this determines the indices of the channels; cross-correlation will be calculated for pairs channel1[0] vs. channel2[0], channel1[1] vs channel2[1], and so forth
- dt: sample resolution
- env: bool; envelope yes or no
- nlags: int; how many lags the output rho should have

The output is:
- rho: array, the cross-correation function (ranging between -1 and 1) OR env, the envelope of rho
- tau: array, vector of lags