### PR TITLE
Account for Rounding Errors when Binning Spike Trains

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -833,6 +833,7 @@ class BinnedSpikeTrain(object):
         --------
         >>> import elephant.conversion as conv
         >>> import neo as n
+        >>> import quantities as pq
         >>> a = n.SpikeTrain([0.5, 0.7, 1.2, 3.1, 4.3, 5.5, 6.7] * pq.s,
         ...                  t_stop=10.0 * pq.s)
         >>> x = conv.BinnedSpikeTrain(a, num_bins=10, binsize=1 * pq.s,

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -173,12 +173,14 @@ def binarize(spiketrain, sampling_rate=None, t_start=None, t_stop=None,
 ###########################################################################
 
 
-def _detect_rounding_errors(values, tolerance=1e-8):
+def _detect_rounding_errors(values, tolerance):
     """
     Finds rounding errors in values that will be cast to int afterwards.
     Returns True for values that are within tolerance of the next integer.
     Works for both scalars and numpy arrays.
     """
+    if tolerance is None:
+        return np.zeros_like(values, dtype=bool)
     return 1 - (values % 1) <= tolerance
 
 
@@ -232,7 +234,7 @@ def _calc_tstop(num_bins, binsize, t_start):
         return t_start.rescale(binsize.units) + num_bins * binsize
 
 
-def _calc_num_bins(binsize, t_start, t_stop):
+def _calc_num_bins(binsize, t_start, t_stop, tolerance):
     """
     Calculates the number of bins from given parameters.
 
@@ -247,6 +249,9 @@ def _calc_num_bins(binsize, t_start, t_stop):
         Start time
     t_stop : pq.Quantity
         Stop time
+    tolerance : float
+        tolerance for detection of rounding errors before casting
+        the resulting num_bins to integer
 
     Returns
     -------
@@ -265,7 +270,11 @@ def _calc_num_bins(binsize, t_start, t_stop):
                              % (t_stop, t_start))
         num_bins = ((t_stop - t_start).rescale(
                         binsize.units) / binsize.magnitude).item()
-        if _detect_rounding_errors(num_bins):
+        if _detect_rounding_errors(num_bins, tolerance):
+            warnings.warn('Correcting a rounding error in the calculation '
+                          'of num_bins by increasing num_bins by 1. '
+                          'You can set tolerance=None to disable this '
+                          'behaviour.')
             num_bins += 1
         return int(num_bins)
 
@@ -363,6 +372,12 @@ class BinnedSpikeTrain(object):
     entries contain the number of spikes that occurred in the given bin of the
     given spike train.
 
+    Note that with most common parameter combinations spike times can end up
+    on bin edges. This makes the binning susceptible to rounding errors which
+    is accounted for by moving spikes which are within tolerance of the next
+    bin edge into the following bin. This can be adjusted using the tolerance
+    parameter and turned off by setting `tolerance=None`.
+
     Parameters
     ----------
     spiketrains : neo.SpikeTrain or list of neo.SpikeTrain or np.ndarray
@@ -379,6 +394,10 @@ class BinnedSpikeTrain(object):
     t_stop : pq.Quantity, optional
         Time of the right edge of the last bin (right extreme; excluded).
         Default: None
+    tolerance : float, optional
+        Tolerance for rounding errors in the binning process and in the input
+        data
+        Default: 1e-8
 
     Raises
     ------
@@ -427,7 +446,7 @@ class BinnedSpikeTrain(object):
     """
 
     def __init__(self, spiketrains, binsize=None, num_bins=None, t_start=None,
-                 t_stop=None):
+                 t_stop=None, tolerance=1e-8):
         """
         Defines a BinnedSpikeTrain class
 
@@ -445,11 +464,12 @@ class BinnedSpikeTrain(object):
 
         # Link to input
         self.lst_input = spiketrains
-        # Set given parameter
+        # Set given parameters
         self.t_start = t_start
         self.t_stop = t_stop
         self.num_bins = num_bins
         self.binsize = binsize
+        self.tolerance = tolerance
         # Empty matrix for storage, time points matrix
         self._mat_u = None
         # Variables to store the sparse matrix
@@ -524,7 +544,8 @@ class BinnedSpikeTrain(object):
         elif t_stop is None:
             self.t_stop = _calc_tstop(num_bins, binsize, t_start)
         elif num_bins is None:
-            self.num_bins = _calc_num_bins(binsize, t_start, t_stop)
+            self.num_bins = _calc_num_bins(binsize, t_start, t_stop,
+                                           self.tolerance)
         elif binsize is None:
             self.binsize = _calc_binsize(num_bins, t_start, t_stop)
 
@@ -936,7 +957,15 @@ class BinnedSpikeTrain(object):
 
             # shift spikes that are very close
             # to the right edge into the next bin
-            scale[_detect_rounding_errors(scale)] += .5
+            rounding_error_indices = _detect_rounding_errors(scale,
+                                                             self.tolerance)
+            num_rounding_corrections = rounding_error_indices.sum()
+            if num_rounding_corrections > 0:
+                warnings.warn('Correcting {} rounding errors by shifting '
+                              'the affected spikes into the following bin. '
+                              'You can set tolerance=None to disable this '
+                              'behaviour.'.format(num_rounding_corrections))
+            scale[rounding_error_indices] += .5
 
             scale = scale.astype(int)
 

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -196,6 +196,7 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
         self.spiketrain_b = neo.SpikeTrain(
             [0.1, 0.7, 1.2, 2.2, 4.3, 5.5, 8.0] * pq.s, t_stop=10.0 * pq.s)
         self.binsize = 1 * pq.s
+        self.tolerance = 1e-8
 
     def test_get_num_of_spikes(self):
         spiketrains = [self.spiketrain_a, self.spiketrain_b]
@@ -452,8 +453,10 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
                           t_start=0 * pq.s, t_stop=0 * pq.s)
 
     def test_calc_attributes_error(self):
-        self.assertRaises(ValueError, cv._calc_num_bins, 1, 1 * pq.s, 0 * pq.s)
-        self.assertRaises(ValueError, cv._calc_binsize, 1, 1 * pq.s, 0 * pq.s)
+        self.assertRaises(ValueError, cv._calc_num_bins,
+                          1, 1 * pq.s, 0 * pq.s, self.tolerance)
+        self.assertRaises(ValueError, cv._calc_binsize,
+                          1, 1 * pq.s, 0 * pq.s)
 
     def test_different_input_types(self):
         a = self.spiketrain_a
@@ -623,12 +626,14 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
         self.assertAlmostEqual(bst.sparsity, 0.1)
 
     # Test fix for rounding errors
+    @unittest.skipUnless(python_version_major == 3, "assertWarns requires 3.2")
     def test_binned_spiketrain_rounding(self):
         train = neo.SpikeTrain(times=np.arange(120000) / 30000. * pq.s,
                                t_start=0*pq.s, t_stop=4*pq.s)
-        bst = cv.BinnedSpikeTrain(train,
-                                  t_start=0*pq.s, t_stop=4*pq.s,
-                                  binsize=1./30000.*pq.s)
+        with self.assertWarns(UserWarning):
+            bst = cv.BinnedSpikeTrain(train,
+                                      t_start=0*pq.s, t_stop=4*pq.s,
+                                      binsize=1./30000.*pq.s)
         assert_array_equal(bst.to_array().nonzero()[1],
                            np.arange(120000))
 

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -403,7 +403,8 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
         # Test storing of sparse mat
         sparse_bool = x_bool.to_sparse_bool_array()
         self.assertTrue(np.array_equal(
-            sparse_bool.toarray(), x_bool.to_sparse_bool_array().toarray()))
+            sparse_bool.toarray(),
+            x_bool.to_sparse_bool_array().toarray()))
 
         # New class without calculating the matrix
         x = cv.BinnedSpikeTrain(b, binsize=pq.s, t_start=0 * pq.s,


### PR DESCRIPTION
To revive the conversation in #196 I implemented the fix I suggested in https://github.com/NeuralEnsemble/elephant/issues/196#issuecomment-559087606

I keep running into this issue and I know of multiple other people who currently have to use local hacks to circumvent this.

What do you think @mdenker @dizcza ?