### PR TITLE
Removed option with window list of floating to avoid rounding errors

### DIFF
--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -372,11 +372,11 @@ def cross_correlation_histogram(
     -----
     cch
     """
-        
+
     def _cross_corr_coef(cch_result, binned_st1, binned_st2):
-        # Normalizes the CCH to obtain the cross-correlation 
+        # Normalizes the CCH to obtain the cross-correlation
         # coefficient function ranging from -1 to 1
-        N  = max(binned_st1.num_bins, binned_st2.num_bins)
+        N = max(binned_st1.num_bins, binned_st2.num_bins)
         Nx = len(binned_st1.spike_indices[0])
         Ny = len(binned_st2.spike_indices[0])
         spmat = [binned_st1.to_sparse_array(), binned_st2.to_sparse_array()]
@@ -385,10 +385,10 @@ def cross_correlation_histogram(
             bin_counts_unique.append(s.data)
         ii = np.dot(bin_counts_unique[0], bin_counts_unique[0])
         jj = np.dot(bin_counts_unique[1], bin_counts_unique[1])
-        rho_xy = (cch_result - Nx*Ny/N) / np.sqrt( (ii-Nx**2./N)*(jj-Ny**2./N) )
+        rho_xy = (cch_result - Nx * Ny / N) / \
+            np.sqrt((ii - Nx**2. / N) * (jj - Ny**2. / N))
         return rho_xy
-        
-        
+
     def _border_correction(counts, max_num_bins, l, r):
         # Correct the values taking into account lacking contributes
         # at the edges
@@ -480,8 +480,8 @@ def cross_correlation_histogram(
         if cch_mode == 'pad':
             # Zero padding to stay between l and r
             st1_arr = np.pad(st1_arr,
-                (int(np.abs(np.min([l, 0]))), np.max([r, 0])),
-                           mode = 'constant')
+                             (int(np.abs(np.min([l, 0]))), np.max([r, 0])),
+                             mode='constant')
             cch_mode = 'valid'
         # Cross correlate the spike trains
         counts = np.correlate(st2_arr, st1_arr, mode=cch_mode)
@@ -564,6 +564,7 @@ def cross_correlation_histogram(
         cch_result = _cross_corr_coef(cch_result, binned_st1, binned_st2)
 
     return cch_result, bin_ids
+
 
 # Alias for common abbreviation
 cch = cross_correlation_histogram
@@ -681,7 +682,7 @@ def spike_time_tiling_coefficient(spiketrain_1, spiketrain_2, dt=0.005 * pq.s):
         PB = run_P(spiketrain_2, spiketrain_1, N2, N1, dt)
         PB = PB / N2
         index = 0.5 * (PA - TB) / (1 - PA * TB) + 0.5 * (PB - TA) / (
-                1 - PB * TA)
+            1 - PB * TA)
     return index
 
 

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -417,7 +417,8 @@ def cross_correlation_histogram(
         # Smooth the cross-correlation histogram with the kern
         return np.convolve(counts, kern, mode='same')
 
-    def _cch_memory(binned_st1, binned_st2, left_edge, right_edge, border_corr, binary, kern):
+    def _cch_memory(binned_st1, binned_st2, left_edge, right_edge,
+                    border_corr, binary, kern):
 
         # Retrieve unclipped matrix
         st1_spmat = binned_st1.to_sparse_array()
@@ -451,8 +452,8 @@ def cross_correlation_histogram(
             assert ((timediff >= left_edge) & (
                 timediff <= right_edge)).all(), 'Not all the '
             'entries of cch lie in the window'
-            counts[timediff + np.abs(left_edge)] += (st1_bin_counts_unique[idx] *
-                                                     st2_bin_counts_unique[il:ir])
+            counts[timediff + np.abs(left_edge)] += (
+                    st1_bin_counts_unique[idx] * st2_bin_counts_unique[il:ir])
             st2_bin_idx_unique = st2_bin_idx_unique[il:]
             st2_bin_counts_unique = st2_bin_counts_unique[il:]
         # Border correction
@@ -475,7 +476,7 @@ def cross_correlation_histogram(
     def _cch_speed(binned_st1, binned_st2, left_edge, right_edge, cch_mode,
                    border_corr, binary, kern):
 
-        # Retrieve the array of the binne spik train
+        # Retrieve the array of the binne spike train
         st1_arr = binned_st1.to_array()[0, :]
         st2_arr = binned_st2.to_array()[0, :]
 
@@ -561,12 +562,12 @@ def cross_correlation_histogram(
 
     if method == "memory":
         cch_result, bin_ids = _cch_memory(
-            binned_st1, binned_st2, left_edge, right_edge, border_correction, binary,
-            kernel)
+            binned_st1, binned_st2, left_edge, right_edge, border_correction,
+            binary, kernel)
     elif method == "speed":
         cch_result, bin_ids = _cch_speed(
-            binned_st1, binned_st2, left_edge, right_edge, cch_mode, border_correction, binary,
-            kernel)
+            binned_st1, binned_st2, left_edge, right_edge, cch_mode,
+            border_correction, binary, kernel)
 
     if cross_corr_coef:
         cch_result = _cross_corr_coef(cch_result, binned_st1, binned_st2)

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -468,22 +468,6 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
             self.binned_st1, self.binned_st2, window='full', binary=False)
         assert_array_equal(cch_win, cch_unclipped[19:80])
 
-        cch_win, bin_ids = sc.cch(
-            self.binned_st1, self.binned_st2, window=[-25*pq.ms, 25*pq.ms])
-        cch_win_mem, bin_ids_mem = sc.cch(
-            self.binned_st1, self.binned_st2, window=[-25*pq.ms, 25*pq.ms],
-            method='memory')
-
-        assert_array_equal(bin_ids, np.arange(-25, 26, 1))
-        assert_array_equal(
-            (bin_ids - 0.5) * self.binned_st1.binsize, cch_win.times)
-
-        assert_array_equal(bin_ids_mem, np.arange(-25, 26, 1))
-        assert_array_equal(
-            (bin_ids_mem - 0.5) * self.binned_st1.binsize, cch_win.times)
-
-        assert_array_equal(cch_win, cch_win_mem)
-
         _, bin_ids = sc.cch(
             self.binned_st1, self.binned_st2, window=[20, 30])
         _, bin_ids_mem = sc.cch(
@@ -502,48 +486,21 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
         assert_array_equal(bin_ids, np.arange(-30, -19, 1))
         assert_array_equal(bin_ids_mem, np.arange(-30, -19, 1))
 
-        # Cehck for wrong assignments to the window parameter
+        # Check for wrong assignments to the window parameter
+        # Test for window longer than the total length of the spike trains
         self.assertRaises(
             ValueError, sc.cross_correlation_histogram, self.binned_st1,
             self.binned_st2, window=[-60, 50])
         self.assertRaises(
             ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-60, 50], method='memory')
-
-        self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
             self.binned_st2, window=[-50, 60])
+        # Test for no integer or wrong string in input
         self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-50, 60], method='memory')
-
+            KeyError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window=[-25.5, 25.5])
         self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-25.5*pq.ms, 25*pq.ms])
-        self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-25.5*pq.ms, 25*pq.ms], method='memory')
-
-        self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-25*pq.ms, 25.5*pq.ms])
-        self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-25*pq.ms, 25.5*pq.ms], method='memory')
-
-        self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-60*pq.ms, 50*pq.ms])
-        self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-60*pq.ms, 50*pq.ms], method='memory')
-
-        self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-50*pq.ms, 60*pq.ms])
-        self.assertRaises(
-            ValueError, sc.cross_correlation_histogram, self.binned_st1,
-            self.binned_st2, window=[-50*pq.ms, 60*pq.ms], method='memory')
+            KeyError, sc.cross_correlation_histogram, self.binned_st1,
+            self.binned_st2, window='test')
 
     def test_border_correction(self):
         '''Test if the border correction for bins at the edges is correctly

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -280,8 +280,8 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
             binary=True, method='memory')
         cch_unclipped_mem, bin_ids_unclipped_mem = \
             sc.cross_correlation_histogram(
-            self.binned_st1, self.binned_st2, window='full',
-            binary=False, method='memory')
+                self.binned_st1, self.binned_st2, window='full',
+                binary=False, method='memory')
         # Check consistency two methods
         assert_array_equal(
             np.squeeze(cch_clipped.magnitude), np.squeeze(
@@ -376,8 +376,8 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
             binary=True, method='memory')
         cch_unclipped_mem, bin_ids_unclipped_mem = \
             sc.cross_correlation_histogram(
-            self.binned_st1, self.binned_st2, window='valid',
-            binary=False, method='memory')
+                self.binned_st1, self.binned_st2, window='valid',
+                binary=False, method='memory')
 
         # Check consistency two methods
         assert_array_equal(

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -247,7 +247,7 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
         self.binned_sts = conv.BinnedSpikeTrain(
             [self.st_1, self.st_2], t_start=0 * pq.ms, t_stop=50. * pq.ms,
             binsize=1 * pq.ms)
-            
+
         # Binned sts to check errors raising
         self.st_check_binsize = conv.BinnedSpikeTrain(
             [self.st_1], t_start=0 * pq.ms, t_stop=50. * pq.ms,
@@ -306,45 +306,44 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
         assert_array_equal(
             target_numpy, np.squeeze(cch_unclipped.magnitude))
 
-
         # Check cross correlation function for several displacements tau
-        # Note: Use Elephant corrcoeff to verify result 
-        tau = [-25.0, 0.0, 13.0] # in ms
+        # Note: Use Elephant corrcoeff to verify result
+        tau = [-25.0, 0.0, 13.0]  # in ms
         for t in tau:
             # adjust t_start, t_stop to shift by tau
-            t0 = np.min([self.st_1.t_start+t*pq.ms, self.st_2.t_start])
-            t1 = np.max([self.st_1.t_stop+t*pq.ms, self.st_2.t_stop])            
-            st1 = neo.SpikeTrain(self.st_1.magnitude+t, units='ms',
-                                t_start = t0*pq.ms, t_stop = t1*pq.ms)           
+            t0 = np.min([self.st_1.t_start + t * pq.ms, self.st_2.t_start])
+            t1 = np.max([self.st_1.t_stop + t * pq.ms, self.st_2.t_stop])
+            st1 = neo.SpikeTrain(self.st_1.magnitude + t, units='ms',
+                                 t_start=t0 * pq.ms, t_stop=t1 * pq.ms)
             st2 = neo.SpikeTrain(self.st_2.magnitude, units='ms',
-                                t_start = t0*pq.ms, t_stop = t1*pq.ms)              
+                                 t_start=t0 * pq.ms, t_stop=t1 * pq.ms)
             binned_sts = conv.BinnedSpikeTrain([st1, st2],
-                                               binsize=1*pq.ms,
-                                               t_start = t0*pq.ms,
-                                               t_stop = t1*pq.ms)
+                                               binsize=1 * pq.ms,
+                                               t_start=t0 * pq.ms,
+                                               t_stop=t1 * pq.ms)
             # caluclate corrcoef
-            corrcoef = sc.corrcoef(binned_sts)[1,0]    
-            
-            # expand t_stop to have two spike trains with same length as st1, st2
+            corrcoef = sc.corrcoef(binned_sts)[1, 0]
+
+            # expand t_stop to have two spike trains with same length as st1,
+            # st2
             st1 = neo.SpikeTrain(self.st_1.magnitude, units='ms',
-                                t_start = self.st_1.t_start, 
-                                t_stop = self.st_1.t_stop+np.abs(t)*pq.ms)           
+                                 t_start=self.st_1.t_start,
+                                 t_stop=self.st_1.t_stop + np.abs(t) * pq.ms)
             st2 = neo.SpikeTrain(self.st_2.magnitude, units='ms',
-                                t_start = self.st_2.t_start, 
-                                t_stop = self.st_2.t_stop+np.abs(t)*pq.ms)
+                                 t_start=self.st_2.t_start,
+                                 t_stop=self.st_2.t_stop + np.abs(t) * pq.ms)
             binned_st1 = conv.BinnedSpikeTrain(
-                st1, t_start=0*pq.ms, t_stop=(50+np.abs(t))*pq.ms,
+                st1, t_start=0 * pq.ms, t_stop=(50 + np.abs(t)) * pq.ms,
                 binsize=1 * pq.ms)
             binned_st2 = conv.BinnedSpikeTrain(
-                st2, t_start=0 * pq.ms, t_stop=(50+np.abs(t))*pq.ms,
+                st2, t_start=0 * pq.ms, t_stop=(50 + np.abs(t)) * pq.ms,
                 binsize=1 * pq.ms)
             # calculate CCHcoef and take value at t=tau
-            CCHcoef, _  = sc.cch(binned_st1, binned_st2, 
-                               cross_corr_coef=True)
+            CCHcoef, _ = sc.cch(binned_st1, binned_st2,
+                                cross_corr_coef=True)
             l = - binned_st1.num_bins + 1
-            tau_bin = int(t/float(binned_st1.binsize.magnitude))
-            assert_array_equal(corrcoef, CCHcoef[tau_bin-l].magnitude)
-            
+            tau_bin = int(t / float(binned_st1.binsize.magnitude))
+            assert_array_equal(corrcoef, CCHcoef[tau_bin - l].magnitude)
 
         # Check correlation using binary spike trains
         mat1 = np.array(self.binned_st1.to_bool_array()[0], dtype=int)
@@ -590,7 +589,7 @@ class SpikeTimeTilingCoefficientTestCase(unittest.TestCase):
         st1 = neo.SpikeTrain([1], units='ms', t_stop=1.)
         st2 = neo.SpikeTrain([5], units='ms', t_stop=10.)
         self.assertEqual(sc.sttc(st1, st2), 1.0)
-        self.assertTrue(bool(sc.sttc(st1, st2, 0.1*pq.ms) < 0))
+        self.assertTrue(bool(sc.sttc(st1, st2, 0.1 * pq.ms) < 0))
 
         # test for high value of dt
         self.assertEqual(sc.sttc(self.st_1, self.st_2, dt=5 * pq.s), 1.0)

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -278,7 +278,8 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
         cch_clipped_mem, bin_ids_clipped_mem = sc.cross_correlation_histogram(
             self.binned_st1, self.binned_st2, window='full',
             binary=True, method='memory')
-        cch_unclipped_mem, bin_ids_unclipped_mem = sc.cross_correlation_histogram(
+        cch_unclipped_mem, bin_ids_unclipped_mem = \
+            sc.cross_correlation_histogram(
             self.binned_st1, self.binned_st2, window='full',
             binary=False, method='memory')
         # Check consistency two methods
@@ -341,9 +342,10 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
             # calculate CCHcoef and take value at t=tau
             CCHcoef, _ = sc.cch(binned_st1, binned_st2,
                                 cross_corr_coef=True)
-            l = - binned_st1.num_bins + 1
+            left_edge = - binned_st1.num_bins + 1
             tau_bin = int(t / float(binned_st1.binsize.magnitude))
-            assert_array_equal(corrcoef, CCHcoef[tau_bin - l].magnitude)
+            assert_array_equal(
+                corrcoef, CCHcoef[tau_bin - left_edge].magnitude)
 
         # Check correlation using binary spike trains
         mat1 = np.array(self.binned_st1.to_bool_array()[0], dtype=int)
@@ -372,7 +374,8 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
         cch_clipped_mem, bin_ids_clipped_mem = sc.cross_correlation_histogram(
             self.binned_st1, self.binned_st2, window='valid',
             binary=True, method='memory')
-        cch_unclipped_mem, bin_ids_unclipped_mem = sc.cross_correlation_histogram(
+        cch_unclipped_mem, bin_ids_unclipped_mem = \
+            sc.cross_correlation_histogram(
             self.binned_st1, self.binned_st2, window='valid',
             binary=False, method='memory')
 


### PR DESCRIPTION
Now the the parameter window can only be a string or a list of integer (to close #146). Also the relative tests are adapted. 