### PR TITLE
don't sort the input array in ISI

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -118,6 +118,12 @@ def isi(spiketrain, axis=-1):
     intervals : np.ndarray or pq.Quantity
         The inter-spike intervals of the `spiketrain`.
 
+    Warns
+    -----
+    UserWarning
+        When the input array is not sorted, negative intervals are returned
+        with a warning.
+
     """
     if isinstance(spiketrain, neo.SpikeTrain):
         intervals = np.diff(spiketrain.magnitude, axis=axis)

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -100,14 +100,14 @@ def isi(spiketrain, axis=-1):
     """
     Return an array containing the inter-spike intervals of the spike train.
 
-    Accepts a `neo.SpikeTrain`, a `pq.Quantity` array, or a plain
-    `np.ndarray`. If either a `neo.SpikeTrain` or `pq.Quantity` is provided,
-    the return value will be `pq.Quantity`, otherwise `np.ndarray`. The units
-    of `pq.Quantity` will be the same as `spiketrain`.
+    Accepts a `neo.SpikeTrain`, a `pq.Quantity` array, a `np.ndarray`, or a
+    list of time spikes. If either a `neo.SpikeTrain` or `pq.Quantity` is
+    provided, the return value will be `pq.Quantity`, otherwise `np.ndarray`.
+    The units of `pq.Quantity` will be the same as `spiketrain`.
 
     Parameters
     ----------
-    spiketrain : neo.SpikeTrain or pq.Quantity or np.ndarray
+    spiketrain : neo.SpikeTrain or pq.Quantity or array-like
         The spike times.
     axis : int, optional
         The axis along which the difference is taken.
@@ -119,13 +119,16 @@ def isi(spiketrain, axis=-1):
         The inter-spike intervals of the `spiketrain`.
 
     """
-    if axis is None:
-        axis = -1
     if isinstance(spiketrain, neo.SpikeTrain):
-        intervals = np.diff(
-            np.sort(spiketrain.times.view(pq.Quantity)), axis=axis)
+        intervals = np.diff(spiketrain.magnitude, axis=axis)
+        # np.diff makes a copy
+        intervals = pq.Quantity(intervals, units=spiketrain.units, copy=False)
     else:
-        intervals = np.diff(np.sort(spiketrain), axis=axis)
+        intervals = np.diff(spiketrain, axis=axis)
+    if (intervals < 0).any():
+        warnings.warn("ISI evaluated to negative values. "
+                      "Please sort the input array.")
+
     return intervals
 
 

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -80,6 +80,13 @@ class isi_TestCase(unittest.TestCase):
         assert not isinstance(res, pq.Quantity)
         assert_array_almost_equal(res, target, decimal=9)
 
+    @unittest.skipUnless(python_version_major == 3, "assertWarns requires 3.2")
+    def test_unsorted_array(self):
+        np.random.seed(0)
+        array = np.random.rand(100)
+        with self.assertWarns(UserWarning):
+            isi = statistics.isi(array)
+
 
 class isi_cv_TestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
The approach taken in #104 is not clear:
* firstly, the author didn't describe scenarios where the spike times are not sorted. We're relying on times being sorted in neo.SpikeTrains throughout many other functions in elephant: kernels.median_index, instantaneous_rate, ... Why should we make an exception for 0.01 % of use cases, if any?
* secondly, sorting an array is `O(N logN)` in time and it's a slap in the face of Elephant optimizations.
* thirdly, the merged solution does an extra copy by accessing `.times` attribute of a spiketrain, which creates a copy under the hood, compared to `.magnitude`.
* finally, sorting is not the only solution to the original problem stated in the pull request. If we do want to deal with unsorted arrays, which is argued upon, a simple check with a warning will do the job in linear time.

Not to mention the absence of a regression test.