### PR TITLE
UEA: capture log(0) warning

### DIFF
--- a/elephant/unitary_event_analysis.py
+++ b/elephant/unitary_event_analysis.py
@@ -625,6 +625,8 @@ def jointJ(p_val):
     """
     p_arr = np.asarray(p_val)
     with np.errstate(divide='ignore'):
+        # Ignore 'Division by zero' warning which happens when p_arr is 1.0 or
+        # 0.0 (no spikes).
         Js = np.log10(1 - p_arr) - np.log10(p_arr)
     return Js
 

--- a/elephant/unitary_event_analysis.py
+++ b/elephant/unitary_event_analysis.py
@@ -624,7 +624,8 @@ def jointJ(p_val):
 
     """
     p_arr = np.asarray(p_val)
-    Js = np.log10(1 - p_arr) - np.log10(p_arr)
+    with np.errstate(divide='ignore'):
+        Js = np.log10(1 - p_arr) - np.log10(p_arr)
     return Js
 
 


### PR DESCRIPTION
Fixes #349 

There are several ways to handle invalid mathematical operations (see https://stackoverflow.com/questions/21752989/numpy-efficiently-avoid-0s-when-taking-logmatrix). I chose capturing the warning for the reasons described in the answer.