### PR TITLE
Fix setup.py not installing the fast FIM module for Windows machines

### DIFF
--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -509,8 +509,9 @@ def concepts_mining(data, binsize, winlen, min_spikes=2, min_occ=2,
     else:
         warnings.warn(
             'Optimized C implementation of FCA (fim.so/fim.pyd) not found ' +
-            'in elephant/spade_src folder,' +
-            'you are using the Python implementation of fast fca.')
+            'in elephant/spade_src folder, or not compatible with this ' +
+            'Python version. You are using the pure Python implementation ' +
+            'of fast fca.')
         # Return output
         mining_results = _fast_fca(
             context,

--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -78,9 +78,6 @@ try:
     HAVE_FIM = True
 except ImportError:  # pragma: no cover
     HAVE_FIM = False
-    warnings.warn(
-        'fim.so not found in elephant/spade_src folder,' +
-        'you are using the python implementation of fast fca')
 
 
 def spade(data, binsize, winlen, min_spikes=2, min_occ=2, max_spikes=None,
@@ -510,6 +507,10 @@ def concepts_mining(data, binsize, winlen, min_spikes=2, min_occ=2,
         return mining_results, rel_matrix
     # Otherwise use fast_fca python implementation
     else:
+        warnings.warn(
+            'Optimized C implementation of FCA (fim.so/fim.pyd) not found ' +
+            'in elephant/spade_src folder,' +
+            'you are using the Python implementation of fast fca.')
         # Return output
         mining_results = _fast_fca(
             context,

--- a/setup.py
+++ b/setup.py
@@ -20,20 +20,28 @@ for extra in ['extras', 'docs', 'tests']:
 is_64bit = sys.maxsize > 2 ** 32
 is_python3 = float(sys.version[0:3]) > 2.7
 
-if is_python3:
-    if is_64bit:
-        urlretrieve('http://www.borgelt.net/bin64/py3/fim.so',
-                    'elephant/spade_src/fim.so')
-    else:
-        urlretrieve('http://www.borgelt.net/bin32/py3/fim.so',
-                    'elephant/spade_src/fim.so')
+if uname()[0] == "Windows":
+    oext = ".pyd"
+elif uname()[0] == "Linux":
+    oext = ".so"
 else:
-    if is_64bit:
-        urlretrieve('http://www.borgelt.net/bin64/py2/fim.so',
-                    'elephant/spade_src/fim.so')
+    oext = None
+
+if oext:
+    if is_python3:
+        if is_64bit:
+            urlretrieve('http://www.borgelt.net/bin64/py3/fim' + oext,
+                        'elephant/spade_src/fim' + oext)
+        else:
+            urlretrieve('http://www.borgelt.net/bin32/py3/fim' + oext,
+                        'elephant/spade_src/fim' + oext)
     else:
-        urlretrieve('http://www.borgelt.net/bin32/py2/fim.so',
-                    'elephant/spade_src/fim.so')
+        if is_64bit:
+            urlretrieve('http://www.borgelt.net/bin64/py2/fim' + oext,
+                        'elephant/spade_src/fim' + oext)
+        else:
+            urlretrieve('http://www.borgelt.net/bin32/py2/fim' + oext,
+                        'elephant/spade_src/fim' + oext)
 
 setup(
     name="elephant",

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 from setuptools import setup
 import os
 import sys
+import platform
 try:
     from urllib.request import urlretrieve
 except ImportError:
@@ -19,10 +20,9 @@ for extra in ['extras', 'docs', 'tests']:
 # spade specific
 is_64bit = sys.maxsize > 2 ** 32
 is_python3 = float(sys.version[0:3]) > 2.7
-
-if uname()[0] == "Windows":
+if platform.uname()[0] == "Windows":
     oext = ".pyd"
-elif uname()[0] == "Linux":
+elif platform.uname()[0] == "Linux":
     oext = ".so"
 else:
     oext = None

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
         os.path.join('current_source_density_src', '*.py'),
         os.path.join('spade_src', '*.py'),
         os.path.join('spade_src', 'LICENSE'),
-        os.path.join('spade_src', '*.so')
+        os.path.join('spade_src', '*.so'),
+        os.path.join('spade_src', '*.pyd')
     ]},
 
     install_requires=install_requires,


### PR DESCRIPTION
This fixes an issue where the setup script did not identify if it is running on Windows, so that it should download the pyd module for frequent itemset mining instead of the .so module. Fixes #212 .