### PR TITLE
keep array_annotations in the output of signal_processing functions

### DIFF
--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -126,6 +126,7 @@ def zscore(signal, inplace=True):
             sig_normalized = sig
         else:
             sig_normalized = sig.duplicate_with_new_data(sig_normalized)
+            sig_normalized.array_annotate(**sig.array_annotations)
         sig_dimless = sig_normalized / sig.units
         result.append(sig_dimless)
 
@@ -142,16 +143,16 @@ def cross_correlation_function(signal, ch_pairs, env=False, nlags=None):
     Computes unbiased estimator of the cross-correlation function.
 
     Calculates the unbiased estimator of the cross-correlation function [1]_
-    
+
     .. math::
              R(\\tau) = \\frac{1}{N-|k|} R'(\\tau) \\ ,
-    
-    where :math:`R'(\\tau) = \\left<x(t)y(t+\\tau)\\right>` in a pairwise 
+
+    where :math:`R'(\\tau) = \\left<x(t)y(t+\\tau)\\right>` in a pairwise
     manner, i.e. `signal[ch_pairs[0,0]]` vs `signal2[ch_pairs[0,1]]`,
     `signal[ch_pairs[1,0]]` vs `signal2[ch_pairs[1,1]]`, and so on. The
     cross-correlation function is obtained by `scipy.signal.fftconvolve`.
     Time series in signal are zscored beforehand. Alternatively returns the
-    Hilbert envelope of :math:`R(\\tau)`, which is useful to determine the 
+    Hilbert envelope of :math:`R(\\tau)`, which is useful to determine the
     correlation length of oscillatory signals.
 
     Parameters
@@ -394,7 +395,9 @@ def butter(signal, highpass_freq=None, lowpass_freq=None, order=4,
 
     if isinstance(signal, neo.AnalogSignal):
         filtered_data = np.rollaxis(filtered_data, -1, 0)
-        return signal.duplicate_with_new_data(filtered_data)
+        signal_out = signal.duplicate_with_new_data(filtered_data)
+        signal_out.array_annotate(**signal.array_annotations)
+        return signal_out
     elif isinstance(signal, pq.quantity.Quantity):
         return filtered_data * signal.units
     else:
@@ -628,6 +631,7 @@ def hilbert(signal, N='nextpow'):
 
     output = signal.duplicate_with_new_data(
         scipy.signal.hilbert(signal.magnitude, N=n, axis=0)[:n_org])
+    output.array_annotate(**signal.array_annotations)
     return output / output.units
 
 

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -126,6 +126,8 @@ def zscore(signal, inplace=True):
             sig_normalized = sig
         else:
             sig_normalized = sig.duplicate_with_new_data(sig_normalized)
+            # todo use flag once is fixed
+            #      https://github.com/NeuralEnsemble/python-neo/issues/752
             sig_normalized.array_annotate(**sig.array_annotations)
         sig_dimless = sig_normalized / sig.units
         result.append(sig_dimless)
@@ -396,6 +398,8 @@ def butter(signal, highpass_freq=None, lowpass_freq=None, order=4,
     if isinstance(signal, neo.AnalogSignal):
         filtered_data = np.rollaxis(filtered_data, -1, 0)
         signal_out = signal.duplicate_with_new_data(filtered_data)
+        # todo use flag once is fixed
+        #      https://github.com/NeuralEnsemble/python-neo/issues/752
         signal_out.array_annotate(**signal.array_annotations)
         return signal_out
     elif isinstance(signal, pq.quantity.Quantity):
@@ -631,6 +635,8 @@ def hilbert(signal, N='nextpow'):
 
     output = signal.duplicate_with_new_data(
         scipy.signal.hilbert(signal.magnitude, N=n, axis=0)[:n_org])
+    # todo use flag once is fixed
+    #      https://github.com/NeuralEnsemble/python-neo/issues/752
     output.array_annotate(**signal.array_annotations)
     return output / output.units
 


### PR DESCRIPTION
In the function signal processing function _zscore_,  _butter_, and _hilbert_ the output is created by using the Neo functionality _duplicate_with_new_data_. However, this function purposely ignores array_annotations. Quote from the source code: 
 ```
        # Note: Array annotations are not copied here, because it is not ensured
        # that the same number of signals is used and they would possibly make no sense
        # when combined with another signal
```
In the case of the above functions, the array_annotations are still valid for the output, therefore, this PR copies them manually to the output.