### PR TITLE
Fast covariance() and Pearson corrcoef()

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -493,7 +493,7 @@ class BinnedSpikeTrain(object):
         """
         # Check if num_bins is an integer (special case)
         if num_bins is not None:
-            if not isinstance(num_bins, int):
+            if not np.issubdtype(type(num_bins), int):
                 raise TypeError("num_bins is not an integer!")
         # Check if all parameters can be calculated, otherwise raise ValueError
         if t_start is None:
@@ -778,7 +778,7 @@ class BinnedSpikeTrain(object):
         scipy.sparse.csr_matrix
         scipy.sparse.csr_matrix.toarray
         """
-        return abs(scipy.sign(self.to_array())).astype(bool)
+        return self.to_array().astype(bool)
 
     def to_array(self, store_array=False):
         """
@@ -861,6 +861,17 @@ class BinnedSpikeTrain(object):
         if bst._mat_u is not None:
             bst._mat_u.clip(max=1, out=bst._mat_u)
         return bst
+
+    @property
+    def sparsity(self):
+        """
+        Returns
+        -------
+        float
+            Matrix sparsity, defined as matrix size, divided by no. of
+            nonzero elements.
+        """
+        return np.prod(self._sparse_mat_u.shape) / len(self._sparse_mat_u.data)
 
     def _convert_to_binned(self, spiketrains):
         """

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -13,6 +13,7 @@ An example is the representation of a spike train as a sequence of 0-1 values
 from __future__ import division, print_function
 
 import warnings
+from copy import deepcopy
 
 import neo
 import numpy as np
@@ -835,13 +836,31 @@ class BinnedSpikeTrain(object):
         """
         self._mat_u = None
 
-    def binarize(self):
+    def binarize(self, copy=True):
         """
-        In-place clipping the internal array to have 0 or 1 values.
+        Clip the internal array (no. of spikes in a bin) to have `0` or `1`
+        values only.
+
+        Parameters
+        ----------
+        copy : bool
+            Make the clipping in-place (False) or with a copy (True).
+            Default is True.
+
+        Returns
+        -------
+        bst : BinnedSpikeTrain
+            Binarized `BinnedSpikeTrain`.
+
         """
-        self._sparse_mat_u.data.clip(max=1, out=self._sparse_mat_u.data)
-        if self._mat_u is not None:
-            self._mat_u.clip(max=1, out=self._mat_u)
+        if copy:
+            bst = deepcopy(self)
+        else:
+            bst = self
+        bst._sparse_mat_u.data.clip(max=1, out=bst._sparse_mat_u.data)
+        if bst._mat_u is not None:
+            bst._mat_u.clip(max=1, out=bst._mat_u)
+        return bst
 
     def _convert_to_binned(self, spiketrains):
         """

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -198,19 +198,19 @@ class CrossCorrHist(object):
 
 
 def covariance(binned_sts, binary=False, fast=True):
-    """
+    r"""
     Calculate the NxN matrix of pairwise covariances between all combinations
     of N binned spike trains.
 
     For each pair of spike trains :math:`(i,j)`, the covariance :math:`C[i,j]`
     is obtained by binning :math:`i` and :math:`j` at the desired bin size. Let
-    :math:`b_i` and :math:`b_j` denote the binned spike trains and :math:`m_i`
-    and :math:`m_j` their respective averages. Then
+    :math:`b_i` and :math:`b_j` denote the binned spike trains and
+    :math:`\mu_i` and :math:`\mu_j` their respective averages. Then
 
     .. math::
-         C[i,j] = <b_i-m_i, b_j-m_j> / (l-1)
+         C[i,j] = <b_i-\mu_i, b_j-\mu_j> / (L-1)
 
-    where <..,.> is the scalar product of two vectors and :math:`l` is the
+    where `<., .>` is the scalar product of two vectors, and :math:`L` is the
     number of bins.
 
     For an input of n spike trains, an n x n matrix is returned containing the
@@ -298,13 +298,13 @@ def corrcoef(binned_sts, binary=False, fast=True):
     For each pair of spike trains :math:`(i,j)`, the correlation coefficient
     :math:`C[i,j]` is obtained by binning :math:`i` and :math:`j` at the
     desired bin size. Let :math:`b_i` and :math:`b_j` denote the binned spike
