### PR TITLE
Correctly handle Compound Units in `elephant.phase_analysis.spike_triggered_phase`

### DIFF
--- a/elephant/phase_analysis.py
+++ b/elephant/phase_analysis.py
@@ -108,7 +108,8 @@ def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
         # Find index into signal for each spike
         ind_at_spike = np.round(
             (spiketrain[sttimeind] - hilbert_transform[phase_i].t_start) /
-            hilbert_transform[phase_i].sampling_period).magnitude.astype(int)
+            hilbert_transform[phase_i].sampling_period). \
+            simplified.magnitude.astype(int)
 
         # Extract times for speed reasons
         times = hilbert_transform[phase_i].times

--- a/elephant/test/test_phase_analysis.py
+++ b/elephant/test/test_phase_analysis.py
@@ -185,6 +185,22 @@ class SpikeTriggeredPhaseTestCase(unittest.TestCase):
             interpolate=False)
         self.assertEqual(len(phases_noint[0]), 1)
 
+    # This test handles the correct dealing with input signals that have
+    # different time units, including a CompoundUnit
+    def test_regression_269(self):
+        # This is a spike train on a 30KHz sampling, one spike at 1s, one just
+        # before the end of the signal
+        cu = pq.CompoundUnit("1/30000.*s")
+        st = SpikeTrain(
+            [30000., (self.anasig0.t_stop-1*pq.s).rescale(cu).magnitude],
+            units=pq.CompoundUnit("1/30000.*s"),
+            t_start=-1*pq.s, t_stop=300*pq.s)
+        phases_noint, _, _ = elephant.phase_analysis.spike_triggered_phase(
+            elephant.signal_processing.hilbert(self.anasig0),
+            st,
+            interpolate=False)
+        self.assertEqual(len(phases_noint[0]), 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a fix and corresponding regression test for #269.

The new unit test reproduces the behavior: if the spike train times (or other time quantities of the input data) contain a CompoundUnit, a division in the code could lead to a unit like
`1/30000*dimensionless`, i.e., one could not take the magnitude of the term to obtain the actual outcome of the division. Use of `simplified` solves the issue. 