### PR TITLE
updating scripts to be compatible with latest numpy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
   matrix:
     # This environment tests the newest supported anaconda env
     - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="true"
-      NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.16.1" PANDAS_VERSION="0.16.2"
+      NUMPY_VERSION="1.15.1" SCIPY_VERSION="1.1.0" PANDAS_VERSION="0.23.4"
       SIX_VERSION="1.10.0" COVERAGE="true"
     - DISTRIB="conda" PYTHON_VERSION="3.5" INSTALL_MKL="true"
-      NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.16.1" PANDAS_VERSION="0.16.2"
+      NUMPY_VERSION="1.15.1" SCIPY_VERSION="1.1.0" PANDAS_VERSION="0.23.4"
       SIX_VERSION="1.10.0" COVERAGE="true"
     # This environment tests minimal dependency versions
     - DISTRIB="conda_min" PYTHON_VERSION="2.7" INSTALL_MKL="false"
@@ -34,7 +34,7 @@ env:
       COVERAGE="true"
     # This environment tests for mpi
     - DISTRIB="mpi" PYTHON_VERSION="3.5" INSTALL_MKL="false"
-      NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.16.1" SIX_VERSION="1.10.0"
+      NUMPY_VERSION="1.15.1" SCIPY_VERSION="1.1.0" SIX_VERSION="1.10.0"
       MPI_VERSION="2.0.0" COVERAGE="true" MPI="true"
 
 install: source continuous_integration/install.sh

