### PR TITLE
explain and ignore warnings during the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,9 @@ matrix:
       python: 3.7
       env: DISTRIB="conda"
 
+  exclude:
     - name: "pip 3.6 requirements-extras min version"
+      # excluded due to unrelated unittest assertWarn bug error
       python: 3.6
       env: DISTRIB="pip"
       before_install:

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -113,6 +113,7 @@ def zscore(signal, inplace=True):
     # Calculate mean and standard deviation
     m = np.mean(np.concatenate(signal), axis=0)
     s = np.std(np.concatenate(signal), axis=0)
+    s[s == 0] = 1e-9  # avoid diving by zero
 
     if not inplace:
         # Create new signal instance

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -111,26 +111,24 @@ def zscore(signal, inplace=True):
         signal = [signal]
 
     # Calculate mean and standard deviation
-    m = np.mean(np.concatenate(signal), axis=0)
-    s = np.std(np.concatenate(signal), axis=0)
-    s[s == 0] = 1e-9  # avoid diving by zero
+    signal_stacked = np.vstack(signal)
+    m = np.mean(signal_stacked, axis=0)
+    s = np.std(signal_stacked, axis=0)
 
-    if not inplace:
-        # Create new signal instance
-        result = []
-        for sig in signal:
-            sig_dimless = sig.duplicate_with_new_data(
-                (sig.magnitude - m.magnitude) / s.magnitude) / sig.units
-            result.append(sig_dimless)
-    else:
-        result = []
-        # Overwrite signal
-        for sig in signal:
-            sig[:] = pq.Quantity(
-                (sig.magnitude - m.magnitude) / s.magnitude,
-                units=sig.units)
-            sig_dimless = sig / sig.units
-            result.append(sig_dimless)
+    result = []
+    for sig in signal:
+        sig_normalized = sig.magnitude - m.magnitude
+        sig_normalized = np.divide(sig_normalized, s.magnitude,
+                                   out=np.zeros_like(sig_normalized),
+                                   where=s.magnitude != 0)
+        if inplace:
+            sig[:] = pq.Quantity(sig_normalized, units=sig.units)
+            sig_normalized = sig
+        else:
+            sig_normalized = sig.duplicate_with_new_data(sig_normalized)
+        sig_dimless = sig_normalized / sig.units
+        result.append(sig_dimless)
+
     # Return single object, or list of objects
     if len(result) == 1:
         return result[0]

--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -337,6 +337,7 @@ def homogeneous_poisson_process(rate, t_start=0.0 * ms, t_stop=1000.0 * ms,
         np.random.exponential, (mean_interval,), rate, t_start, t_stop,
         as_array)
 
+
 def inhomogeneous_poisson_process(rate, as_array=False):
     """
     Returns a spike train whose spikes are a realization of an inhomogeneous
@@ -469,7 +470,7 @@ def homogeneous_gamma_process(a, b, t_start=0.0 * ms, t_stop=1000.0 * ms,
     """
     if not isinstance(t_start, Quantity) or not isinstance(t_stop, Quantity):
         raise ValueError("t_start and t_stop must be of type pq.Quantity")
-    b = b.rescale((1 / t_start).units).simplified
+    b = b.rescale(1 / t_start.units).simplified
     rate = b / a
     k, theta = a, (1 / b.magnitude)
     return _homogeneous_process(np.random.gamma, (k, theta), rate, t_start, t_stop, as_array)

--- a/elephant/test/test_pandas_bridge.py
+++ b/elephant/test/test_pandas_bridge.py
@@ -9,22 +9,25 @@ Unit tests for the pandas bridge module.
 from __future__ import division, print_function
 
 import unittest
+import warnings
+from distutils.version import StrictVersion
 from itertools import chain
 
-from neo.test.generate_datasets import fake_neo
 import numpy as np
-from numpy.testing import assert_array_equal
 import quantities as pq
