### PR TITLE
Skip filter_for_moving_window_subsets for winlen=1

### DIFF
--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -957,6 +957,10 @@ def _filter_for_moving_window_subsets(concepts, winlen):
     if len(concepts) == 0:
         return concepts
 
+    # don't do anything if winlen is one
+    if winlen == 1:
+        return concepts
+
     if hasattr(concepts[0], 'intent'):
         # fca format
         # sort the concepts by (decreasing) support


### PR DESCRIPTION
As the name suggests this function discards patterns that are trivially explained by larger patterns but do not have the same signature due to the way the input for FIM is created for moving window analyses. However, there are no such patterns for `winlen = 1` since that case simply corresponds to individual bins, not moving windows, so there cannot be trivial subsets with different signatures.

So, in short, this filter does not do anything when looking for synchronous patterns, however it can take a considerable amount of time if a lot of patterns are found. Skipping it should result in a decent speed-up.