--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -41,7 +41,6 @@ References:
 [1] Torre, Canova, Denker, Gerstein, Helias, Gruen (submitted)
 """
 
-
 import numpy as np
 import scipy.spatial
 import scipy.stats
@@ -51,6 +50,7 @@ import itertools
 import elephant.conversion as conv
 import elephant.spike_train_surrogates as spike_train_surrogates
 from sklearn.cluster import dbscan as dbscan
+
 
 # =============================================================================
 # Some Utility Functions to be dealt with in some way or another
@@ -78,7 +78,7 @@ def _signals_same_tstart(signals):
     signals : list
         a list of signals (e.g. AnalogSignals or SpikeTrains) having
         attribute `t_start`
-
+en
     Returns
     -------
     t_start : Quantity
@@ -248,7 +248,7 @@ def _transactions(spiketrains, binsize, t_start=None, t_stop=None, ids=None):
 
     # Compute and return the transaction list
     return [[train_id for train_id, b in zip(ids, filled_bins)
-            if bin_id in b] for bin_id in _xrange(Nbins)]
+             if bin_id in b] for bin_id in _xrange(Nbins)]
 
 
 def _analog_signal_step_interp(signal, times):
@@ -379,6 +379,7 @@ def _time_slice(signal, t_start, t_stop):
 
     return sliced_signal
 
+
 # =============================================================================
 # HERE ASSET STARTS
 # =============================================================================
@@ -420,12 +421,12 @@ def intersection_matrix(
         type of normalization to be applied to each entry [i,j] of the
         intersection matrix. Given the sets s_i, s_j of neuron ids in the
         bins i, j respectively, the normalisation coefficient can be:
-        
+
             * norm = 0 or None: no normalisation (row counts)
             * norm = 1: len(intersection(s_i, s_j))
             * norm = 2: sqrt(len(s_1) * len(s_2))
             * norm = 3: len(union(s_i, s_j))
-            
+
         Default: None
 
     Returns
@@ -455,7 +456,7 @@ def intersection_matrix(
         if not (st.t_stop > t_stop_max or
                 _quantities_almost_equal(st.t_stop, t_stop_max)):
             msg = 'SpikeTrain %d is shorter than the required time ' % i + \
-                'span: t_stop (%s) < %s' % (st.t_stop, t_stop_max)
+                  'span: t_stop (%s) < %s' % (st.t_stop, t_stop_max)
             raise ValueError(msg)
 
     # For both x and y axis, cut all SpikeTrains between t_start and t_stop
@@ -628,7 +629,7 @@ def mask_matrices(matrices, thresholds):
 
     # Replace nans, coming from False * np.inf, with 0s
     # (trick to find nans in masked: a number is nan if it's not >= - np.inf)
-    mask[True - (mask >= -np.inf)] = False
+    mask[np.logical_xor(True, (mask >= -np.inf))] = False
 
     return np.array(mask, dtype=bool)
 
@@ -712,7 +713,7 @@ def cluster_matrix_entries(mat, eps=10, min=2, stretch=5):
     a neighbourhood if at least one of them has a distance not larger than
     eps from the others, and if they are at least min. Overlapping
     neighborhoods form a cluster.
-    
+
         * Clusters are assigned integers from 1 to the total number k of
           clusters
         * Unclustered ("isolated") positive elements of mat are
@@ -873,10 +874,10 @@ def probability_matrix_montecarlo(
     pmat = np.array(np.zeros(imat.shape), dtype=int)
     if verbose:
         print('pmat_bootstrap(): begin of bootstrap...')
-    for i in _xrange(n_surr):                      # For each surrogate id i
+    for i in _xrange(n_surr):  # For each surrogate id i
         if verbose:
             print('    surr %d' % i)
-        surrs_i = [st[i] for st in surrs]         # Take each i-th surrogate
+        surrs_i = [st[i] for st in surrs]  # Take each i-th surrogate
         imat_surr, xx, yy = intersection_matrix(  # compute the related imat
             surrs_i, binsize=binsize, dt=dt,
             t_start_x=t_start_x, t_start_y=t_start_y)
@@ -897,7 +898,7 @@ def probability_matrix_analytical(
 
     The approximation is analytical and works under the assumptions that the
     input spike trains are independent and Poisson. It works as follows:
-    
+
         * Bin each spike train at the specified binsize: this yields a binary
           array of 1s (spike in bin) and 0s (no spike in bin) (clipping used)
         * If required, estimate the rate profile of each spike train by 
@@ -1006,7 +1007,7 @@ def probability_matrix_analytical(
         # Reshape all rates to one-dimensional array object (e.g. AnalogSignal)
         for i, rate in enumerate(fir_rates):
             if len(rate.shape) == 2:
-                fir_rates[i] = rate.reshape((-1, ))
+                fir_rates[i] = rate.reshape((-1,))
             elif len(rate.shape) > 2:
                 raise ValueError(
                     'elements in fir_rates have too many dimensions')
@@ -1079,17 +1080,17 @@ def _jsf_uniform_orderstat_3d(u, alpha, n):
     '''
     Considered n independent random variables X1, X2, ..., Xn all having
     uniform distribution in the interval (alpha, 1):
-    
+
     .. centered::  Xi ~ Uniform(alpha, 1),
-    
+
     with alpha \in [0, 1), and given a 3D matrix U = (u_ijk) where each U_ij
     is an array of length d: U_ij = [u0, u1, ..., u_{d-1}] of
     quantiles, with u1 <= u2 <= ... <= un, computes the joint survival function
     (jsf) of the d highest order statistics (U_{n-d+1}, U_{n-d+2}, ..., U_n),
     where U_i := "i-th highest X's" at each u_ij, i.e.:
-    
+
     .. centered::  jsf(u_ij) = Prob(U_{n-k} >= u_ijk, k=0,1,..., d-1).
-    
+
 
     Arguments
     ---------
@@ -1415,7 +1416,7 @@ def sse_intersection(sse1, sse2, intersection='linkwise'):
     consisting of a pool of positions (iK, jK) of matrix entries and
     associated synchronous events SK, finds the intersection among them.
     The intersection can be performed 'pixelwise' or 'linkwise'.
-        
+
         * if 'pixelwise', it yields a new SSE which retains only events in sse1
           whose pixel position matches a pixel position in sse2. This operation
           is not symmetric: intersection(sse1, sse2) != intersection(sse2, sse1).
@@ -1425,9 +1426,9 @@ def sse_intersection(sse1, sse2, intersection='linkwise'):
           intersection(sse1, sse2) = intersection(sse2, sse1).
 
     Both sse1 and sse2 must be provided as dictionaries of the type
-    
+
     .. centered:: {(i1, j1): S1, (i2, j2): S2, ..., (iK, jK): SK},
-    
+
     where each i, j is an integer and each S is a set of neuron ids.
     (See also: extract_sse() that extracts SSEs from given spiketrains).
 
@@ -1535,9 +1536,9 @@ def _remove_empty_events(sse):
     copy of sse where all empty events have been removed.
 
     sse must be provided as a dictionary of type
-    
+
     .. centered:: {(i1, j1): S1, (i2, j2): S2, ..., (iK, jK): SK},
-    
+
     where each i, j is an integer and each S is a set of neuron ids.
     (See also: extract_sse() that extracts SSEs from given spiketrains).
 
@@ -1571,9 +1572,9 @@ def sse_isequal(sse1, sse2):
     do not belong to sse1 (i.e. sse1 and sse2 are not identical)
 
     Both sse1 and sse2 must be provided as dictionaries of the type
-    
+
     .. centered:: {(i1, j1): S1, (i2, j2): S2, ..., (iK, jK): SK},
-    
+
     where each i, j is an integer and each S is a set of neuron ids.
     (See also: extract_sse() that extracts SSEs from given spiketrains).
 
@@ -1606,9 +1607,9 @@ def sse_isdisjoint(sse1, sse2):
     associated to common pixels are disjoint.
 
     Both sse1 and sse2 must be provided as dictionaries of the type
-    
+
     .. centered:: {(i1, j1): S1, (i2, j2): S2, ..., (iK, jK): SK},
-    
+
     where each i, j is an integer and each S is a set of neuron ids.
     (See also: extract_sse() that extracts SSEs from given spiketrains).
 

--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -78,7 +78,7 @@ def _signals_same_tstart(signals):
     signals : list
         a list of signals (e.g. AnalogSignals or SpikeTrains) having
         attribute `t_start`
-en
+        
     Returns
     -------
     t_start : Quantity

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -6,7 +6,7 @@ Unit tests for the statistics module.
 :license: Modified BSD, see LICENSE.txt for details.
 """
 from __future__ import division
