### PR TITLE
Added __all__ in elephant modules

### DIFF
--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -125,6 +125,17 @@ except ImportError:
     rank = 0
 
 
+__all__ = [
+    "ASSET",
+    "synchronous_events_intersection",
+    "synchronous_events_difference",
+    "synchronous_events_identical",
+    "synchronous_events_no_overlap",
+    "synchronous_events_contained_in",
+    "synchronous_events_contains_all",
+    "synchronous_events_overlap"
+]
+
 # =============================================================================
 # Some Utility Functions to be dealt with in some way or another
 # =============================================================================

--- a/elephant/cell_assembly_detection.py
+++ b/elephant/cell_assembly_detection.py
@@ -80,6 +80,10 @@ from scipy.stats import f
 import elephant.conversion as conv
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "cell_assembly_detection"
+]
+
 
 @deprecated_alias(data='binned_spiketrain', maxlag='max_lag',
                   min_occ='min_occurrences',

--- a/elephant/change_point_detection.py
+++ b/elephant/change_point_detection.py
@@ -53,6 +53,11 @@ import quantities as pq
 
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "multiple_filter_test",
+    "empirical_parameters"
+]
+
 
 @deprecated_alias(dt='time_step')
 def multiple_filter_test(window_sizes, spiketrain, t_final, alpha,

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -22,6 +22,11 @@ import scipy.sparse as sps
 
 from elephant.utils import is_binary, deprecated_alias
 
+__all__ = [
+    "binarize",
+    "BinnedSpikeTrain"
+]
+
 
 def binarize(spiketrain, sampling_rate=None, t_start=None, t_stop=None,
              return_times=False):

--- a/elephant/cubic.py
+++ b/elephant/cubic.py
@@ -29,6 +29,10 @@ import warnings
 
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "cubic"
+]
+
 
 # Based on matlab code by Benjamin Staude
 # Adaptation to python by Pietro Quaglio and Emiliano Torre

--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -43,9 +43,13 @@ import quantities as pq
 from scipy.integrate import simps
 
 import elephant.current_source_density_src.utility_functions as utils
-from elephant.current_source_density_src import KCSD
-from elephant.current_source_density_src import icsd
+from elephant.current_source_density_src import KCSD, icsd
 from elephant.utils import deprecated_alias
+
+__all__ = [
+    "estimate_csd",
+    "generate_lfp"
+]
 
 utils.patch_quantities()
 

--- a/elephant/gpfa/__init__.py
+++ b/elephant/gpfa/__init__.py
@@ -3,3 +3,7 @@ try:
 except ImportError:
     # please run command `pip install -r requirements-extras.txt`
     pass
+
+__all__ = [
+    "GPFA"
+]

--- a/elephant/neo_tools.py
+++ b/elephant/neo_tools.py
@@ -14,6 +14,13 @@ from itertools import chain
 from neo.core.container import unique_objs
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "extract_neo_attributes",
+    "get_all_spiketrains",
+    "get_all_events",
+    "get_all_epochs"
+]
+
 
 @deprecated_alias(obj='neo_object')
 def extract_neo_attributes(neo_object, parents=True, child_first=True,

--- a/elephant/parallel/__init__.py
+++ b/elephant/parallel/__init__.py
@@ -46,3 +46,10 @@ except ImportError:
     # mpi4py is missing
     warnings.warn("mpi4py package is missing. Please run 'pip install mpi4py' "
                   "in a terminal to activate MPI features.")
+
+__all__ = [
+    "ProcessPoolExecutor",
+    "SingleProcess",
+    "MPIPoolExecutor",
+    "MPICommExecutor"
+]

--- a/elephant/phase_analysis.py
+++ b/elephant/phase_analysis.py
@@ -11,6 +11,10 @@ from __future__ import division, print_function, unicode_literals
 import numpy as np
 import quantities as pq
 
+__all__ = [
+    "spike_triggered_phase"
+]
+
 
 def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
     """

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -16,6 +16,16 @@ import scipy.signal
 
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "zscore",
+    "cross_correlation_function",
+    "butter",
+    "wavelet_transform",
+    "hilbert",
+    "rauc",
+    "derivative"
+]
+
 
 def zscore(signal, inplace=True):
     r"""

--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -74,6 +74,16 @@ import elephant.spike_train_surrogates as surr
 from elephant.spade_src import fast_fca
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "spade",
+    "concepts_mining",
+    "pvalue_spectrum",
+    "test_signature_significance",
+    "approximate_stability",
+    "pattern_set_reduction",
+    "concept_output_to_patterns"
+]
+
 warnings.simplefilter('once', UserWarning)
 
 try:

