### PR TITLE
Build documentation in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - name: "conda 2.7"
       python: 2.7
       env: DISTRIB="conda"
+      before_install: sed -i 's/conda-forge/conda/g' requirements/environment.yml
 
     - name: "pip 2.7"
       python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,38 @@ addons:
 
 matrix:
   include:
+    - name: "conda 2.7"
+      python: 2.7
+      env: DISTRIB="conda"
+      before_install: sed -i 's/conda-forge/conda/g' requirements/environment.yml
+
+    - name: "pip 2.7"
+      python: 2.7
+      env: DISTRIB="pip"
+
+    - name: "pip 3.5"
+      python: 3.5
+      env: DISTRIB="pip"
+
+    - name: "pip 3.6 requirements-extras"
+      python: 3.6
+      env: DISTRIB="pip"
+      before_install: sudo apt install -y libopenmpi-dev openmpi-bin
+      before_script: pip install -r requirements/requirements-extras.txt
+      script: mpiexec -n 1 python -m mpi4py.futures -m nose --with-coverage --cover-package=elephant
+      after_success: coveralls || echo "coveralls failed"
+
+    - name: "conda 3.7"
+      python: 3.7
+      env: DISTRIB="conda"
+
+    - name: "conda 3.8"
+      python: 3.8
+      env: DISTRIB="conda"
+
+    - name: "pip 3.8"
+      python: 3.8
+      env: DISTRIB="pip"
 
     - name: "docs"
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,15 @@ matrix:
       python: 3.8
       env: DISTRIB="pip"
 
+    - name: "docs"
+      python: 3.6
+      env: DISTRIB="conda"
+      before_script:
+        - pip install -r requirements/requirements-docs.txt
+        - pip install -r requirements/requirements-tutorials.txt
+        - sed -i -E "s/nbsphinx_execute *=.*/nbsphinx_execute = 'always'/g" doc/conf.py
+      script: cd doc && make html
+
 install:
   - if [[ "${DISTRIB}" == "conda" ]];
     then

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,10 @@ matrix:
       python: 3.6
       env: DISTRIB="conda"
       before_script:
+        - conda install -c conda-forge mpi4py
         - pip install -r requirements/requirements-docs.txt
         - pip install -r requirements/requirements-tutorials.txt
+        - pip install -r requirements/requirements-extras.txt
         - sed -i -E "s/nbsphinx_execute *=.*/nbsphinx_execute = 'always'/g" doc/conf.py
       script: cd doc && make html
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,38 +9,6 @@ addons:
 
 matrix:
   include:
-    - name: "conda 2.7"
-      python: 2.7
-      env: DISTRIB="conda"
-      before_install: sed -i 's/conda-forge/conda/g' requirements/environment.yml
-
-    - name: "pip 2.7"
-      python: 2.7
-      env: DISTRIB="pip"
-
-    - name: "pip 3.5"
-      python: 3.5
-      env: DISTRIB="pip"
-
-    - name: "pip 3.6 requirements-extras"
-      python: 3.6
-      env: DISTRIB="pip"
-      before_install: sudo apt install -y libopenmpi-dev openmpi-bin
-      before_script: pip install -r requirements/requirements-extras.txt
-      script: mpiexec -n 1 python -m mpi4py.futures -m nose --with-coverage --cover-package=elephant
-      after_success: coveralls || echo "coveralls failed"
-
-    - name: "conda 3.7"
-      python: 3.7
-      env: DISTRIB="conda"
-
-    - name: "conda 3.8"
-      python: 3.8
-      env: DISTRIB="conda"
-
-    - name: "pip 3.8"
-      python: 3.8
-      env: DISTRIB="pip"
 
     - name: "docs"
       python: 3.6
@@ -50,7 +18,6 @@ matrix:
         - pip install -r requirements/requirements-docs.txt
         - pip install -r requirements/requirements-tutorials.txt
         - pip install -r requirements/requirements-extras.txt