-    trains and :math:`m_i` and :math:`m_j` their respective averages. Then
+    trains and :math:`\mu_i` and :math:`\mu_j` their respective means. Then
 
     .. math::
-         C[i,j] = <b_i-m_i, b_j-m_j> /
-                      \sqrt{<b_i-m_i, b_i-m_i>*<b_j-m_j,b_j-m_j>}
+         C[i,j] = <b_i-\mu_i, b_j-\mu_j> /
+                  \sqrt{<b_i-\mu_i, b_i-\mu_i> \cdot <b_j-\mu_j, b_j-\mu_j>}
 
-    where <..,.> is the scalar product of two vectors.
+    where `<., .>` is the scalar product of two vectors.
 
     For an input of n spike trains, an n x n matrix is returned.
     Each entry in the matrix is a real number ranging between -1 (perfectly
@@ -389,11 +389,24 @@ def corrcoef(binned_sts, binary=False, fast=True):
 
 
 def _covariance_sparse(binned_sts, corrcoef_norm):
-    """
+    r"""
     Memory efficient helper function for `covariance()` and `corrcoef()`
     that performs the complete calculation for either the covariance
     (`corrcoef_norm=False`) or correlation coefficient (`corrcoef_norm=True`).
     Both calculations differ only by the denominator.
+
+    For any two `BinnedSpikeTrain`s :math:`\hat{b_x}` and :math:`\hat{b_y}`
+    with mean :math:`\vec{\mu_x}` and :math:`\vec{mu_y}` respectively
+    computes the dot product
+
+    .. math::
+        <\hat{b_x} - \vec{\mu_x}, \hat{b_y} - \vec{\mu_y}>_{ij} =
+            (\hat{b_x} \cdot \hat{b_y}^T)_{ij} -
+            \frac{(\vec{N_x}^T \cdot \vec{N_y})_{ij}}{L}
+
+    where :math:`N_x^i = \sum_j{b_x^{ij}}` - the number of spikes in `i`th row
+    of :math:`\hat{b_x}`, :math:`L` - the number of bins, and
+    :math:`\vec{\mu_x} = \frac{\vec{N_x}}{L}`.
 
     Parameters
     ----------

--- a/elephant/test/test_spade.py
+++ b/elephant/test/test_spade.py
@@ -394,7 +394,7 @@ class SpadeTestCase(unittest.TestCase):
         # Test negative minimum number of spikes
         self.assertRaises(AttributeError, spade.spade, [neo.SpikeTrain(
             [1, 2, 3] * pq.s, t_stop=5 * pq.s), neo.SpikeTrain(
-            [3, 4, 5] * pq.s, t_stop=5 * pq.s)], 1 * pq.ms, 4, min_neu=-3)
+            [3, 4, 4.5] * pq.s, t_stop=5 * pq.s)], 1 * pq.ms, 4, min_neu=-3)
         # Test negative number of surrogates
         self.assertRaises(AttributeError, spade.pvalue_spectrum, [
             neo.SpikeTrain([1, 2, 3] * pq.s, t_stop=5 * pq.s), neo.SpikeTrain(

--- a/elephant/test/test_spade.py
+++ b/elephant/test/test_spade.py
@@ -394,7 +394,7 @@ class SpadeTestCase(unittest.TestCase):
         # Test negative minimum number of spikes
         self.assertRaises(AttributeError, spade.spade, [neo.SpikeTrain(
             [1, 2, 3] * pq.s, t_stop=5 * pq.s), neo.SpikeTrain(
-            [3, 4, 4.5] * pq.s, t_stop=5 * pq.s)], 1 * pq.ms, 4, min_neu=-3)
+            [3, 4, 5] * pq.s, t_stop=5 * pq.s)], 1 * pq.ms, 4, min_neu=-3)
         # Test negative number of surrogates
         self.assertRaises(AttributeError, spade.pvalue_spectrum, [
             neo.SpikeTrain([1, 2, 3] * pq.s, t_stop=5 * pq.s), neo.SpikeTrain(

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -570,7 +570,8 @@ class cross_correlation_histogram_TestCase(unittest.TestCase):
             method='memory')
 
         self.assertEqual(np.any(np.not_equal(cch, cch_corrected)), True)
-        self.assertEqual(np.any(np.not_equal(cch_mem, cch_corrected_mem)), True)
+        self.assertEqual(np.any(np.not_equal(cch_mem, cch_corrected_mem)),
+                         True)
 
     def test_kernel(self):
         '''Test if the smoothing kernel is correctly defined, and wheter it is
@@ -646,7 +647,7 @@ class SpikeTimeTilingCoefficientTestCase(unittest.TestCase):
 
         # test for TA = PB = 1 but TB /= PA /= 1 and vice versa
         st3 = neo.SpikeTrain([1, 5, 9], units='ms', t_stop=10.)
-        target2 = 1./3.
+        target2 = 1. / 3.
         self.assertAlmostEqual(target2, sc.sttc(st3, st2,
                                                 0.003 * pq.s))
         self.assertAlmostEqual(target2, sc.sttc(st2, st3,
@@ -673,16 +674,16 @@ class SpikeTrainTimescaleTestCase(unittest.TestCase):
         [1] Lindner, B. (2009). A brief introduction to some simple stochastic
             processes. Stochastic Methods in Neuroscience, 1.
         '''
-        nu = 25/pq.s
-        T = 15*pq.min
-        binsize = 1*pq.ms
-        timescale = 1 / (4*nu)
+        nu = 25 / pq.s
+        T = 15 * pq.min
+        binsize = 1 * pq.ms
+        timescale = 1 / (4 * nu)
 
         timescale_num = []
         for _ in range(10):
-            spikes = homogeneous_gamma_process(2, 2*nu, 0*pq.ms, T)
+            spikes = homogeneous_gamma_process(2, 2 * nu, 0 * pq.ms, T)
             spikes_bin = conv.BinnedSpikeTrain(spikes, binsize)
-            timescale_i = sc.spike_train_timescale(spikes_bin, 10*timescale)
+            timescale_i = sc.spike_train_timescale(spikes_bin, 10 * timescale)
             timescale_i.units = timescale.units
             timescale_num.append(timescale_i.magnitude)
         target = np.allclose(timescale.magnitude, timescale_num, rtol=2e-1)


### PR DESCRIPTION
1. Vectorized memory-efficient covariance implementation of sparse `BinnedSpikeTrain` matrix (previously, `__calculate_correlation_or_covariance()`; now `_covariance_sparse()`). Now it works even faster than numpy equivalent when the sparsity is lower than `0.1`.
2. Added `fast=True` flag in `covariance()` and `corrcoef()`. This _might lead_ to the MemoryError for large `BinnedSpikeTrain` arrays.
3. Finally, clarified the difference in the implementation of `CrossCorrHist.cross_corr_coef()` and the reference book "Analysis of parallel spike trains", 2010, Gruen & Rotter, Vol 7. First introduced in #111 and came up again in the discussion in #273 .

Other things:
1. Added `copy=True` flag in `BinnedSpikeTrain.binarize()`.
2. Added `BinnedSpikeTrain.sparsity` property - a convenient way to keep track of memory/speed trade-off.

-----

Why the magic `_SPARSITY_MEMORY_EFFICIENT_THR = 0.1`

![100_bins](https://user-images.githubusercontent.com/7688337/69163875-48057480-0aef-11ea-8745-f78bdd606d49.png)
![1000_bins](https://user-images.githubusercontent.com/7688337/69163876-48057480-0aef-11ea-8ec1-675b3c0ab63c.png)
![10000_bins](https://user-images.githubusercontent.com/7688337/69163877-489e0b00-0aef-11ea-8b41-0f2983ce584a.png)
![100000_bins](https://user-images.githubusercontent.com/7688337/69163878-489e0b00-0aef-11ea-9a45-59f2d90ba61c.png)
![1000000_bins](https://user-images.githubusercontent.com/7688337/69163879-489e0b00-0aef-11ea-9b3b-96cd2857eb72.png)
