### PR TITLE
fixed min requirements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+# .coveragerc to control coverage.py
+[report]
+omit = elephant/test/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,8 @@ matrix:
       python: 3.6
       env: DISTRIB="pip"
       before_install:
-        - sudo apt install libblas-dev liblapack-dev libatlas-base-dev gfortran
+        - sudo apt install -y libopenmpi-dev openmpi-bin
+        - sudo apt install -y libblas-dev liblapack-dev libatlas-base-dev gfortran
         - sed -i 's/>=/==/g' requirements*.txt
       before_script: pip install -r requirements-extras.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,13 @@ matrix:
       python: 3.7
       env: DISTRIB="conda"
 
-  exclude:
-    - name: "pip 3.6 requirements min version"
-      # excluded due to unmet dependencies in neo, quantities, and scipy
+    - name: "pip 3.6 requirements-extras min version"
       python: 3.6
       env: DISTRIB="pip"
       before_install:
         - sudo apt install libblas-dev liblapack-dev libatlas-base-dev gfortran
-        - sed -i 's/>=/==/g' requirements.txt
+        - sed -i 's/>=/==/g' requirements*.txt
+      before_script: pip install -r requirements-extras.txt
 
 
 install:

--- a/elephant/current_source_density_src/KCSD.py
+++ b/elephant/current_source_density_src/KCSD.py
@@ -48,7 +48,7 @@ class CSD(object):
         if ele_pos.shape[0] < 1+ele_pos.shape[1]: #Dim+1
             raise Exception("Number of electrodes must be at least :",
                             1+ele_pos.shape[1])
-        if utils.check_for_duplicated_electrodes(ele_pos) is False:
+        if utils.contains_duplicated_electrodes(ele_pos):
             raise Exception("Error! Duplicated electrode!")
 
     def sanity(self, true_csd, pos_csd):

--- a/elephant/current_source_density_src/utility_functions.py
+++ b/elephant/current_source_density_src/utility_functions.py
@@ -35,17 +35,19 @@ def patch_quantities():
         lastdefinition = definition
     return
 
-def check_for_duplicated_electrodes(elec_pos):
+
+def contains_duplicated_electrodes(elec_pos):
     """Checks for duplicate electrodes
     Parameters
     ----------
     elec_pos : np.array
+
     Returns
     -------
     has_duplicated_elec : Boolean
     """
-    unique_elec_pos = np.unique(elec_pos, axis=0)
-    has_duplicated_elec = unique_elec_pos.shape == elec_pos.shape
+    unique_elec_pos = set(map(tuple, elec_pos))
+    has_duplicated_elec = len(unique_elec_pos) < len(elec_pos)
     return has_duplicated_elec
 
 

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,3 +1,3 @@
-pandas>=0.14.1
-scikit-learn
+pandas>=0.18.0
+scikit-learn>=0.19.0
 mpi4py>=3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 neo>=0.7.1,<0.8.0
-numpy>=1.8.2
-quantities>=0.10.1
-scipy>=0.14.0
+numpy>=1.10.1
+quantities>=0.12.1
+scipy>=0.17.0
 six>=1.10.0


### PR DESCRIPTION
Currently, the min package requirements versions are broken. I found the corresponding issue https://github.com/NeuralEnsemble/elephant/issues/10.
This commit fixes it and includes "pip 3.6 requirements-extras min version" test in travis to make sure we will not break dependencies again.

* Min scikit-learn version that supports python 2.7 and 3.5 is 0.19.0. That triggers numpy>=1.9.3 but v1.9.3 is broken, and the next stable one is 1.10.1.
* Min quantities version that works well with the latest neo==0.7.1 is 0.12.1, not 0.10.1 (neo's guys should change min quantities version as well).
* `DataFrame.sort_index(level=...)` was introduced in pandas v0.18.0.

One problem that I see now is that "pip 3.6 requirements-extras min version" test case takes 20 minutes while the other ones finish in less than 10 min. Building numpy, scipy and pandas old versions takes a lot of time. This is the caveat that is thankfully avoided in later and up-to-date versions. Consider excluding this test once again if that will harden the continuous development and integration.

-----
I also added `.coveragerc` file to ignore tests from being counted as source code when the coverage command is run.