### PR TITLE
pairwise_cross_correlation scaleopt flag

### DIFF
--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -49,8 +49,7 @@ def zscore(signal, inplace=True):
 
     Returns
     -------
-    neo.AnalogSignal or list
-        Or list of AnalogSignals.
+    neo.AnalogSignal or list of neo.AnalogSignal
         The output format matches the input format: for each supplied
         AnalogSignal object a corresponding object is returned containing
         the z-transformed signal with the unit dimensionless.

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -143,7 +143,7 @@ def zscore(signal, inplace=True):
         return result
 
 
-def pairwise_cross_correlation(signal, ch_pairs, env=False, nlags=None,
+def cross_correlation_function(signal, ch_pairs, env=False, nlags=None,
                                scaleopt='unbiased'):
     r"""
     Calculates the pairwise cross-correlation estimate of `signal[ch_pairs]`
@@ -309,16 +309,6 @@ def pairwise_cross_correlation(signal, ch_pairs, env=False, nlags=None,
                                   sampling_rate=signal.sampling_rate,
                                   dtype=float)
     return cross_corr
-
-
-def cross_correlation_function(*args, **kwargs):
-    # The name 'cross_correlation_function' is ambiguous and clashes with
-    # 'cross_correlation_histogram()' and 'corrcoef()' functions in
-    # spike_train_correlation.py
-    warnings.warn("'cross_correlation_function()' is deprecated. "
-                  "Use 'pairwise_cross_correlation()' instead.",
-                  DeprecationWarning)
-    return pairwise_cross_correlation(*args, **kwargs)
 
 
 def butter(signal, highpass_freq=None, lowpass_freq=None, order=4,

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -45,7 +45,7 @@ class PairwiseCrossCorrelationTest(unittest.TestCase):
                                           t_start=0. * pq.ms,
                                           sampling_rate=self.sampling_rate,
                                           dtype=float)
-            rho = elephant.signal_processing.pairwise_cross_correlation(
+            rho = elephant.signal_processing.cross_correlation_function(
                 signal_neo, [[0, 1], [0, 2]])
             # Cross-correlation of sine and cosine should be sine
             assert_array_almost_equal(
@@ -65,7 +65,7 @@ class PairwiseCrossCorrelationTest(unittest.TestCase):
         signal = neo.AnalogSignal(signal, units='mV', t_start=0.*pq.ms,
                                   sampling_rate=self.sampling_rate,
                                   dtype=float)
-        rho = elephant.signal_processing.pairwise_cross_correlation(
+        rho = elephant.signal_processing.cross_correlation_function(
             signal, [0, 1], nlags=nlags)
         # Test if vector of lags tau has correct length
         assert len(rho.times) == 2*int(nlags)+1
@@ -82,7 +82,7 @@ class PairwiseCrossCorrelationTest(unittest.TestCase):
         signal = neo.AnalogSignal(signal, units='mV', t_start=0.*pq.ms,
                                   sampling_rate=self.sampling_rate,
                                   dtype=float)
-        rho = elephant.signal_processing.pairwise_cross_correlation(
+        rho = elephant.signal_processing.cross_correlation_function(
             signal, [0, 1])
         # Cross-correlation of sine and cosine should be sine + phi
         assert_array_almost_equal(
@@ -102,7 +102,7 @@ class PairwiseCrossCorrelationTest(unittest.TestCase):
         signal = neo.AnalogSignal(signal, units='mV', t_start=0.*pq.ms,
                                   sampling_rate=self.sampling_rate,
                                   dtype=float)
-        envelope = elephant.signal_processing.pairwise_cross_correlation(
+        envelope = elephant.signal_processing.cross_correlation_function(
             signal, [0, 1], nlags=nlags, env=True)
         # Envelope should be one for sinusoidal function
         assert_array_almost_equal(envelope, np.ones_like(envelope), decimal=2)
@@ -112,10 +112,10 @@ class PairwiseCrossCorrelationTest(unittest.TestCase):
                        np.cos(2. * np.pi * self.freq * self.times)] * pq.mV
         signal = neo.AnalogSignal(signal, t_start=0. * pq.ms,
                                   sampling_rate=self.sampling_rate)
-        raw = elephant.signal_processing.pairwise_cross_correlation(
+        raw = elephant.signal_processing.cross_correlation_function(
             signal, [0, 1], scaleopt='none'
         )
-        biased = elephant.signal_processing.pairwise_cross_correlation(
+        biased = elephant.signal_processing.cross_correlation_function(
             signal, [0, 1], scaleopt='biased'
         )
         assert_array_almost_equal(biased, raw / biased.shape[0])
@@ -125,7 +125,7 @@ class PairwiseCrossCorrelationTest(unittest.TestCase):
                        np.cos(2. * np.pi * self.freq * self.times)] * pq.mV
         signal = neo.AnalogSignal(signal, t_start=0. * pq.ms,
                                   sampling_rate=self.sampling_rate)
-        normalized = elephant.signal_processing.pairwise_cross_correlation(
+        normalized = elephant.signal_processing.cross_correlation_function(
             signal, [0, 1], scaleopt='coeff'
         )
         sig1, sig2 = signal.magnitude.T
@@ -142,7 +142,7 @@ class PairwiseCrossCorrelationTest(unittest.TestCase):
         signal = signal[:, np.newaxis] * pq.mV
         signal = neo.AnalogSignal(signal, t_start=0. * pq.ms,
                                   sampling_rate=self.sampling_rate)
-        normalized = elephant.signal_processing.pairwise_cross_correlation(
+        normalized = elephant.signal_processing.cross_correlation_function(
             signal, [0, 0], scaleopt='coeff'
         )
         # auto-correlation at zero lag should equal 1

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -128,12 +128,12 @@ class PairwiseCrossCorrelationTest(unittest.TestCase):
         normalized = elephant.signal_processing.pairwise_cross_correlation(
             signal, [0, 1], scaleopt='coeff'
         )
-        sig1, sig2 = signal.T
+        sig1, sig2 = signal.magnitude.T
         target_numpy = np.correlate(sig1, sig2, mode="same")
         target_numpy /= np.sqrt((sig1 ** 2).sum() * (sig2 ** 2).sum())
         target_numpy = np.expand_dims(target_numpy, axis=1)
         assert_array_almost_equal(normalized.magnitude,
-                                  target_numpy.magnitude,
+                                  target_numpy,
                                   decimal=3)
 
     def test_cross_correlation_coeff_autocorr(self):


### PR DESCRIPTION
Fixes #265 

1. Renamed `cross_correlation_function()` -> `pairwise_cross_correlation()`.
2. Previously, `cross_correlation_function()` calculated the unbiased estimate. Now I added the flag `scaleopt` to be equivalent with matlab `xcorr()`. Default is `ubiased`.