### PR TITLE
Fix/spade

### DIFF
--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -1927,8 +1927,8 @@ def concept_output_to_patterns(concepts, winlen, binsize, pvalue_spectrum=None,
             output_dict['pvalue'] = -1
         # Signature (size, n occ) of the pattern
         elif spectrum == '3d#':
-            sgnt = (len(conc[0]), len(conc[1]), max(
-                np.abs(np.diff(np.array(conc[0]) % winlen))))
+            duration = (max(conc[0]) - min(conc[0])) % winlen
+            sgnt = (len(conc[0]), len(conc[1]), duration)
             output_dict['signature'] = sgnt
             # p-value assigned to the pattern from the pvalue spectrum
             try:

--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -163,7 +163,7 @@ def spade(data, binsize, winlen, min_spikes=2, min_occ=2, max_spikes=None,
         filtering the pattern spectrum. A spike at time t is placed randomly
         within ]t-dither, t+dither[ (see also
         elephant.spike_train_surrogates.dither_spikes).
-        Default: 15*pq.s
+        Default: 15*pq.ms
     spectrum: str
         Define the signature of the patterns, it can assume values:
         '#': pattern spectrum using the as signature the pair:
@@ -244,7 +244,7 @@ def spade(data, binsize, winlen, min_spikes=2, min_occ=2, max_spikes=None,
                     pattern.
                 lags: array containing the lags (integers corresponding to the
                     number of bins) between the spikes of the patterns. The
-                    first lag is always assumed to be 0 and correspond to the
+                    first lag is always assumed to be 0 and corresponds to the
                     first spike ['times'] array containing the times.
             (integers corresponding to the bin idx) of the occurrences of the
             patterns
@@ -459,7 +459,7 @@ def concepts_mining(data, binsize, winlen, min_spikes=2, min_occ=2,
     rel_matrix : numpy.array
         A binary matrix with shape (number of windows, winlen*len(data)). Each
         row corresponds to a window (order according to their position in
-        time). Each column correspond to one bin and one neuron and it is 0 if
+        time). Each column corresponds to one bin and one neuron and it is 0 if
         no spikes or 1 if one or more spikes occurred in that bin for that
         particular neuron. For example, the entry [0,0] of this matrix
         corresponds to the first bin of the first window position for the first
@@ -555,11 +555,11 @@ def _build_context(binary_matrix, winlen, only_windows_with_first_spike=True):
         attributes of the corresponding object.
     rel_matrix : numpy.array
         A binary matrix with shape (number of windows, winlen*len(data)). Each
-        row correspond to a window (order according to their position in time).
-        Each column correspond to one bin and one neuron and it is 0 if no
+        row corresponds to a window (order according to their position in time).
+        Each column corresponds to one bin and one neuron and it is 0 if no
         spikes or 1 if one or more spikes occurred in that bin for that
         particular neuron.
-        E.g. the entry [0,0] of this matrix correspond to the first bin of the
+        E.g. the entry [0,0] of this matrix corresponds to the first bin of the
         first window position for the first neuron, the entry [0,winlen] to the
         first bin of the first window position for the second neuron.
     """
@@ -646,11 +646,11 @@ def _fpgrowth(transactions, min_c=2, min_z=2, max_z=None,
         Default: 'a'
     rel_matrix : None or numpy.array
         A binary matrix with shape (number of windows, winlen*len(data)). Each
-        row correspond to a window (order according to their position in time).
-        Each column correspond to one bin and one neuron and it is 0 if no
+        row corresponds to a window (order according to their position in time).
+        Each column corresponds to one bin and one neuron and it is 0 if no
         spikes or 1 if one or more spikes occurred in that bin for that
         particular neuron.
-        E.g. the entry [0,0] of this matrix correspond to the first bin of the
+        E.g. the entry [0,0] of this matrix corresponds to the first bin of the
         first window position for the first neuron, the entry [0,winlen] to the
         first bin of the first window position for the second neuron.
         If == None only the closed frequent itemsets (intent) are returned and
@@ -1299,7 +1299,7 @@ def approximate_stability(concepts, rel_matrix, n_subsets, delta=0, epsilon=0):
     rel_matrix: numpy.array
         A binary matrix with shape (number of windows, winlen*len(data)). Each
         row corresponds to a window (order according to their position in
-        time). Each column correspond to one bin and one neuron and it is 0 if
+        time). Each column corresponds to one bin and one neuron and it is 0 if
         no spikes or 1 if one or more spikes occurred in that bin for that
         particular neuron. For example, the entry [0,0] of this matrix
         corresponds to the first bin of the first window position for the first
@@ -1841,7 +1841,7 @@ def concept_output_to_patterns(concepts, winlen, binsize, pvalue_spectrum=None,
     Parameters
     ----------
     concepts: tuple
-        Each element of the tuple correspond to a pattern and it is itself a
+        Each element of the tuple corresponds to a pattern and it is itself a
         tuple consisting of:
             ((spikes in the pattern), (occurrences of the patterns))
     winlen: int
@@ -1850,14 +1850,14 @@ def concept_output_to_patterns(concepts, winlen, binsize, pvalue_spectrum=None,
         The time precision used to discretize the data (binning).
     pvalue_spectrum: None or tuple
         Contains a tuple of signatures and the corresponding p-value. If equal
-        to None all the pvalues are set to -1
+        to None all pvalues are set to -1
     t_start: Quantity
         t_start of the analyzed spike trains
 
     Returns
     --------
     output: list
-        List of dictionaries. Each dictionary correspond to a patterns and
+        List of dictionaries. Each dictionary corresponds to a pattern and
         has the following entries:
             ['itemset'] list of the spikes in the pattern
                 expressed in the form of itemset, each spike is encoded by:
@@ -1867,15 +1867,15 @@ def concept_output_to_patterns(concepts, winlen, binsize, pvalue_spectrum=None,
             ['neurons'] array containing the idx of the neurons of the pattern
             ['lags'] array containing the lags (integers corresponding to the
                 number of bins) between the spikes of the patterns. The first
-                lag is always assumed to be 0 and correspond to the first
+                lag is always assumed to be 0 and corresponds to the first
                 spike.
-            ['times'] array contianing the times (integers corresponding to the
+            ['times'] array containing the times (integers corresponding to the
                 bin idx) of the occurrences of the patterns.
             ['signature'] tuple containing two integers
                 (number of spikes of the patterns,
                 number of occurrences of the pattern)
             ['pvalue'] the pvalue corresponding to the pattern. If n_surr==0
-                the pvalues are set to -1.
+             then all pvalues are set to -1.
     """
     if pvalue_spectrum is not None:
         if len(pvalue_spectrum) == 0:

--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -379,7 +379,7 @@ def spade(data, binsize, winlen, min_spikes=2, min_occ=2, max_spikes=None,
                                                             winlen, binsize,
                                                             pv_spec,
                                                             data[0].t_start)
-        if output_format == 'concepts':
+        elif output_format == 'concepts':
             output['patterns'] = concepts
         else:
             raise ValueError(
@@ -1881,7 +1881,9 @@ def concept_output_to_patterns(concepts, winlen, binsize, pvalue_spectrum=None,
             ['pvalue'] the pvalue corresponding to the pattern. If n_surr==0
              then all pvalues are set to -1.
     """
-    if pvalue_spectrum is not None:
+    if pvalue_spectrum is None:
+        spectrum = '#'
+    else:
         if len(pvalue_spectrum) == 0:
             spectrum = '#'
             pass

--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -379,8 +379,12 @@ def spade(data, binsize, winlen, min_spikes=2, min_occ=2, max_spikes=None,
                                                             winlen, binsize,
                                                             pv_spec,
                                                             data[0].t_start)
-        else:
+        if output_format == 'concepts':
             output['patterns'] = concepts
+        else:
+            raise ValueError(
+                "The output_format value has to be one between"
+                "'patterns' and 'concepts'")
         return output
     # rank!=0 returning None
     else:

--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -56,12 +56,11 @@ plt.show()
 :copyright: Copyright 2017 by the Elephant team, see `doc/authors.rst`.
 :license: BSD, see LICENSE.txt for details.
 '''
-import numpy
+import numpy as np
 import neo
 import elephant.spike_train_surrogates as surr
 import elephant.conversion as conv
 from itertools import chain, combinations
-import numpy as np
 import time
 import quantities as pq
 import warnings
@@ -1134,8 +1133,8 @@ def _fdr(pvalues, alpha):
     """
 
     # Sort the p-values from largest to smallest
-    pvs_array = numpy.array(pvalues)              # Convert PVs to an array
-    pvs_sorted = numpy.sort(pvs_array)[::-1]  # Sort PVs in decreasing order
+    pvs_array = np.array(pvalues)              # Convert PVs to an array
+    pvs_sorted = np.sort(pvs_array)[::-1]  # Sort PVs in decreasing order
 
     # Perform FDR on the sorted p-values
     m = len(pvalues)
@@ -1230,7 +1229,7 @@ def test_signature_significance(pvalue_spectrum, alpha, corr='',
     # If alpha == 1 all signatures are significant
     if alpha == 1:
         return []
-    x_array = numpy.array(pvalue_spectrum)
+    x_array = np.array(pvalue_spectrum)
     # Compute significance...
     if corr == '' or corr == 'no':  # ...without statistical correction
         tests = x_array[:, -1] <= alpha

--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -558,7 +558,8 @@ def _build_context(binary_matrix, winlen, only_windows_with_first_spike=True):
         attributes of the corresponding object.
     rel_matrix : numpy.array
         A binary matrix with shape (number of windows, winlen*len(data)). Each
-        row corresponds to a window (order according to their position in time).
+        row corresponds to a window (order according to
+        their position in time).
         Each column corresponds to one bin and one neuron and it is 0 if no
         spikes or 1 if one or more spikes occurred in that bin for that
         particular neuron.
@@ -649,7 +650,8 @@ def _fpgrowth(transactions, min_c=2, min_z=2, max_z=None,
         Default: 'a'
     rel_matrix : None or numpy.array
         A binary matrix with shape (number of windows, winlen*len(data)). Each
-        row corresponds to a window (order according to their position in time).
+        row corresponds to a window (order according to
+        their position in time).
         Each column corresponds to one bin and one neuron and it is 0 if no
         spikes or 1 if one or more spikes occurred in that bin for that
         particular neuron.


### PR DESCRIPTION
In this pull request we fixed a few issues in the spade.py module. We
- fixed the calculation of the duration of a pattern, in the output of spade. Previously, in the function restructuring the output format and making it more 'human readable' (concept_output_to_patterns), the calculation of the pattern duration was not always correct, depending on the order of lags and neurons. We fixed the bug by accounting the duration independently from the order of neurons;
- added raise ValueErrors in code when the output_format is not one of the two parameters allowed
- fixed bug of undefined spectrum type when running spade without surrogates (only FIM)
In addition:
- corrected typos in documentation and removed redundant calls to numpy