-        - sed -i -E "s/nbsphinx_execute *=.*/nbsphinx_execute = 'always'/g" doc/conf.py
       script: cd doc && make html
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,13 @@ matrix:
     - name: "docs"
       python: 3.6
       env: DISTRIB="conda"
+      before_install: sudo apt install -y libopenmpi-dev openmpi-bin
       before_script:
-        - conda install -c conda-forge mpi4py pandoc
+        - conda install -c conda-forge pandoc
         - pip install -r requirements/requirements-docs.txt
         - pip install -r requirements/requirements-tutorials.txt
         - pip install -r requirements/requirements-extras.txt
+        - sed -i -E "s/nbsphinx_execute *=.*/nbsphinx_execute = 'always'/g" doc/conf.py
       script: cd doc && make html
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       python: 3.6
       env: DISTRIB="conda"
       before_script:
-        - conda install -c conda-forge mpi4py
+        - conda install -c conda-forge mpi4py pandoc
         - pip install -r requirements/requirements-docs.txt
         - pip install -r requirements/requirements-tutorials.txt
         - pip install -r requirements/requirements-extras.txt

--- a/doc/tutorials/asset.ipynb
+++ b/doc/tutorials/asset.ipynb
@@ -134,7 +134,7 @@
    ],
    "source": [
     "plt.figure()\n",
-    "plt.eventplot(spiketrains, linewidths=5, linelengths=5)\n",
+    "plt.eventplot([st.magnitude for st in spiketrains], linewidths=5, linelengths=5)\n",
     "plt.xlabel('time [ms]')\n",
     "plt.ylabel('neuron id')\n",
     "plt.title('Raw spikes')\n",
@@ -800,7 +800,7 @@
    ],
    "source": [
     "plt.figure()\n",
-    "plt.eventplot(reordered_sts, linewidths=5, linelengths=5)\n",
+    "plt.eventplot([st.magnitude for st in reordered_sts], linewidths=5, linelengths=5)\n",
     "plt.xlabel('time [ms]')\n",
     "plt.ylabel('reordered neuron id')\n",
     "plt.title('Reconstructed ordering of the neurons (y-axis) with synfire chains');"
@@ -839,7 +839,7 @@
     "spiketrains_ordered = [spiketrains[idx] for idx in ordering_true]\n",
     "\n",
     "plt.figure()\n",
-    "plt.eventplot(spiketrains_ordered, linewidths=5, linelengths=5)\n",
+    "plt.eventplot([st.magnitude for st in spiketrains_ordered], linewidths=5, linelengths=5)\n",
     "plt.xlabel('time [ms]')\n",
     "plt.ylabel('neuron id')\n",
     "plt.title('True (unknown) ordering of the neurons (y-axis)')\n",

--- a/doc/tutorials/gpfa.ipynb
+++ b/doc/tutorials/gpfa.ipynb
@@ -940,6 +940,9 @@
   }
  ],
  "metadata": {
+   "nbsphinx": {
+    "execute": "never"
+  },
   "anaconda-cloud": {},
   "kernelspec": {
    "display_name": "Python 3",

--- a/doc/tutorials/parallel.ipynb
+++ b/doc/tutorials/parallel.ipynb
@@ -77,27 +77,6 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "Exception",
-     "evalue": "You shall not pass!",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-5eb51fb926d2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"You shall not pass!\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mException\u001b[0m: You shall not pass!"
-     ]
-    }
-   ],
-   "source": [
-    "raise Exception(\"You shall not pass!\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
    "outputs": [],
    "source": [
     "rate = 10 * pq.Hz\n",
@@ -428,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/parallel.ipynb
+++ b/doc/tutorials/parallel.ipynb
@@ -77,6 +77,27 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
+   "outputs": [
+    {
+     "ename": "Exception",
+     "evalue": "You shall not pass!",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-5eb51fb926d2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"You shall not pass!\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mException\u001b[0m: You shall not pass!"
+     ]
+    }
+   ],
+   "source": [
+    "raise Exception(\"You shall not pass!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [],
    "source": [
     "rate = 10 * pq.Hz\n",
@@ -407,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/parallel.ipynb
+++ b/doc/tutorials/parallel.ipynb
@@ -10,6 +10,7 @@
     "\n",
     "`elephant.parallel` module provides a simple interface to parallelize multiple calls to any user-specified function. The typical use case is calling a function many times with different parameters.\n",
     "\n",
+    "\n",
     "## Available executors\n",
     "\n",
     "`elephant.parallel` has 3 interfaces to choose from, depending whether the user has a laptop/PC or the computation is being done on a cluster machine with many nodes and MPI installed.\n",
@@ -22,6 +23,7 @@
     "\n",
     "All listed above classes have the same API and can be used interchangeably.\n",
     "\n",
+    "\n",
     "## How to use\n",
     "\n",
     "Let's say you want to call some function `my_function()` for each element in a list `iterables_list` like so:\n",
@@ -32,7 +34,11 @@
     "\n",
     "(eq. 2) `results = Executor().execute(my_function, iterables_list)`,\n",
     "\n",
-    "where `Executor` can be any of the available executors listed above. For more information about parallel executors in Python refer to https://docs.python.org/3/library/concurrent.futures.html."
+    "where `Executor` can be any of the available executors listed above. For more information about parallel executors in Python refer to https://docs.python.org/3/library/concurrent.futures.html.\n",
+    "\n",
+    "**Note**. To successfully run this notebook, `mpi4py` package should be installed in either of ways:\n",
+    "* `conda install -c conda-forge mpi4py`\n",
+    "* `pip install mpi4py`, if you have manually installed OpenMPI with `sudo apt install libopenmpi-dev openmpi-bin`\n"
    ]
   },
   {
@@ -235,7 +241,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is because both MPI executors require `-m mpi4py.futures` flag while running python scripts:\n",
+    "This is because MPI executors require `-m mpi4py.futures` flag while running python scripts:\n",
     "\n",
     "```\n",
     "mpiexec -n numprocs python -m mpi4py.futures pyfile [arg] ...\n",
@@ -282,6 +288,49 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[AnalogSignal with 1 channels of length 100; units dimensionless; datatype float64 \n",
+       " sampling rate: 10.0 1/s\n",
+       " time: 0.0 s to 10.0 s,\n",
+       " AnalogSignal with 1 channels of length 43; units dimensionless; datatype float64 \n",
+       " sampling rate: 4.375 1/s\n",
+       " time: 0.0 s to 9.82857142857143 s,\n",
+       " AnalogSignal with 1 channels of length 28; units dimensionless; datatype float64 \n",
+       " sampling rate: 2.7999999999999994 1/s\n",
+       " time: 0.0 s to 10.000000000000002 s,\n",
+       " AnalogSignal with 1 channels of length 20; units dimensionless; datatype float64 \n",
+       " sampling rate: 2.0588235294117645 1/s\n",
+       " time: 0.0 s to 9.714285714285715 s,\n",
+       " AnalogSignal with 1 channels of length 16; units dimensionless; datatype float64 \n",
+       " sampling rate: 1.627906976744186 1/s\n",
+       " time: 0.0 s to 9.82857142857143 s,\n",
+       " AnalogSignal with 1 channels of length 13; units dimensionless; datatype float64 \n",
+       " sampling rate: 1.346153846153846 1/s\n",
+       " time: 0.0 s to 9.657142857142858 s,\n",
+       " AnalogSignal with 1 channels of length 11; units dimensionless; datatype float64 \n",
+       " sampling rate: 1.1475409836065573 1/s\n",
+       " time: 0.0 s to 9.585714285714285 s,\n",
+       " AnalogSignal with 1 channels of length 10; units dimensionless; datatype float64 \n",
+       " sampling rate: 1.0 1/s\n",
+       " time: 0.0 s to 10.0 s]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "time_hist"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -294,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,14 +356,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "722 ms ± 43.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "873 ms ± 35.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -325,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -358,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/statistics.ipynb
+++ b/doc/tutorials/statistics.ipynb
@@ -154,7 +154,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(8, 3))\n",
-    "plt.eventplot([spiketrain1, spiketrain2], linelengths=0.75, color='black')\n",
+    "plt.eventplot([spiketrain1.magnitude, spiketrain2.magnitude], linelengths=0.75, color='black')\n",
     "plt.xlabel('Time (ms)', fontsize=16)\n",
     "plt.yticks([0,1], labels=[\"spiketrain1\", \"spiketrain2\"], fontsize=16)\n",
     "plt.title(\"Figure 1\");"
@@ -475,7 +475,7 @@
    "outputs": [],
    "source": [
     "plt.figure(dpi=150)\n",
-    "plt.eventplot(spiketrain_list, linelengths=0.75, linewidths=0.75, color='black')\n",
+    "plt.eventplot([st.magnitude for st in spiketrain_list], linelengths=0.75, linewidths=0.75, color='black')\n",
     "plt.xlabel(\"Time, s\")\n",
     "plt.ylabel(\"Neuron id\")\n",
     "plt.xlim([0, 1]);"

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -633,12 +633,17 @@ class BinnedSpikeTrain(object):
                 raise ValueError(
                     'too many / too large time bins. Some spike trains are '
                     'not defined in the ending time')
-        if num_bins != int((
+        # account for rounding errors in the reference num_bins
+        num_bins_test = ((
             (t_stop - t_start).rescale(
-                binsize.units) / binsize).magnitude):
+                binsize.units) / binsize).magnitude)
+        if _detect_rounding_errors(num_bins_test, tolerance=self.tolerance):
+            num_bins_test += 1
+        num_bins_test = int(num_bins_test)
+        if num_bins != num_bins_test:
             raise ValueError(
                 "Inconsistent arguments t_start (%s), " % t_start +
-                "t_stop (%s), binsize (%d) " % (t_stop, binsize) +
+                "t_stop (%s), binsize (%s) " % (t_stop, binsize) +
                 "and num_bins (%d)" % num_bins)
         if num_bins - int(num_bins) != 0 or num_bins < 0:
             raise TypeError(

--- a/postBuild
+++ b/postBuild
@@ -1,5 +1,4 @@
-pip install .[tutorials]
-
 # Install conda version of mpi4py for mybinder service
-conda install mpi4py
+conda install -c conda-forge mpi4py
 
+pip install .[tutorials]

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -1,4 +1,4 @@
-name: elephant-test
+name: elephant
 
 channels:
   - conda-forge  # required by mpi4py

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -1,4 +1,7 @@
-name: elephant
+name: elephant-test
+
+channels:
+  - conda-forge  # required by mpi4py
 
 dependencies:
   - python>=3.6
@@ -10,3 +13,5 @@ dependencies:
   - pandas
   - scikit-learn
   - statsmodels
+  - pip:
+     - -r file:requirements.txt

--- a/requirements/requirements-tutorials.txt
+++ b/requirements/requirements-tutorials.txt
@@ -1,3 +1,4 @@
 # Packages required to execute jupyter notebook tutorials
 matplotlib>=3.1.0
 h5py>=2.9.0
+nixio==1.5.0b3


### PR DESCRIPTION
This PR fixes several issues:
* BinnedSpkeTrain._check_consistency(), originally found by Alex in Aitor in #322 
* parallel.ipynb notebook did not run
* fix for matplotlib v3.3.0 `plt.eventplot(spiketrains)`
* added `pip install -r file:requirements.txt` rule in condas `environment.yml` because creating an environment with conda implies that everything is installed with one command. Previously, a user has to manually install missing requirements in a conda-created env.

To prevent further degradation, the doc build is added as another travis job. GPFA tutorial is excluded because it takes >10 min.

Travis build: https://travis-ci.org/github/NeuralEnsemble/elephant/builds/710405567