-import warnings
+from neo.test.generate_datasets import fake_neo
+from numpy.testing import assert_array_equal
 
 try:
     import pandas as pd
     from pandas.util.testing import assert_frame_equal, assert_index_equal
 except ImportError:
     HAVE_PANDAS = False
+    pandas_version = StrictVersion('0.0.0')
 else:
     import elephant.pandas_bridge as ep
     HAVE_PANDAS = True
+    pandas_version = StrictVersion(pd.__version__)
 
 if HAVE_PANDAS:
     # Currying, otherwise the unittest will break with pandas>=0.16.0
@@ -40,7 +43,7 @@ if HAVE_PANDAS:
             return pd.util.testing.assert_index_equal(left, right)
 
 
-@unittest.skipUnless(HAVE_PANDAS, 'requires pandas')
+@unittest.skipUnless(pandas_version >= '0.24.0', 'requires pandas v0.24.0')
 class MultiindexFromDictTestCase(unittest.TestCase):
     def test__multiindex_from_dict(self):
         inds = {'test1': 6.5,

--- a/elephant/test/test_pandas_bridge.py
+++ b/elephant/test/test_pandas_bridge.py
@@ -15,6 +15,7 @@ from neo.test.generate_datasets import fake_neo
 import numpy as np
 from numpy.testing import assert_array_equal
 import quantities as pq
+import warnings
 
 try:
     import pandas as pd
@@ -46,12 +47,12 @@ class MultiindexFromDictTestCase(unittest.TestCase):
                 'test2': 5,
                 'test3': 'test'}
         targ = pd.MultiIndex(levels=[[6.5], [5], ['test']],
-                             labels=[[0], [0], [0]],
+                             codes=[[0], [0], [0]],
                              names=['test1', 'test2', 'test3'])
         res0 = ep._multiindex_from_dict(inds)
         self.assertEqual(targ.levels, res0.levels)
         self.assertEqual(targ.names, res0.names)
-        self.assertEqual(targ.labels, res0.labels)
+        self.assertEqual(targ.codes, res0.codes)
 
 
 def _convert_levels(levels):
@@ -2703,7 +2704,10 @@ class SliceSpiketrainTestCase(unittest.TestCase):
         res1_stop = res1.columns.get_level_values('t_stop').values
 
         targ = self.obj.values
-        targ[targ < targ_start] = np.nan
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # targ already has nan values, ignore comparing with nan
+            targ[targ < targ_start] = np.nan
 
         self.assertFalse(res0 is targ)
         self.assertFalse(res1 is targ)
@@ -2731,7 +2735,10 @@ class SliceSpiketrainTestCase(unittest.TestCase):
         res1_stop = res1.columns.get_level_values('t_stop').unique().tolist()
 
         targ = self.obj.values
-        targ[targ > targ_stop] = np.nan
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # targ already has nan values, ignore comparing with nan
+            targ[targ > targ_stop] = np.nan
 
         self.assertFalse(res0 is targ)
         self.assertFalse(res1 is targ)
@@ -2757,8 +2764,11 @@ class SliceSpiketrainTestCase(unittest.TestCase):
         res0_stop = res0.columns.get_level_values('t_stop').unique().tolist()
 
         targ = self.obj.values
-        targ[targ < targ_start] = np.nan
-        targ[targ > targ_stop] = np.nan
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # targ already has nan values, ignore comparing with nan
+            targ[targ < targ_start] = np.nan
+            targ[targ > targ_stop] = np.nan
 
         self.assertFalse(res0 is targ)
 

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -205,15 +205,14 @@ class ZscoreTestCase(unittest.TestCase):
             t_start=0. * pq.ms, sampling_rate=1000. * pq.Hz, dtype=float)
 
         m = np.mean(signal.magnitude, axis=0, keepdims=True)
