### PR TITLE
added missing doc pages

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -22,5 +22,6 @@ Function Reference by Module
    reference/conversion
    reference/neo_tools
    reference/pandas_bridge
+   reference/spade
 
 

--- a/doc/reference/cell_assembly_detection.rst
+++ b/doc/reference/cell_assembly_detection.rst
@@ -1,0 +1,6 @@
+=============================
+Cell assembly detection (CAD)
+=============================
+
+.. automodule:: elephant.cell_assembly_detection
+   :members:

--- a/doc/reference/spade.rst
+++ b/doc/reference/spade.rst
@@ -1,0 +1,6 @@
+==============================================
+Spike Pattern Detection and Evaluation (SPADE)
+==============================================
+
+.. automodule:: elephant.spade
+   :members:


### PR DESCRIPTION
With this PR the documentation which is missing two modules `CAD` and `SPADE` should be complete. 