### PR TITLE
Added information on citing Elephant to documentation, fixed bib entries

### DIFF
--- a/CITATION.txt
+++ b/CITATION.txt
@@ -1,0 +1,4 @@
+To refer to the Elephant software package in publications, please use 
+    Elephant (RRID:SCR_003833)
+
+To cite Elephant, please see doc/citation.rst.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ recursive-include elephant *.py
 include requirements/*
 include README.md
 include LICENSE.txt
+include CITATION.txt
 include elephant/VERSION
 include elephant/current_source_density_src/README.md
 include elephant/current_source_density_src/test_data.mat

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 spike trains, LFP, analog signals. The input-output data format is either
 [Neo](https://github.com/NeuralEnsemble/python-neo), Quantity or Numpy array.
 
+
 ### More Information
 
 * Documentation: https://elephant.readthedocs.io/en/latest/
@@ -21,10 +22,18 @@ spike trains, LFP, analog signals. The input-output data format is either
  
 Modified BSD License, see [LICENSE.txt](LICENSE.txt) for details.
 
+
 #### Copyright
 
 :copyright: 2014-2020 by the [Elephant team](doc/authors.rst).
 
+
 #### Acknowledgments
 
 See [acknowledgments](doc/acknowledgments.rst).
+
+
+#### Citation
+
+See [citations](doc/citation.rst).
+

--- a/doc/bib/elephant.bib
+++ b/doc/bib/elephant.bib
@@ -70,7 +70,7 @@
   journal = {Biosystems},
   volume = {185},
   pages = {104022},
-  doi = {https://doi.org/10.1016/j.biosystems.2019.104022}
+  doi = {10.1016/j.biosystems.2019.104022}
 }
     
 @article{Torre16_e1004939,

--- a/doc/bib/elephant.bib
+++ b/doc/bib/elephant.bib
@@ -49,8 +49,7 @@
   volume = {94},
   number = {1},
   pages = {67--79},
-  doi = {10.1016/s0165-0270(99)00126-0}
-  
+  doi = {10.1016/s0165-0270(99)00126-0} 
 }
 
 @article{Riehle97_1950,
@@ -64,13 +63,35 @@
   doi = {10.1126/science.278.5345.1950}
 }
 
-@article{torre2016asset,
+@article{Stella19_104022,
+  title = {3d-{SPADE}: {S}ignificance evaluation of spatio-temporal patterns of various temporal extents},
+  author = {Stella, A. and Quaglio, P. and Torre, E. and Gr{\"u}n, S.},
+  year = {2019},
+  journal = {Biosystems},
+  volume = {185},
+  pages = {104022},
+  doi = {https://doi.org/10.1016/j.biosystems.2019.104022}
+}
+    
+@article{Torre16_e1004939,
   title={ASSET: analysis of sequences of synchronous events in massively parallel spike trains},
-  author={Torre, Emiliano and Canova, Carlos and Denker, Michael and Gerstein, George and Helias, Moritz and Gr{\"u}n, Sonja},
+  author={Torre, E. and Canova, C. and Denker, M. and Gerstein, G. and Helias, M. and Gr{\"u}n, S.},
   year={2016},
-  journal={PLoS computational biology},
+  journal={PLoS Comp. Biol.},
   volume={12},
   number={7},
   pages={e1004939},
   doi={10.1371/journal.pcbi.1004939}
 }
+
+@article{Rostami17_3,
+  title = {[{Re}] {S}pike synchronization and rate modulation differentially involved in motor cortical function},
+  author = {Rostami, V. and Ito, J. and Denker, M. and Gr{\"u}n, S.},
+  year = {2017},
+  journal = {ReScience},
+  volume = {3},
+  number = {1},
+  pages = {3},
+  doi = {10.5281/zenodo.583814}
+}
+

--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -1,0 +1,34 @@
+***************
+Citing Elephant
+***************
+
+To refer to the Elephant software package in publications, please use: **Elephant (RRID:SCR_003833)**.
+
+    
+To cite Elephant, please use:
+
+**Denker M, Yegenoglu A, Grün S (2018) Collaborative HPC-enabled workflows on the HBP Collaboratory using the Elephant framework. Neuroinformatics 2018, P19. doi: 10.12751/incf.ni2018.0019**
+
+A BibTeX entry for LaTeX users is:
+
+.. code-block:: bibtex
+
+    @conference{elephant18,
+        author = {Denker, M. and Yegenoglu, A. and Grün, S.},
+        booktitle = {Neuroinformatics 2018},
+        title = {{C}ollaborative {HPC}-enabled workflows on the {HBP} {C}ollaboratory using the {E}lephant framework},
+        pages = {P19},
+        year = {2018}
+        doi = {10.12751/incf.ni2018.0019},
+        url = {https://abstracts.g-node.org/conference/NI2018/abstracts#/uuid/023bec4e-0c35-4563-81ce-2c6fac282abd},
+    }
+    
+
+Further publications directly related to Elephant development 
+:cite:`citations-Rostami17_3,citations-Stella19_104022` (see
+`doc/bib/elephant.bib` for full BibTeX entries).
+
+.. bibliography:: bib/elephant.bib
+   :labelprefix: citations-
+   :keyprefix: citations-
+   :style: unsrt    

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,6 +34,7 @@ Table of Contents
     release_notes
     get_in_touch
     acknowledgments
+    citation
 
 
 

--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-ASSET is a statistical method :cite:`asset-torre2016asset` for the detection of
-repeating sequences of synchronous spiking events in parallel spike trains.
+ASSET is a statistical method :cite:`asset-Torre16_e1004939` for the detection
+of repeating sequences of synchronous spiking events in parallel spike trains.
 
 
 ASSET analysis class object of finding patterns


### PR DESCRIPTION
This is inspired by #344, and gives a copy paste on how to reference Elephant including the RRID:SCR_003833 identifier, and on a reference on the Elephant package (currently to Neuroinformatics 2018). Also, the page lists papers that directly involve parts of the implementations in the Elephant package.