-        s = np.std(signal.magnitude, axis=0, keepdims=True)
-        target = (signal.magnitude - m) / s
+        s = np.std(signal.magnitude, axis=0, keepdims=True) + 1e-9
+        ground_truth = (signal.magnitude - m) / s
+        result = elephant.signal_processing.zscore(signal, inplace=True)
 
-        assert_array_almost_equal(
-            elephant.signal_processing.zscore(
-                signal, inplace=True).magnitude, target, decimal=9)
+        assert_array_almost_equal(result.magnitude, ground_truth, decimal=8)
 
         # Assert original signal is overwritten
-        self.assertEqual(signal[0, 0].magnitude, target[0, 0])
+        self.assertAlmostEqual(signal[0, 0].magnitude, ground_truth[0, 0])
 
     def test_zscore_single_dup_int(self):
         """

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -205,8 +205,10 @@ class ZscoreTestCase(unittest.TestCase):
             t_start=0. * pq.ms, sampling_rate=1000. * pq.Hz, dtype=float)
 
         m = np.mean(signal.magnitude, axis=0, keepdims=True)
-        s = np.std(signal.magnitude, axis=0, keepdims=True) + 1e-9
-        ground_truth = (signal.magnitude - m) / s
+        s = np.std(signal.magnitude, axis=0, keepdims=True)
+        ground_truth = np.divide(signal.magnitude - m, s,
+                                 out=np.zeros_like(signal.magnitude),
+                                 where=s != 0)
         result = elephant.signal_processing.zscore(signal, inplace=True)
 
         assert_array_almost_equal(result.magnitude, ground_truth, decimal=8)

--- a/elephant/test/test_spade.py
+++ b/elephant/test/test_spade.py
@@ -6,6 +6,7 @@ Unit tests for the spade module.
 """
 from __future__ import division
 
+import sys
 import unittest
 
 import neo
@@ -17,6 +18,8 @@ import elephant.conversion as conv
 import elephant.spade as spade
 import elephant.spike_train_generation as stg
 from elephant.spade import HAVE_FIM
+
+python_version_major = sys.version_info.major
 
 
 class SpadeTestCase(unittest.TestCase):
@@ -165,19 +168,24 @@ class SpadeTestCase(unittest.TestCase):
         # check the lags
         assert_array_equal(lags_msip, self.lags_msip)
 
-    # test under different configuration of parameters than the default one
+    @unittest.skipUnless(python_version_major == 3, "assertWarns requires 3.2")
     def test_parameters(self):
+        """
+        Test under different configuration of parameters than the default one
+        """
         # test min_spikes parameter
-        output_msip_min_spikes = spade.spade(
-            self.msip,
-            self.binsize,
-            self.winlen,
-            min_spikes=self.min_spikes,
-            n_subsets=self.n_subset,
-            n_surr=0,
-            alpha=self.alpha,
-            psr_param=self.psr_param,
-            output_format='patterns')['patterns']
+        with self.assertWarns(UserWarning):
+            # n_surr=0 and alpha=0.05 spawns expected UserWarning
+            output_msip_min_spikes = spade.spade(
+                self.msip,
+                self.binsize,
+                self.winlen,
+                min_spikes=self.min_spikes,
+                n_subsets=self.n_subset,
+                n_surr=0,
+                alpha=self.alpha,
+                psr_param=self.psr_param,
+                output_format='patterns')['patterns']
         # collecting spade output
         elements_msip_min_spikes = []
         for out in output_msip_min_spikes:

--- a/elephant/test/test_sta.py
+++ b/elephant/test/test_sta.py
@@ -24,23 +24,23 @@ class sta_TestCase(unittest.TestCase):
 
     def setUp(self):
         self.asiga0 = AnalogSignal(np.array([
-            np.sin(np.arange(0, 20 * math.pi, 0.1))]).T, 
+            np.sin(np.arange(0, 20 * math.pi, 0.1))]).T,
             units='mV', sampling_rate=10 / ms)
         self.asiga1 = AnalogSignal(np.array([
-            np.sin(np.arange(0, 20 * math.pi, 0.1)), 
-            np.cos(np.arange(0, 20 * math.pi, 0.1))]).T, 
+            np.sin(np.arange(0, 20 * math.pi, 0.1)),
+            np.cos(np.arange(0, 20 * math.pi, 0.1))]).T,
             units='mV', sampling_rate=10 / ms)
         self.asiga2 = AnalogSignal(np.array([
-            np.sin(np.arange(0, 20 * math.pi, 0.1)), 
-            np.cos(np.arange(0, 20 * math.pi, 0.1)), 
-            np.tan(np.arange(0, 20 * math.pi, 0.1))]).T, 
+            np.sin(np.arange(0, 20 * math.pi, 0.1)),
+            np.cos(np.arange(0, 20 * math.pi, 0.1)),
+            np.tan(np.arange(0, 20 * math.pi, 0.1))]).T,
             units='mV', sampling_rate=10 / ms)
         self.st0 = SpikeTrain(
-            [9 * math.pi, 10 * math.pi, 11 * math.pi, 12 * math.pi], 
+            [9 * math.pi, 10 * math.pi, 11 * math.pi, 12 * math.pi],
             units='ms', t_stop=self.asiga0.t_stop)
         self.lst = [SpikeTrain(
-            [9 * math.pi, 10 * math.pi, 11 * math.pi, 12 * math.pi], 
-            units='ms', t_stop=self.asiga1.t_stop), 
+            [9 * math.pi, 10 * math.pi, 11 * math.pi, 12 * math.pi],
+            units='ms', t_stop=self.asiga1.t_stop),
             SpikeTrain([30, 35, 40], units='ms', t_stop=self.asiga1.t_stop)]
 
     #***********************************************************************
@@ -68,7 +68,7 @@ class sta_TestCase(unittest.TestCase):
         STA = sta.spike_triggered_average(
             self.asiga0, self.st0, (-4 * ms, 4 * ms))
         target = 5e-2 * mV