--- a/elephant/spectral.py
+++ b/elephant/spectral.py
@@ -17,6 +17,11 @@ import scipy.signal
 
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "welch_psd",
+    "welch_coherence"
+]
+
 
 @deprecated_alias(num_seg='n_segments', len_seg='len_segment',
                   freq_res='frequency_resolution')

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -17,6 +17,14 @@ from scipy import integrate
 
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "covariance",
+    "correlation_coefficient",
+    "cross_correlation_histogram",
+    "spike_time_tiling_coefficient",
+    "spike_train_timescale"
+]
+
 # The highest sparsity of the `BinnedSpikeTrain` matrix for which
 # memory-efficient (sparse) implementation of `covariance()` is faster than
 # with the corresponding numpy dense array.

--- a/elephant/spike_train_dissimilarity.py
+++ b/elephant/spike_train_dissimilarity.py
@@ -25,6 +25,11 @@ from neo.core import SpikeTrain
 import elephant.kernels as kernels
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "victor_purpura_distance",
+    "van_rossum_distance"
+]
+
 
 def _create_matrix_from_indexed_function(
         shape, func, symmetric_2d=False, **func_params):

--- a/elephant/spike_train_generation.py
+++ b/elephant/spike_train_generation.py
@@ -22,6 +22,17 @@ import quantities as pq
 from elephant.spike_train_surrogates import dither_spike_train
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "spike_extraction",
+    "threshold_detection",
+    "peak_detection",
+    "homogeneous_poisson_process",
+    "inhomogeneous_poisson_process",
+    "homogeneous_gamma_process",
+    "single_interaction_process",
+    "compound_poisson_process"
+]
+
 
 @deprecated_alias(extr_interval='interval')
 def spike_extraction(signal, threshold=0.0 * pq.mV, sign='above',

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -56,6 +56,16 @@ from scipy.ndimage import gaussian_filter
 from elephant.statistics import isi
 from elephant.utils import deprecated_alias
 
+__all__ = [
+    "dither_spikes",
+    "randomise_spikes",
+    "shuffle_isis",
+    "dither_spike_train",
+    "jitter_spikes",
+    "JointISI",
+    "surrogates"
+]
+
 # List of all available surrogate methods
 SURR_METHODS = ['dither_spike_train', 'dither_spikes', 'jitter_spikes',
                 'randomise_spikes', 'shuffle_isis', 'joint_isi_dithering',

--- a/elephant/sta.py
+++ b/elephant/sta.py
@@ -16,6 +16,11 @@ from neo.core import AnalogSignal, SpikeTrain
 import warnings
 from .conversion import BinnedSpikeTrain
 
+__all__ = [
+    "spike_triggered_average",
+    "spike_field_coherence"
+]
+
 
 def spike_triggered_average(signal, spiketrains, window):
     """

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -77,6 +77,20 @@ from elephant.utils import deprecated_alias
 
 from elephant.utils import is_time_quantity
 
+__all__ = [
+    "isi",
+    "mean_firing_rate",
+    "fanofactor",
+    "lv",
+    "cv",
+    "cv2",
+    "instantaneous_rate",
+    "time_histogram",
+    "complexity_pdf",
+    "fftkernel",
+    "optimal_kernel_bandwidth"
+]
+
 cv = scipy.stats.variation
 
 

--- a/elephant/unitary_event_analysis.py
+++ b/elephant/unitary_event_analysis.py
@@ -64,6 +64,18 @@ import scipy
 import elephant.conversion as conv
 from elephant.utils import is_binary
 
+__all__ = [
+    "hash_from_pattern",
+    "inverse_hash_from_pattern",
+    "n_emp_mat",
+    "n_emp_mat_sum_trial",
+    "n_exp_mat",
+    "n_exp_mat_sum_trial",
+    "gen_pval_anal",
+    "jointJ",
+    "jointJ_window_analysis"
+]
+
 
 def hash_from_pattern(m, base=2):
     """

--- a/elephant/waveform_features.py
+++ b/elephant/waveform_features.py
@@ -12,6 +12,11 @@ import warnings
 
 import numpy as np
 
+__all__ = [
+    "waveform_width",
+    "waveform_snr"
+]
+
 
 def waveform_width(waveform, cutoff=0.75):
     """


### PR DESCRIPTION
Currently, `from elephant.module import *` imports all junk variables and other imports like numpy. Specifying `__all__` reduces `dir(module)` to a list of limited entries.
Initially discovered in integration with NEST Desktop. The idea is to replace `dir(module)` in [elephant-server](https://github.com/babsey/elephant-server) by `module.__all__` for user queries to get a list of available methods in a module.