-    
+
 import unittest
 
 import neo
@@ -384,8 +384,10 @@ class RateEstimationTestCase(unittest.TestCase):
         self.st_margin = 5.0  # seconds
         self.st_rate = 10.0  # Hertz
 
-        st_num_spikes = np.random.poisson(self.st_rate*(self.st_dur-2*self.st_margin))
-        spike_train = np.random.rand(st_num_spikes) * (self.st_dur-2*self.st_margin) + self.st_margin
+        st_num_spikes = np.random.poisson(
+            self.st_rate*(self.st_dur-2*self.st_margin))
+        spike_train = np.random.rand(
+            st_num_spikes) * (self.st_dur-2*self.st_margin) + self.st_margin
         spike_train.sort()
 
         # convert spike train into neo objects
@@ -394,7 +396,7 @@ class RateEstimationTestCase(unittest.TestCase):
                                           t_stop=self.st_tr[1]*pq.s)
 
         # generation of a multiply used specific kernel
-        self.kernel = kernels.TriangularKernel(sigma = 0.03*pq.s)
+        self.kernel = kernels.TriangularKernel(sigma=0.03*pq.s)
 
     def test_instantaneous_rate_and_warnings(self):
         st = self.spike_train
@@ -402,24 +404,27 @@ class RateEstimationTestCase(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             inst_rate = es.instantaneous_rate(
                 st, sampling_period, self.kernel, cutoff=0)
-            self.assertEqual("The width of the kernel was adjusted to a minimally "
-                             "allowed width.", str(w[-2].message))
-            self.assertEqual("Instantaneous firing rate approximation contains "
-                             "negative values, possibly caused due to machine "
-                             "precision errors.", str(w[-1].message))
+            message1 = "The width of the kernel was adjusted to a minimally " \
+                       "allowed width."
+            message2 = "Instantaneous firing rate approximation contains " \
+                       "negative values, possibly caused due to machine " \
+                       "precision errors."
+            warning_message = [str(m.message) for m in w]
+            self.assertTrue(message1 in warning_message)
+            self.assertTrue(message2 in warning_message)
         self.assertIsInstance(inst_rate, neo.core.AnalogSignal)
-        self.assertEquals(
+        self.assertEqual(
             inst_rate.sampling_period.simplified, sampling_period.simplified)
-        self.assertEquals(inst_rate.simplified.units, pq.Hz)
-        self.assertEquals(inst_rate.t_stop.simplified, st.t_stop.simplified)
-        self.assertEquals(inst_rate.t_start.simplified, st.t_start.simplified)
+        self.assertEqual(inst_rate.simplified.units, pq.Hz)
+        self.assertEqual(inst_rate.t_stop.simplified, st.t_stop.simplified)
+        self.assertEqual(inst_rate.t_start.simplified, st.t_start.simplified)
 
     def test_error_instantaneous_rate(self):
         self.assertRaises(
-            TypeError, es.instantaneous_rate, spiketrain=[1,2,3]*pq.s,
+            TypeError, es.instantaneous_rate, spiketrain=[1, 2, 3]*pq.s,
             sampling_period=0.01*pq.ms, kernel=self.kernel)
         self.assertRaises(
-            TypeError, es.instantaneous_rate, spiketrain=[1,2,3],
+            TypeError, es.instantaneous_rate, spiketrain=[1, 2, 3],
             sampling_period=0.01*pq.ms, kernel=self.kernel)
         st = self.spike_train
         self.assertRaises(
@@ -432,9 +437,9 @@ class RateEstimationTestCase(unittest.TestCase):
             TypeError, es.instantaneous_rate, spiketrain=st,
             sampling_period=0.01*pq.ms, kernel='NONE')
         self.assertRaises(TypeError, es.instantaneous_rate, self.spike_train,
-            sampling_period=0.01*pq.s, kernel='wrong_string',
-            t_start=self.st_tr[0]*pq.s, t_stop=self.st_tr[1]*pq.s,
-            trim=False)
+                          sampling_period=0.01*pq.s, kernel='wrong_string',
+                          t_start=self.st_tr[0]*pq.s, t_stop=self.st_tr[1]*pq.s,
+                          trim=False)
         self.assertRaises(
             TypeError, es.instantaneous_rate, spiketrain=st,
             sampling_period=0.01*pq.ms, kernel=self.kernel, cutoff=20*pq.ms)
@@ -464,30 +469,30 @@ class RateEstimationTestCase(unittest.TestCase):
         kernel_resolution = 0.01*pq.s
         for kernel in kernel_list:
             rate_estimate_a0 = es.instantaneous_rate(self.spike_train,
-                                            sampling_period=kernel_resolution,
-                                            kernel='auto',
-                                            t_start=self.st_tr[0]*pq.s,
-                                            t_stop=self.st_tr[1]*pq.s,
-                                            trim=False)
+                                                     sampling_period=kernel_resolution,
+                                                     kernel='auto',
+                                                     t_start=self.st_tr[0]*pq.s,
+                                                     t_stop=self.st_tr[1]*pq.s,
+                                                     trim=False)
 
             rate_estimate0 = es.instantaneous_rate(self.spike_train,
-                                            sampling_period=kernel_resolution,
-                                            kernel=kernel)
+                                                   sampling_period=kernel_resolution,
+                                                   kernel=kernel)
 
             rate_estimate1 = es.instantaneous_rate(self.spike_train,
-                                            sampling_period=kernel_resolution,
-                                            kernel=kernel,
-                                            t_start=self.st_tr[0]*pq.s,
-                                            t_stop=self.st_tr[1]*pq.s,
-                                            trim=False)
+                                                   sampling_period=kernel_resolution,
+                                                   kernel=kernel,
+                                                   t_start=self.st_tr[0]*pq.s,
+                                                   t_stop=self.st_tr[1]*pq.s,
+                                                   trim=False)
 
             rate_estimate2 = es.instantaneous_rate(self.spike_train,
-                                            sampling_period=kernel_resolution,
-                                            kernel=kernel,
-                                            t_start=self.st_tr[0]*pq.s,
-                                            t_stop=self.st_tr[1]*pq.s,
-                                            trim=True)
-            ### test consistency
+                                                   sampling_period=kernel_resolution,
+                                                   kernel=kernel,
+                                                   t_start=self.st_tr[0]*pq.s,
+                                                   t_stop=self.st_tr[1]*pq.s,
+                                                   trim=True)
+            # test consistency
             rate_estimate_list = [rate_estimate0, rate_estimate1,
                                   rate_estimate2, rate_estimate_a0]
 
