### PR TITLE
Timescale function option to return nan if there are few spikes (<=2)

### DIFF
--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -952,7 +952,7 @@ def spike_train_timescale(binned_st, tau_max):
         Physical Review E, 92(4), 040901.
     """
     if binned_st.get_num_of_spikes() < 2:
-        warnings.warn("Spike train contains less than 2 spikes! ",
+        warnings.warn("Spike train contains less than 2 spikes! "
                       "np.nan will be returned.")
         return np.nan
 

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -952,6 +952,8 @@ def spike_train_timescale(binned_st, tau_max):
         Physical Review E, 92(4), 040901.
     """
     if binned_st.get_num_of_spikes() < 2:
+        warnings.warn("Spike train contains less than 2 spikes! ",
+                      "np.nan will be returned.")
         return np.nan
 
     binsize = binned_st.binsize

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -906,7 +906,7 @@ def spike_time_tiling_coefficient(spiketrain_1, spiketrain_2, dt=0.005 * pq.s):
 sttc = spike_time_tiling_coefficient
 
 
-def spike_train_timescale(binned_st, tau_max):
+def spike_train_timescale(binned_st, tau_max, with_nan=False):
     r"""
     Calculates the auto-correlation time of a binned spike train.
     Uses the definition of the auto-correlation time proposed in [[1]_,
@@ -925,6 +925,9 @@ def spike_train_timescale(binned_st, tau_max):
         A binned spike train containing the spike train to be evaluated.
     tau_max : pq.Quantity
         Maximal integration time of the auto-correlation function.
+    with_nan : bool
+        If True returns NaN for spike trains with 2 or less spikes.
+        Default: False
 
     Returns
     -------
@@ -951,13 +954,16 @@ def spike_train_timescale(binned_st, tau_max):
     """
     binsize = binned_st.binsize
     if not (tau_max / binsize).simplified.units == pq.dimensionless:
-        raise AssertionError("tau_max needs units of time")
+        raise ValueError("tau_max needs units of time")
 
     # safe casting of tau_max/binsize to integer
     tau_max_bins = int(np.round((tau_max / binsize).simplified.magnitude))
     if not np.isclose(tau_max.simplified.magnitude,
                       (tau_max_bins * binsize).simplified.magnitude):
-        raise AssertionError("tau_max has to be a multiple of the binsize")
+        raise ValueError("tau_max has to be a multiple of the binsize")
+
+    if len(np.where(binned_st.to_array())[1]) <= 2 and with_nan:
+        return np.nan
 
     cch_window = [-tau_max_bins, tau_max_bins]
     corrfct, bin_ids = cross_correlation_histogram(

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -801,6 +801,8 @@ class SpikeTrainTimescaleTestCase(unittest.TestCase):
         self.assertRaises(ValueError,
                           sc.spike_train_timescale, spikes_bin, tau_max)
 
+    @unittest.skipUnless(python_version_major == 3,
+                         "assertWarns requires python 3.2")
     def test_timescale_nan(self):
         st0 = neo.SpikeTrain([]*pq.ms, t_stop=10*pq.ms)
         st1 = neo.SpikeTrain([1]*pq.ms, t_stop=10*pq.ms)
@@ -820,6 +822,9 @@ class SpikeTrainTimescaleTestCase(unittest.TestCase):
             bst = conv.BinnedSpikeTrain(st, binsize)
             timescale = sc.spike_train_timescale(bst, tau_max)
             self.assertFalse(math.isnan(timescale))
+
+        with self.assertWarns(UserWarning):
+            timescale = sc.spike_train_timescale(bst, tau_max)
 
 
 if __name__ == '__main__':

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -811,14 +811,14 @@ class SpikeTrainTimescaleTestCase(unittest.TestCase):
         binsize = 1 * pq.ms
         tau_max = 1 * pq.ms
 
-        for st in [st0, st1, st2]:
+        for st in [st0, st1]:
             bst = conv.BinnedSpikeTrain(st, binsize)
-            timescale = sc.spike_train_timescale(bst, tau_max, with_nan=True)
+            timescale = sc.spike_train_timescale(bst, tau_max)
             self.assertTrue(math.isnan(timescale))
 
-        for st in [st3, st4]:
+        for st in [st2, st3, st4]:
             bst = conv.BinnedSpikeTrain(st, binsize)
-            timescale = sc.spike_train_timescale(bst, tau_max, with_nan=True)
+            timescale = sc.spike_train_timescale(bst, tau_max)
             self.assertFalse(math.isnan(timescale))
 
 

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -815,16 +815,14 @@ class SpikeTrainTimescaleTestCase(unittest.TestCase):
 
         for st in [st0, st1]:
             bst = conv.BinnedSpikeTrain(st, binsize)
-            timescale = sc.spike_train_timescale(bst, tau_max)
+            with self.assertWarns(UserWarning):
+                timescale = sc.spike_train_timescale(bst, tau_max)
             self.assertTrue(math.isnan(timescale))
 
         for st in [st2, st3, st4]:
             bst = conv.BinnedSpikeTrain(st, binsize)
             timescale = sc.spike_train_timescale(bst, tau_max)
             self.assertFalse(math.isnan(timescale))
-
-        with self.assertWarns(UserWarning):
-            timescale = sc.spike_train_timescale(bst, tau_max)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hey!

I have added an option to the `spike_train_timescale` function to return nan if there are 2 or less spikes in the given spiketrains.

To this I have also added two tests:
1. Testing the error raising (which probably should have been done in the original PR)
2. Testing that indeed the nans are returned for spiketrains with 0, 1 or 2 spikes and that whatever is returned for spiketrains with 3 or 4 spikes is not a nan.

Please have a look and let me know if anything should be changed. 

Best,
Aitor