### PR TITLE
Corrected CV2 equation documentation

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -344,7 +344,7 @@ def cv2(v, with_nan=False):
     as:
 
     .. math::
-        CV2 := \frac{1}{N} \sum{i=1}^{N-1}
+        CV2 := \frac{1}{N} \sum_{i=1}^{N-1}
                            \frac{2|isi_{i+1}-isi_i|}
                           {|isi_{i+1}+isi_i|}
 


### PR DESCRIPTION
The CV2 equation in the documentation was not correct due to a missing underscore. This PR addresses the issue.