### PR TITLE
Added CAD docs and removed some duplicated aliases

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -3,7 +3,7 @@ Function Reference by Module
 ****************************
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    reference/statistics
    reference/signal_processing
@@ -16,6 +16,7 @@ Function Reference by Module
    reference/unitary_event_analysis
    reference/cubic
    reference/asset
+   reference/cell_assembly_detection
    reference/spike_train_generation
    reference/spike_train_surrogates
    reference/conversion

--- a/doc/reference/spike_train_correlation.rst
+++ b/doc/reference/spike_train_correlation.rst
@@ -10,3 +10,4 @@ Spike train correlation
 
 .. automodule:: elephant.spike_train_correlation
    :members:
+   :exclude-members: cch, sttc


### PR DESCRIPTION
The CAD docs were still missing from the doc build. Also, aliases made functions appear twice, were removed using Sphinx functionality.