### PR TITLE
Fixed #192: Handling of neo 0.7 array_annotations

### DIFF
--- a/elephant/neo_tools.py
+++ b/elephant/neo_tools.py
@@ -45,16 +45,18 @@ def extract_neo_attrs(obj, parents=True, child_first=True,
 
     """
     attrs = obj.annotations.copy()
-    try:
-        for a in obj.array_annotations:
-            if a not in [_[0] for _ in obj._necessary_attrs + obj._recommended_attrs]:
-                if "array_annotations" not in attrs:
-                    attrs["array_annotations"] = {}
-                attrs["array_annotations"][a] = obj.array_annotations[a].copy()
-    except AttributeError:
-        pass
+    if not skip_array:
+        try:
+            for a in obj.array_annotations:
+                # Exclude labels and durations (and maybe other attributes) that are handled as array_annotations
+                # These would be duplicate
+                if a not in [_[0] for _ in obj._necessary_attrs + obj._recommended_attrs]:
+                    if "array_annotations" not in attrs:
+                        attrs["array_annotations"] = {}
+                    attrs["array_annotations"][a] = obj.array_annotations[a].copy()
+        except AttributeError:
+            pass
     for attr in obj._necessary_attrs + obj._recommended_attrs:
-        print(attr)
         if skip_array and len(attr) >= 3 and attr[2]:
             continue
         attr = attr[0]

--- a/elephant/neo_tools.py
+++ b/elephant/neo_tools.py
@@ -45,7 +45,16 @@ def extract_neo_attrs(obj, parents=True, child_first=True,
 
     """
     attrs = obj.annotations.copy()
+    try:
+        for a in obj.array_annotations:
+            if a not in [_[0] for _ in obj._necessary_attrs + obj._recommended_attrs]:
+                if "array_annotations" not in attrs:
+                    attrs["array_annotations"] = {}
+                attrs["array_annotations"][a] = obj.array_annotations[a].copy()
+    except AttributeError:
+        pass
     for attr in obj._necessary_attrs + obj._recommended_attrs:
+        print(attr)
         if skip_array and len(attr) >= 3 and attr[2]:
             continue
         attr = attr[0]

--- a/elephant/test/test_neo_tools.py
+++ b/elephant/test/test_neo_tools.py
@@ -26,7 +26,8 @@ ARRAY_ATTRS = ['waveforms',
                'index',
                'channel_names',
                'channel_ids',
-               'coordinates'
+               'coordinates',
+               'array_annotations'
                ]
 
 


### PR DESCRIPTION
This fixes handling of neos array_annotations in neo_tools (see #192).
The code treats array_annotations like array attributes but keeps them nested in a dictionary. I'm not sure if this extra nesting is desired or not, because e.g. annotations are not nested in their own subdictionary but rather flattened. If flattening is better I will change this behavior.
The new code also removes any duplicates that emerge due to the fact that regular array attributes (like labels and durations) are handled as array_annotations internally.  In test_neo_tools array_annotations are now also listed in `array_attrs` to make sure they are removed in `strip_iter_values`.

Unfortunately this code will not make the tests pass because there are bugs in `get_fake_values` in neo which is used for those tests. Code that the test_neo_tools tests pass with can be found at NeuralEnsemble/python-neo#656. This is, however, still work in progress.