### PR TITLE
fixed readthedocs.yml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,15 @@
-name: elephant
+# readthedocs version
+version: 2
 
 build:
     image: latest
 
+sphinx:
+  builder: html
+  configuration: doc/conf.py
+
 python:
     version: 3.7
+    install:
+        - requirements: requirements.txt
+        - requirements: requirements-docs.txt


### PR DESCRIPTION
In one of the pull requests I made I forgot to merge readthedocs.yml, and currently, the docs badge shows the docs build is failed.
So here it is.
Built docs: https://elephant.readthedocs.io/en/docs_fix2/