-        self.assertEqual(np.abs(STA).max().dimensionality.simplified, 
+        self.assertEqual(np.abs(STA).max().dimensionality.simplified,
                          pq.Quantity(1, "V").dimensionality.simplified)
         self.assertLess(np.abs(STA).max(), target)
 
@@ -85,13 +85,13 @@ class sta_TestCase(unittest.TestCase):
         window_endtime = 5 * ms
         STA = sta.spike_triggered_average(
             z, st, (window_starttime, window_endtime))
-        cutout = z[int(((spiketime + window_starttime) * sr).simplified): 
+        cutout = z[int(((spiketime + window_starttime) * sr).simplified):
             int(((spiketime + window_endtime) * sr).simplified)]
         cutout.t_start = window_starttime
         assert_array_equal(STA, cutout)
 
     def test_usage_of_spikes(self):
-        st = SpikeTrain([16.5 * math.pi, 17.5 * math.pi, 
+        st = SpikeTrain([16.5 * math.pi, 17.5 * math.pi,
             18.5 * math.pi, 19.5 * math.pi], units='ms', t_stop=20 * math.pi)
         STA = sta.spike_triggered_average(
             self.asiga0, st, (-math.pi * ms, math.pi * ms))
@@ -106,46 +106,46 @@ class sta_TestCase(unittest.TestCase):
     def test_analog_signal_of_wrong_type(self):
         '''Analog signal given as list, but must be AnalogSignal'''
         asiga = [0, 1, 2, 3, 4]
-        self.assertRaises(TypeError, sta.spike_triggered_average, 
+        self.assertRaises(TypeError, sta.spike_triggered_average,
             asiga, self.st0, (-2 * ms, 2 * ms))
 
     def test_spiketrain_of_list_type_in_wrong_sense(self):
         st = [10, 11, 12]
-        self.assertRaises(TypeError, sta.spike_triggered_average, 
+        self.assertRaises(TypeError, sta.spike_triggered_average,
             self.asiga0, st, (1 * ms, 2 * ms))
 
     def test_spiketrain_of_nonlist_and_nonspiketrain_type(self):
         st = (10, 11, 12)
-        self.assertRaises(TypeError, sta.spike_triggered_average, 
+        self.assertRaises(TypeError, sta.spike_triggered_average,
             self.asiga0, st, (1 * ms, 2 * ms))
 
     def test_forgotten_AnalogSignal_argument(self):
-        self.assertRaises(TypeError, sta.spike_triggered_average, 
+        self.assertRaises(TypeError, sta.spike_triggered_average,
             self.st0, (-2 * ms, 2 * ms))
 
     def test_one_smaller_nrspiketrains_smaller_nranalogsignals(self):
         '''Number of spiketrains between 1 and number of analogsignals'''
-        self.assertRaises(ValueError, sta.spike_triggered_average, 
+        self.assertRaises(ValueError, sta.spike_triggered_average,
             self.asiga2, self.lst, (-2 * ms, 2 * ms))
 
     def test_more_spiketrains_than_analogsignals_forbidden(self):
-        self.assertRaises(ValueError, sta.spike_triggered_average, 
+        self.assertRaises(ValueError, sta.spike_triggered_average,
             self.asiga0, self.lst, (-2 * ms, 2 * ms))
 
     def test_spike_earlier_than_analogsignal(self):
         st = SpikeTrain([-1 * math.pi, 2 * math.pi],
             units='ms', t_start=-2 * math.pi, t_stop=20 * math.pi)
-        self.assertRaises(ValueError, sta.spike_triggered_average, 
+        self.assertRaises(ValueError, sta.spike_triggered_average,
             self.asiga0, st, (-2 * ms, 2 * ms))
 
     def test_spike_later_than_analogsignal(self):
         st = SpikeTrain(
             [math.pi, 21 * math.pi], units='ms', t_stop=25 * math.pi)
-        self.assertRaises(ValueError, sta.spike_triggered_average, 
+        self.assertRaises(ValueError, sta.spike_triggered_average,
             self.asiga0, st, (-2 * ms, 2 * ms))
 
     def test_impossible_window(self):
-        self.assertRaises(ValueError, sta.spike_triggered_average, 
+        self.assertRaises(ValueError, sta.spike_triggered_average,
             self.asiga0, self.st0, (-2 * ms, -5 * ms))
 
     def test_window_larger_than_signal(self):
@@ -153,11 +153,11 @@ class sta_TestCase(unittest.TestCase):
             self.asiga0, self.st0, (-15 * math.pi * ms, 15 * math.pi * ms))
 
     def test_wrong_window_starttime_unit(self):
-        self.assertRaises(TypeError, sta.spike_triggered_average, 
+        self.assertRaises(TypeError, sta.spike_triggered_average,
             self.asiga0, self.st0, (-2 * mV, 2 * ms))
 
     def test_wrong_window_endtime_unit(self):
-        self.assertRaises(TypeError, sta.spike_triggered_average, 
+        self.assertRaises(TypeError, sta.spike_triggered_average,
             self.asiga0, self.st0, (-2 * ms, 2 * Hz))
 
     def test_window_borders_as_complex_numbers(self):
@@ -171,21 +171,25 @@ class sta_TestCase(unittest.TestCase):
     def test_empty_analogsignal(self):
         asiga = AnalogSignal([], units='mV', sampling_rate=10 / ms)
         st = SpikeTrain([5], units='ms', t_stop=10)
-        self.assertRaises(ValueError, sta.spike_triggered_average, 
+        self.assertRaises(ValueError, sta.spike_triggered_average,
             asiga, st, (-1 * ms, 1 * ms))
 
     def test_one_spiketrain_empty(self):
         '''Test for one empty SpikeTrain, but existing spikes in other'''
         st = [SpikeTrain(
-            [9 * math.pi, 10 * math.pi, 11 * math.pi, 12 * math.pi], 
-            units='ms', t_stop=self.asiga1.t_stop), 
+            [9 * math.pi, 10 * math.pi, 11 * math.pi, 12 * math.pi],
+            units='ms', t_stop=self.asiga1.t_stop),
             SpikeTrain([], units='ms', t_stop=self.asiga1.t_stop)]
-        STA = sta.spike_triggered_average(self.asiga1, st, (-1 * ms, 1 * ms))
-        cmp_array = AnalogSignal(np.array([np.zeros(20, dtype=float)]).T,
-            units='mV', sampling_rate=10 / ms)
-        cmp_array = cmp_array / 0.
-        cmp_array.t_start = -1 * ms
-        assert_array_equal(STA.magnitude[:, 1], cmp_array.magnitude[:, 0])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            """
+            Ignore the RuntimeWarning: invalid value encountered in true_divide
+            new_signal = f(other, *args) for the empty SpikeTrain.
+            """
+            STA = sta.spike_triggered_average(self.asiga1,
+                                              spiketrains=st,
+                                              window=(-1 * ms, 1 * ms))
+        assert np.isnan(STA.magnitude[:, 1]).all()
 
     def test_all_spiketrains_empty(self):
         st = SpikeTrain([], units='ms', t_stop=self.asiga1.t_stop)
@@ -345,8 +349,15 @@ class sfc_TestCase_new_scipy(unittest.TestCase):
 
     def test_spike_field_coherence_perfect_coherence(self):
         # check for detection of 20Hz peak in anasig0/bst0
-        s, f = sta.spike_field_coherence(
-            self.anasig0, self.bst0, window='boxcar')
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            """
+            When the spiketrain is a vector with zero values, ignore the
+            warning RuntimeWarning: invalid value encountered in true_divide
+              Cxy = np.abs(Pxy)**2 / Pxx / Pyy.
+            """
+            s, f = sta.spike_field_coherence(
+                self.anasig0, self.bst0, window='boxcar')
 
         f_ind = np.where(f >= 19.)[0][0]
         max_ind = np.argmax(s[1:]) + 1
@@ -361,21 +372,30 @@ class sfc_TestCase_new_scipy(unittest.TestCase):
         # check number of frequency samples
         self.assertEqual(len(f), nfft / 2 + 1)
 
+        f_max = self.anasig3.sampling_rate.rescale('Hz').magnitude / 2
+        f_ground_truth = np.linspace(start=0,
+                                     stop=f_max,
+                                     num=nfft // 2 + 1) * pq.Hz
+
         # check values of frequency samples
-        assert_array_almost_equal(
-            f, np.linspace(
-                0, self.anasig3.sampling_rate.rescale('Hz').magnitude / 2,
-                nfft / 2 + 1) * pq.Hz)
+        assert_array_almost_equal(f, f_ground_truth)
 
     def test_short_spiketrain(self):
         # this spike train has the same length as anasig0
-        s1, f1 = sta.spike_field_coherence(
-            self.anasig0, self.bst3, window='boxcar')
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            """
+            When the spiketrain is a vector with zero values, ignore the
+            warning RuntimeWarning: invalid value encountered in true_divide
+              Cxy = np.abs(Pxy)**2 / Pxx / Pyy.
+            """
+            s1, f1 = sta.spike_field_coherence(
+                self.anasig0, self.bst3, window='boxcar')
 
-        # this spike train has the same spikes as above, but is shorter than
-        # anasig0
-        s2, f2 = sta.spike_field_coherence(
-            self.anasig0, self.bst4, window='boxcar')
+            # this spike train has the same spikes as above,
+            # but it's shorter than anasig0
+            s2, f2 = sta.spike_field_coherence(
+                self.anasig0, self.bst4, window='boxcar')
 
         # the results above should be the same, nevertheless
         assert_array_equal(s1.magnitude, s2.magnitude)

--- a/elephant/test/test_waveform_features.py
+++ b/elephant/test/test_waveform_features.py
@@ -7,12 +7,16 @@ Unit tests for the waveform_feature module.
 
 from __future__ import division
 
+import sys
 import unittest
+
 import neo
 import numpy as np
 import quantities as pq
 
 from elephant import waveform_features
+
+python_version_major = sys.version_info.major
 
 
 class WaveformSignalToNoiseRatioTestCase(unittest.TestCase):
@@ -33,9 +37,12 @@ class WaveformSignalToNoiseRatioTestCase(unittest.TestCase):
         self.assertRaises(ValueError, waveform_features.waveform_snr,
                           self.spiketrain_without_waveforms)
 
+    @unittest.skipUnless(python_version_major == 3, "assertWarns requires 3.2")
     def test_with_zero_waveforms(self):
-        result = waveform_features.waveform_snr(
-            self.spiketrain_with_zero_waveforms)
+        with self.assertWarns(UserWarning):
+            # expect np.nan result when spiketrain noise is zero.
+            result = waveform_features.waveform_snr(
+                self.spiketrain_with_zero_waveforms)
         self.assertTrue(np.isnan(result))
 
     def test_with_waveforms(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 neo>=0.7.1,<0.8.0
 numpy>=1.10.1
 quantities>=0.12.1
-scipy>=0.18.0
+scipy>=0.19.0
 six>=1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 neo>=0.7.1,<0.8.0
 numpy>=1.10.1
 quantities>=0.12.1
-scipy>=0.17.0
+scipy>=0.18.0
 six>=1.10.0


### PR DESCRIPTION
All these UserWarnings and RuntimeWarnings at tests always confuse me. I could not understand whether the problem was in the source code, test setup, or dependency package issues.
Before
```
/home/travis/build/NeuralEnsemble/elephant/elephant/asset.py:687: RuntimeWarning: invalid value encountered in true_divide
  AngCoeff = dY / dX
./home/travis/build/NeuralEnsemble/elephant/elephant/asset.py:687: RuntimeWarning: divide by zero encountered in true_divide
  AngCoeff = dY / dX
/home/travis/build/NeuralEnsemble/elephant/elephant/asset.py:687: RuntimeWarning: invalid value encountered in true_divide
  AngCoeff = dY / dX
/home/travis/build/NeuralEnsemble/elephant/elephant/asset.py:687: RuntimeWarning: divide by zero encountered in true_divide
  AngCoeff = dY / dX
/home/travis/build/NeuralEnsemble/elephant/elephant/asset.py:687: RuntimeWarning: invalid value encountered in true_divide
  AngCoeff = dY / dX
./home/travis/build/NeuralEnsemble/elephant/elephant/asset.py:687: RuntimeWarning: divide by zero encountered in true_divide
  AngCoeff = dY / dX
/home/travis/build/NeuralEnsemble/elephant/elephant/asset.py:687: RuntimeWarning: invalid value encountered in true_divide
  AngCoeff = dY / dX
....../home/travis/build/NeuralEnsemble/elephant/elephant/asset.py:687: RuntimeWarning: divide by zero encountered in true_divide
  AngCoeff = dY / dX
/home/travis/build/NeuralEnsemble/elephant/elephant/asset.py:687: RuntimeWarning: invalid value encountered in true_divide
  AngCoeff = dY / dX
.................................................................../home/travis/build/NeuralEnsemble/elephant/elephant/cubic.py:110: UserWarning: Test aborted, xihat= 11 > ximax= 10
  warnings.warn('Test aborted, xihat= %i > ximax= %i' % (xi, ximax))
...........................S........................................................................................................................./home/travis/build/NeuralEnsemble/elephant/elephant/test/test_pandas_bridge.py:50: FutureWarning: the 'labels' keyword is deprecated, use 'codes' instead
  names=['test1', 'test2', 'test3'])
/home/travis/build/NeuralEnsemble/elephant/elephant/test/test_pandas_bridge.py:54: FutureWarning: .labels was deprecated in version 0.24.0. Use .codes instead.
  self.assertEqual(targ.labels, res0.labels)
./home/travis/build/NeuralEnsemble/elephant/elephant/test/test_pandas_bridge.py:2760: RuntimeWarning: invalid value encountered in less
  targ[targ < targ_start] = np.nan
/home/travis/build/NeuralEnsemble/elephant/elephant/test/test_pandas_bridge.py:2761: RuntimeWarning: invalid value encountered in greater
  targ[targ > targ_stop] = np.nan
../home/travis/build/NeuralEnsemble/elephant/elephant/test/test_pandas_bridge.py:2706: RuntimeWarning: invalid value encountered in less
  targ[targ < targ_start] = np.nan
./home/travis/build/NeuralEnsemble/elephant/elephant/test/test_pandas_bridge.py:2734: RuntimeWarning: invalid value encountered in greater
  targ[targ > targ_stop] = np.nan
......................................................./home/travis/build/NeuralEnsemble/elephant/elephant/test/test_signal_processing.py:209: RuntimeWarning: invalid value encountered in true_divide
  target = (signal.magnitude - m) / s
/home/travis/build/NeuralEnsemble/elephant/elephant/signal_processing.py:129: RuntimeWarning: invalid value encountered in true_divide
  (sig.magnitude - m.magnitude) / s.magnitude,
./home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/quantities/quantity.py:321: RuntimeWarning: divide by zero encountered in true_divide
  return np.true_divide(other, self)
../home/travis/build/NeuralEnsemble/elephant/elephant/spade.py:308: UserWarning: 0<alpha<1 but p-value spectrum has not been computed (n_surr==0)
  warnings.warn('0<alpha<1 but p-value spectrum has not been '
................................/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/quantities/quantity.py:321: RuntimeWarning: divide by zero encountered in true_divide
  return np.true_divide(other, self)
............/home/travis/build/NeuralEnsemble/elephant/elephant/spike_train_generation.py:335: RuntimeWarning: divide by zero encountered in true_divide
  mean_interval = 1 / rate.magnitude
......../home/travis/build/NeuralEnsemble/elephant/elephant/spike_train_generation.py:267: RuntimeWarning: invalid value encountered in sqrt
  number = np.ceil(n + 3 * np.sqrt(n))
............................/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/scipy/signal/spectral.py:1577: RuntimeWarning: invalid value encountered in true_divide
  Cxy = np.abs(Pxy)**2 / Pxx / Pyy
............/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/neo/core/basesignal.py:132: RuntimeWarning: invalid value encountered in true_divide
  new_signal = f(other, *args)
.........................../home/travis/build/NeuralEnsemble/elephant/elephant/statistics.py:256: UserWarning: Input size is too small. Please provide an input with more than 1 entry. lv returns 'NaN'since the argument `with_nan` is True
  warnings.warn("Input size is too small. Please provide "
......../home/travis/build/NeuralEnsemble/elephant/elephant/statistics.py:867: UserWarning: Instantaneous firing rate approximation contains negative values, possibly caused due to machine precision errors.
  warnings.warn("Instantaneous firing rate approximation contains "
........................................................../home/travis/build/NeuralEnsemble/elephant/elephant/waveform_features.py:70: UserWarning: The noise was evaluated to 0.
  warnings.warn('The noise was evaluated to 0.')
..
```
Now
```
 nosetests --cover-package=elephant
......................................................................................................S..................................................................................................................................................................................................................................................................................................................................................................................
Ran 473 tests in 275.283s

OK (SKIP=1)
```
Future warnings can be easily caught.

Affected changes:
* removed handwritten `_xrange` wrapper
* `np.arctan(y/x)` -> numerically stable `np.arctan2(y, x)`