### PR TITLE
[spectral] replaced _welch() by scipy.signal.welch()

### DIFF
--- a/elephant/spectral.py
+++ b/elephant/spectral.py
@@ -422,10 +422,7 @@ def welch_cohere(x, y, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
     _, Pxy = scipy.signal.csd(xdata, ydata, **params)
 
     coherency = np.abs(Pxy) ** 2 / (Pxx * Pyy)
-
-    # conjugate is taken to follow the old behavior of _welch() function
-    # that was a copy-paste of scipy v0.16.0
-    phase_lag = np.angle(Pxy.conj())
+    phase_lag = np.angle(Pxy)
 
     # attach proper units to return values
     if isinstance(x, pq.quantity.Quantity):

--- a/elephant/spectral.py
+++ b/elephant/spectral.py
@@ -9,219 +9,10 @@ spectrum).
 
 from __future__ import division, print_function, unicode_literals
 
-import warnings
-
-import numpy as np
-import scipy.signal
-import scipy.fftpack as fftpack
-import scipy.signal.signaltools as signaltools
-from scipy.signal.windows import get_window
-from six import string_types
-import quantities as pq
 import neo
-
-
-def _welch(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
-           nfft=None, detrend='constant', scaling='density', axis=-1):
-    """
-    A helper function to estimate cross spectral density using Welch's method.
-
-    Welch's method [1]_ computes an estimate of the cross spectral density
-    by dividing the data into overlapping segments, computing a modified
-    periodogram for each segment and averaging the cross-periodograms.
-
-    Parameters
-    ----------
-    x : list or tuple or np.ndarray
-        Time series of measurement values for the first signal.
-        It will be converted to `np.ndarray`.
-    y : list or tuple or np.ndarray
-        Time series of measurement values for the second signal.
-        It will be converted to `np.ndarray`.
-    fs : float, optional
-        Sampling frequency of the `x` and `y` time series in units of Hz.
-        Default: 1.0.
-    window : str or tuple or np.ndarray, optional
-        Desired window to use.
-        If `window` is a string, see `scipy.signal.get_window` for a list of
-        windows and required parameters.
-        If `window` is tuple or `np.ndarray`, it will be used directly as the
-        window, and its length will be used for `nperseg`. If not string,
-        it will be treated as `np.ndarray`, and the result must be a vector
-        with length less than or equal to the length of the last axes of `x`
-        and `y`.
-        Default: 'hanning'.
-    nperseg : int, optional
-        Length of each segment.
-        Default: 256.
-    noverlap : int, optional
-        Number of points to overlap between segments.
-        If None, `noverlap` will be set to `nperseg`/2.
-        Default: None.
-    nfft : int, optional
-        Length of the FFT used, if a zero-padded FFT is desired.
-        If None, the FFT length is `nperseg`.
-        Default: None.
-    detrend : str or function, optional
-        Specifies how to detrend each segment.
-        If `detrend` is a string, it is passed as the `type` argument to
-        `scipy.signal.detrend`.
-        If it is a function, it takes a segment as input and returns a
-        detrended segment.
-        Default: 'constant'.
-    scaling : {'density', 'spectrum'}, optional
-        If 'density', computes the power spectral density where Pxx has units
-        of V**2/Hz if `x` is measured in V.
-        If 'spectrum', computes the power spectrum where Pxx has units of V**2
-        if `x` is measured in V.
-        Default: 'density'.
-    axis : int, optional
-        Axis along which the periodogram is computed.
-        Default: last axis (-1).
-
-    Returns
-    -------
-    f : np.ndarray
-        Array of sample frequencies.
-    Pxy : np.ndarray
-        Cross spectral density or cross spectrum of `x` and `y`.
-
-    Raises
-    ------
-    ValueError
-        If `x` and `y` do not have the same shape.
-
-        If `window` is tuple or `np.ndarray` and has more than 1 dimension.
-
-        If length of `window` is greater than the length of the `axis`.
-
-        If `scaling` is neither 'density' nor 'spectrum'.
-
-        If `noverlap` is greater than or equal to `nperseg`.
-
-        If `nfft` is less than `nperseg`.
-
-    Warns
-    -----
-    UserWarning
-        If `nperseg` is greater than the shape of the axis used (`axis`),
-        `nperseg` will be changed to the shape of `axis`.
-
-    Notes
-    -----
-    1. This function is a slightly modified version of `scipy.signal.welch`
-       function, with modifications based on
-       `matplotlib.mlab._spectral_helper`.
-    2. An appropriate amount of overlap will depend on the choice of window
-       and on your requirements. For the default 'hanning' window, an overlap
-       of 50% is a reasonable trade off between accurately estimating
-       the signal power, while not over counting any of the data. Narrower
-       windows may require a larger overlap.
-    3. If `noverlap` is 0, this method is equivalent to Bartlett's method
-       [2]_.
-
-    References
-    ----------
-    .. [1] P. Welch, "The use of the fast Fourier transform for the
-           estimation of power spectra: A method based on time averaging
-           over short, modified periodograms", IEEE Trans. Audio
-           Electroacoust., vol. 15, pp. 70-73, 1967.
-    .. [2] M.S. Bartlett, "Periodogram Analysis and Continuous Spectra",
-           Biometrika, vol. 37, pp. 1-16, 1950.
-    """
-    # TODO: This function should be replaced by `scipy.signal.csd()`, which
-    # will appear in SciPy 0.16.0.
-
-    # The checks for if y is x are so that we can use the same function to
-    # obtain both power spectrum and cross spectrum without doing extra
-    # calculations.
-    same_data = y is x
-    # Make sure we're dealing with a numpy array. If y and x were the same
-    # object to start with, keep them that way
-    x = np.asarray(x)
-    if same_data:
-        y = x
-    else:
-        if x.shape != y.shape:
-            raise ValueError("x and y must be of the same shape.")
-        y = np.asarray(y)
-
-    if x.size == 0:
-        return np.empty(x.shape), np.empty(x.shape)
-
-    if axis != -1:
-        x = np.rollaxis(x, axis, len(x.shape))
-        if not same_data:
-            y = np.rollaxis(y, axis, len(y.shape))
-
-    if x.shape[-1] < nperseg:
-        warnings.warn('nperseg = %d, is greater than x.shape[%d] = %d, using '
-                      'nperseg = x.shape[%d]'
-                      % (nperseg, axis, x.shape[axis], axis))
-        nperseg = x.shape[-1]
-
-    if isinstance(window, string_types) or type(window) is tuple:
-        win = get_window(window, nperseg)
-    else:
-        win = np.asarray(window)
-        if len(win.shape) != 1:
-            raise ValueError('window must be 1-D')
-        if win.shape[0] > x.shape[-1]:
-            raise ValueError('window is longer than x.')
-        nperseg = win.shape[0]
-
-    if scaling == 'density':
-        scale = 1.0 / (fs * (win * win).sum())
-    elif scaling == 'spectrum':
-        scale = 1.0 / win.sum()**2
-    else:
-        raise ValueError('Unknown scaling: %r' % scaling)
-
-    if noverlap is None:
-        noverlap = nperseg // 2
-    elif noverlap >= nperseg:
-        raise ValueError('noverlap must be less than nperseg.')
-
-    if nfft is None:
-        nfft = nperseg
-    elif nfft < nperseg:
-        raise ValueError('nfft must be greater than or equal to nperseg.')
-
-    if not hasattr(detrend, '__call__'):
-        detrend_func = lambda seg: signaltools.detrend(seg, type=detrend)
-    elif axis != -1:
-        # Wrap this function so that it receives a shape that it could
-        # reasonably expect to receive.
-        def detrend_func(seg):
-            seg = np.rollaxis(seg, -1, axis)
-            seg = detrend(seg)
-            return np.rollaxis(seg, axis, len(seg.shape))
-    else:
-        detrend_func = detrend
-
-    step = nperseg - noverlap
-    indices = np.arange(0, x.shape[-1] - nperseg + 1, step)
-
-    for k, ind in enumerate(indices):
-        x_dt = detrend_func(x[..., ind:ind + nperseg])
-        xft = fftpack.fft(x_dt * win, nfft)
-        if same_data:
-            yft = xft
-        else:
-            y_dt = detrend_func(y[..., ind:ind + nperseg])
-            yft = fftpack.fft(y_dt * win, nfft)
-        if k == 0:
-            Pxy = (xft * yft.conj())
-        else:
-            Pxy *= k / (k + 1.0)
-            Pxy += (xft * yft.conj()) / (k + 1.0)
-    Pxy *= scale
-    f = fftpack.fftfreq(nfft, 1.0 / fs)
-
-    if axis != -1:
-        Pxy = np.rollaxis(Pxy, -1, axis)
-
-    return f, Pxy
+import numpy as np
+import quantities as pq
+import scipy.signal
 
 
 def welch_psd(signal, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
@@ -572,8 +363,7 @@ def welch_cohere(x, y, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
 
     """
 
-    # initialize a parameter dict (to be given to _welch()) with
-    # the parameters directly passed on to _welch()
+    # initialize a parameter dict for scipy.signal.csd()
     params = {'window': window, 'nfft': nfft,
               'detrend': detrend, 'scaling': scaling, 'axis': axis}
 
@@ -627,11 +417,15 @@ def welch_cohere(x, y, num_seg=8, len_seg=None, freq_res=None, overlap=0.5,
     params['nperseg'] = nperseg
     params['noverlap'] = int(nperseg * overlap)
 
-    freqs, Pxy = _welch(xdata, ydata, **params)
-    freqs, Pxx = _welch(xdata, xdata, **params)
-    freqs, Pyy = _welch(ydata, ydata, **params)
-    coherency = np.abs(Pxy)**2 / (np.abs(Pxx) * np.abs(Pyy))
-    phase_lag = np.angle(Pxy)
+    freqs, Pxx = scipy.signal.welch(xdata, **params)
+    _, Pyy = scipy.signal.welch(ydata, **params)
+    _, Pxy = scipy.signal.csd(xdata, ydata, **params)
+
+    coherency = np.abs(Pxy) ** 2 / (Pxx * Pyy)
+
+    # conjugate is taken to follow the old behavior of _welch() function
+    # that was a copy-paste of scipy v0.16.0
+    phase_lag = np.angle(Pxy.conj())
 
     # attach proper units to return values
     if isinstance(x, pq.quantity.Quantity):

--- a/elephant/test/test_spectral.py
+++ b/elephant/test/test_spectral.py
@@ -12,6 +12,7 @@ import numpy as np
 import scipy.signal as spsig
 import quantities as pq
 import neo.core as n
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 import elephant.spectral
 
@@ -210,9 +211,9 @@ class WelchCohereTestCase(unittest.TestCase):
         freqs_np, coherency_np, phase_lag_np =\
             elephant.spectral.welch_cohere(x.magnitude.flatten(), y.magnitude.flatten(),
                 fs=1/sampling_period, freq_res=freq_res)
-        self.assertTrue((freqs == freqs_np).all() and
-                        (coherency[:, 0] == coherency_np).all() and
-                        (phase_lag[:, 0] == phase_lag_np).all())
+        assert_array_almost_equal(freqs.simplified.magnitude, freqs_np)
+        assert_array_almost_equal(coherency[:, 0], coherency_np)
+        assert_array_almost_equal(phase_lag[:, 0], phase_lag_np)
 
         # - check the behavior of parameter `axis` using multidimensional data
         num_channel = 4
@@ -223,9 +224,9 @@ class WelchCohereTestCase(unittest.TestCase):
             elephant.spectral.welch_cohere(x_multidim, y_multidim)
         freqs_T, coherency_T, phase_lag_T =\
             elephant.spectral.welch_cohere(x_multidim.T, y_multidim.T, axis=0)
-        self.assertTrue(np.all(freqs==freqs_T))
-        self.assertTrue(np.all(coherency==coherency_T.T))
-        self.assertTrue(np.all(phase_lag==phase_lag_T.T))
+        assert_array_almost_equal(freqs, freqs_T)
+        assert_array_almost_equal(coherency, coherency_T.T)
+        assert_array_almost_equal(phase_lag, phase_lag_T.T)
 
     def test_welch_cohere_input_types(self):
         # generate a test data

--- a/elephant/test/test_spectral.py
+++ b/elephant/test/test_spectral.py
@@ -206,7 +206,7 @@ class WelchCohereTestCase(unittest.TestCase):
         self.assertAlmostEqual(freq_res, freqs[1]-freqs[0])
         self.assertAlmostEqual(freqs[coherency.argmax()], signal_freq,
             places=2)
-        self.assertAlmostEqual(phase_lag[coherency.argmax()], np.pi/2,
+        self.assertAlmostEqual(phase_lag[coherency.argmax()], -np.pi/2,
             places=2)
         freqs_np, coherency_np, phase_lag_np =\
             elephant.spectral.welch_cohere(x.magnitude.flatten(), y.magnitude.flatten(),
@@ -224,9 +224,9 @@ class WelchCohereTestCase(unittest.TestCase):
             elephant.spectral.welch_cohere(x_multidim, y_multidim)
         freqs_T, coherency_T, phase_lag_T =\
             elephant.spectral.welch_cohere(x_multidim.T, y_multidim.T, axis=0)
-        assert_array_almost_equal(freqs, freqs_T)
-        assert_array_almost_equal(coherency, coherency_T.T)
-        assert_array_almost_equal(phase_lag, phase_lag_T.T)
+        assert_array_equal(freqs, freqs_T)
+        assert_array_equal(coherency, coherency_T.T)
+        assert_array_equal(phase_lag, phase_lag_T.T)
 
     def test_welch_cohere_input_types(self):
         # generate a test data

--- a/elephant/test/test_spectral.py
+++ b/elephant/test/test_spectral.py
@@ -211,9 +211,9 @@ class WelchCohereTestCase(unittest.TestCase):
         freqs_np, coherency_np, phase_lag_np =\
             elephant.spectral.welch_cohere(x.magnitude.flatten(), y.magnitude.flatten(),
                 fs=1/sampling_period, freq_res=freq_res)
-        assert_array_almost_equal(freqs.simplified.magnitude, freqs_np)
-        assert_array_almost_equal(coherency[:, 0], coherency_np)
-        assert_array_almost_equal(phase_lag[:, 0], phase_lag_np)
+        assert_array_equal(freqs.simplified.magnitude, freqs_np)
+        assert_array_equal(coherency[:, 0], coherency_np)
+        assert_array_equal(phase_lag[:, 0], phase_lag_np)
 
         # - check the behavior of parameter `axis` using multidimensional data
         num_channel = 4


### PR DESCRIPTION
Fixed the TODO which says

"This function (`_welch()`) should be replaced by `scipy.signal.csd()`, which will appear in SciPy 0.16.0."

1. Now it returns onesided fft array instead of two-sided (old behavior)
2. the phase is inverted - a conjugate transform to what was before. but both ways are "correct" and we decided to stick to the current scipy way of defining the phase