@@ -498,12 +503,14 @@ class RateEstimationTestCase(unittest.TestCase):
                 self.assertAlmostEqual(num_spikes, auc, delta=0.05*num_spikes)
 
     def test_instantaneous_rate_spiketrainlist(self):
-        st_num_spikes = np.random.poisson(self.st_rate*(self.st_dur-2*self.st_margin))
-        spike_train2 = np.random.rand(st_num_spikes) * (self.st_dur - 2 * self.st_margin) + self.st_margin
+        st_num_spikes = np.random.poisson(
+            self.st_rate*(self.st_dur-2*self.st_margin))
+        spike_train2 = np.random.rand(
+            st_num_spikes) * (self.st_dur - 2 * self.st_margin) + self.st_margin
         spike_train2.sort()
         spike_train2 = neo.SpikeTrain(spike_train2 * pq.s,
-                                          t_start=self.st_tr[0] * pq.s,
-                                          t_stop=self.st_tr[1] * pq.s)
+                                      t_start=self.st_tr[0] * pq.s,
+                                      t_stop=self.st_tr[1] * pq.s)
         st_rate_1 = es.instantaneous_rate(self.spike_train,
                                           sampling_period=0.01*pq.s,
                                           kernel=self.kernel)
@@ -524,6 +531,7 @@ class RateEstimationTestCase(unittest.TestCase):
         # function should react with a ValueError.
         st = neo.SpikeTrain([2.12, 2.13, 2.15] * pq.s, t_stop=10 * pq.s)
         self.assertRaises(ValueError, es.instantaneous_rate, st, 1 * pq.ms)
+
 
 class TimeHistogramTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
PR to fix breaking travis script:
* updated to latest numpy, scipy and pandas versions in the corresponding env build
* updated several scripts which broke because of the new libraries (incorporating PR #168)
* updated accompanying tests 
* pep8 in those scripts 