### PR TITLE
Surrogates get arbitrary sampling_rate

### DIFF
--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -249,8 +249,8 @@ def dither_spikes(spiketrain, dither, n_surrogates=1, decimals=None,
             dithered_spiketrains.rescale(pq.ms).round(decimals).rescale(units)
 
     # Return the surrogates as list of neo.SpikeTrain
-    return [neo.SpikeTrain(
-        train, t_start=t_start, t_stop=t_stop)
+    return [neo.SpikeTrain(train, t_start=t_start, t_stop=t_stop,
+                           sampling_rate=spiketrain.sampling_rate)
         for train in dithered_spiketrains]
 
 
@@ -314,7 +314,8 @@ def randomise_spikes(spiketrain, n_surrogates=1, decimals=None):
 
     # Convert the Quantity array to a list of SpikeTrains, and return them
     return [neo.SpikeTrain(np.sort(st), t_start=spiketrain.t_start,
-                           t_stop=spiketrain.t_stop)
+                           t_stop=spiketrain.t_stop,
+                           sampling_rate=spiketrain.sampling_rate)
             for st in sts]
 
 
@@ -379,12 +380,15 @@ def shuffle_isis(spiketrain, n_surrogates=1, decimals=None):
                 spiketrain.units + spiketrain.t_start
             sts.append(neo.SpikeTrain(
                 surr_times, t_start=spiketrain.t_start,
-                t_stop=spiketrain.t_stop))
+                t_stop=spiketrain.t_stop,
+                sampling_rate=spiketrain.sampling_rate))
 
     else:
         sts = [neo.SpikeTrain([] * spiketrain.units,
                               t_start=spiketrain.t_start,
-                              t_stop=spiketrain.t_stop)] * n_surrogates
+                              t_stop=spiketrain.t_stop,
+                              sampling_rate=spiketrain.sampling_rate)
+               ] * n_surrogates
 
     return sts
 
@@ -478,7 +482,9 @@ def dither_spike_train(spiketrain, shift, n_surrogates=1, decimals=None,
 
     # Return the surrogates as SpikeTrains
     return [neo.SpikeTrain(s, t_start=spiketrain.t_start,
-                           t_stop=spiketrain.t_stop).rescale(spiketrain.units)
+                           t_stop=spiketrain.t_stop,
+                           sampling_rate=spiketrain.sampling_rate
+                           ).rescale(spiketrain.units)
             for s in surr]
 
 
@@ -568,7 +574,9 @@ def jitter_spikes(spiketrain, bin_size, n_surrogates=1):
     surr = np.sort(surr_poiss01 * dilats + offsets, axis=1) * std_unit
 
     return [neo.SpikeTrain(s, t_start=spiketrain.t_start,
-                           t_stop=spiketrain.t_stop).rescale(spiketrain.units)
+                           t_stop=spiketrain.t_stop,
+                           sampling_rate=spiketrain.sampling_rate
+                           ).rescale(spiketrain.units)
             for s in surr]
 
 
@@ -968,7 +976,9 @@ class JointISI(object):
                 np.r_[0., np.cumsum(dithered_isi)]
             dithered_st = neo.SpikeTrain(dithered_st * self._unit,
                                          t_start=self.spiketrain.t_start,
-                                         t_stop=self.spiketrain.t_stop)
+                                         t_stop=self.spiketrain.t_stop,
+                                         sampling_rate=
+                                         self.spiketrain.sampling_rate)
             dithered_sts.append(dithered_st)
         return dithered_sts
 
@@ -1126,6 +1136,8 @@ def trial_shifting(spiketrains, dither, n_surrogates=1):
                 for single_trial_st in spiketrains]
     t_stops = [single_trial_st.t_stop.simplified.magnitude
                for single_trial_st in spiketrains]
+    sampling_rates = [single_trial_st.sampling_rate
+                      for single_trial_st in spiketrains]
     spiketrains = [single_trial_st.simplified.magnitude
                    for single_trial_st in spiketrains]
 
@@ -1138,7 +1150,8 @@ def trial_shifting(spiketrains, dither, n_surrogates=1):
             surrogate_spiketrain[trial_id] * pq.s,
             t_start=t_starts[trial_id] * pq.s,
             t_stop=t_stops[trial_id] * pq.s,
-            units=units)
+            units=units,
+            sampling_rate=sampling_rates[trial_id])
           for trial_id in range(len(surrogate_spiketrain))]
          for surrogate_spiketrain in surrogate_spiketrains]
 
@@ -1222,7 +1235,8 @@ def _trial_shifting_of_concatenated_spiketrain(
         np.hstack(surrogate_spiketrain) * pq.s,
         t_start=t_start * pq.s,
         t_stop=t_stop * pq.s,
-        units=units)
+        units=units,
+        sampling_rate=spiketrain.sampling_rate)
         for surrogate_spiketrain in surrogate_spiketrains]
     return surrogate_spiketrains
 
@@ -1356,12 +1370,13 @@ def surrogates(
             dt.simplified.magnitude / kwargs['bin_size'].simplified.magnitude)
         binned_surrogates = method(
             binned_spiketrain, max_displacement, n_surrogates=n_surrogates)
-        surrogate_spiketrains = [neo.SpikeTrain(
-            bin_grid[binned_surrogate.to_bool_array()[0]] * pq.s,
-            t_start=spiketrain.t_start,
-            t_stop=spiketrain.t_stop,
-            units=spiketrain.units)
-            for binned_surrogate in binned_surrogates]
+        surrogate_spiketrains = \
+            [neo.SpikeTrain(bin_grid[binned_surr.to_bool_array()[0]] * pq.s,
+                            t_start=spiketrain.t_start,
+                            t_stop=spiketrain.t_stop,
+                            units=spiketrain.units,
+                            sampling_rate=spiketrain.sampling_rate)
+             for binned_surr in binned_surrogates]
         return surrogate_spiketrains
     # surr_method is 'joint_isi_dithering' or isi_dithering:
     return method(n_surrogates)

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -251,7 +251,7 @@ def dither_spikes(spiketrain, dither, n_surrogates=1, decimals=None,
     # Return the surrogates as list of neo.SpikeTrain
     return [neo.SpikeTrain(train, t_start=t_start, t_stop=t_stop,
                            sampling_rate=spiketrain.sampling_rate)
-        for train in dithered_spiketrains]
+            for train in dithered_spiketrains]
 
 
 @deprecated_alias(n='n_surrogates')
@@ -974,11 +974,11 @@ class JointISI(object):
 
             dithered_st = self.spiketrain[0].magnitude + \
                 np.r_[0., np.cumsum(dithered_isi)]
+            sampling_rate = self.spiketrain.sampling_rate
             dithered_st = neo.SpikeTrain(dithered_st * self._unit,
                                          t_start=self.spiketrain.t_start,
                                          t_stop=self.spiketrain.t_stop,
-                                         sampling_rate=
-                                         self.spiketrain.sampling_rate)
+                                         sampling_rate=sampling_rate)
             dithered_sts.append(dithered_st)
         return dithered_sts
 


### PR DESCRIPTION
Hey all,

I have included the sampling rate to the generation of surrogates, since the current version does not pass it from the original spike train to the surrogate ones (like it does with the t_start or t_stop). 

Hopefully nothing breaks down.

Best,
Aitor