### PR TITLE
deprecation: pandas bridge will be removed

### DIFF
--- a/elephant/pandas_bridge.py
+++ b/elephant/pandas_bridge.py
@@ -10,10 +10,16 @@ from __future__ import division, print_function, unicode_literals
 
 import numpy as np
 import pandas as pd
+import warnings
 import quantities as pq
 
 from elephant.neo_tools import (extract_neo_attrs, get_all_epochs,
                                 get_all_events, get_all_spiketrains)
+
+
+warnings.simplefilter('once', DeprecationWarning)
+warnings.warn("pandas_bridge module will be removed in Elephant v0.7.x",
+              DeprecationWarning)
 
 
 def _multiindex_from_dict(inds):

--- a/elephant/pandas_bridge.py
+++ b/elephant/pandas_bridge.py
@@ -18,7 +18,7 @@ from elephant.neo_tools import (extract_neo_attrs, get_all_epochs,
 
 
 warnings.simplefilter('once', DeprecationWarning)
-warnings.warn("pandas_bridge module will be removed in Elephant v0.7.x",
+warnings.warn("pandas_bridge module will be removed in Elephant v0.8.x",
               DeprecationWarning)
 
 


### PR DESCRIPTION
pandas_bridge module will be removed in Elephant v0.8.x
since nobody I've talked to so far has been using pandas bridge + it misses documentation + it's not used at all in Elephant + ... it's convoluted.