### PR TITLE
STTC speedup by using numpy instead of loops

### DIFF
--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -656,9 +656,16 @@ def spike_time_tiling_coefficient(spiketrain_1, spiketrain_2, dt=0.005 * pq.s):
         within dt
         """
 
-        diff = spiketrain_1.times[:, np.newaxis] - spiketrain_2.times[np.newaxis, :]
-        sumdiff = np.sum(np.abs(diff) <= dt, axis=1)
-        return np.count_nonzero(sumdiff)
+        ind = np.searchsorted(spiketrain_2.times, spiketrain_1.times)
+        ind[ind == 0] = 1
+        ind[ind == N2] = N2 - 1
+        # TODO: Index Errors if N1 == 1 || N2 == 1
+        diff_left = np.abs(spiketrain_2.times[ind - 1] - spiketrain_1.times)
+        diff_right = np.abs(spiketrain_2.times[ind] - spiketrain_1.times)
+        diff_left = diff_left <= dt
+        diff_right = diff_right <= dt
+        diff = diff_left + diff_right
+        return np.count_nonzero(diff)
 
     def run_T(spiketrain, N, dt):
         """


### PR DESCRIPTION
The current implementation of STTC is following the implementation provided along the original paper very closely. This makes it easy to understand and it's very clear the implementation does the same. 
However, directly transcribing C code to Python makes it really slow. 
This PR provides a considerable increase in performance (multiple hours => few minutes) due to using numpy at the cost of not being easily comparable to the original implementation.

The two main parts of this PR are:
- in run_T: Instead of looping over the spike time differences one by one, this is now vectorized, computing a vector of differences and summing over it. 
This should be relatively easy to understand and compare to the original code.
- in run_P: What this function does, is that for every spike in `spiketrain_1` it checks if there is any spike in `spiketrain_2` within `dt` of it. Instead of looping over every single spike, the implementation here uses a binary search algorithm. This INCREASES runtime complexity, but due to the numpy implementation it outperforms the current version even for very large spiketrains.

I'm not sure if moving this far away from the original code is desired, so please let me know what you think.