### PR TITLE
optimized zscore

### DIFF
--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -14,7 +14,7 @@ import numpy as np
 import quantities as pq
 import scipy.signal
 
-from elephant.utils import deprecated_alias
+from elephant.utils import deprecated_alias, check_same_units
 
 __all__ = [
     "zscore",
@@ -134,6 +134,7 @@ def zscore(signal, inplace=True):
     # Transform input to a list
     if isinstance(signal, neo.AnalogSignal):
         signal = [signal]
+    check_same_units(signal, object_type=neo.AnalogSignal)
 
     # Calculate mean and standard deviation
     signal_stacked = np.vstack(signal).magnitude

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -54,9 +54,9 @@ def zscore(signal, inplace=True):
         Signals for which to calculate the z-score.
     inplace : bool, optional
         If True, the contents of the input `signal` is replaced by the
-        z-transformed signal.
+        z-transformed signal, if possible, i.e when the signal type is float.
         If False, a copy of the original `signal` is returned.
-        Default: True.
+        Default: True
 
     Returns
     -------
@@ -132,29 +132,31 @@ def zscore(signal, inplace=True):
 
     """
     # Transform input to a list
-    if not isinstance(signal, list):
+    if isinstance(signal, neo.AnalogSignal):
         signal = [signal]
 
     # Calculate mean and standard deviation
-    signal_stacked = np.vstack(signal)
-    m = np.mean(signal_stacked, axis=0)
-    s = np.std(signal_stacked, axis=0)
+    signal_stacked = np.vstack(signal).magnitude
+    mean = signal_stacked.mean(axis=0)
+    std = signal_stacked.std(axis=0)
 
     signal_ztransofrmed = []
     for sig in signal:
-        sig_normalized = sig.magnitude - m.magnitude
-        sig_normalized = np.divide(sig_normalized, s.magnitude,
-                                   out=np.zeros_like(sig_normalized),
-                                   where=s.magnitude != 0)
-        if inplace:
-            sig[:] = pq.Quantity(sig_normalized, units=sig.units)
-            sig_normalized = sig
-        else:
-            sig_normalized = sig.duplicate_with_new_data(sig_normalized)
-            # todo use flag once is fixed
-            #      https://github.com/NeuralEnsemble/python-neo/issues/752
-            sig_normalized.array_annotate(**sig.array_annotations)
-        sig_dimless = sig_normalized / sig.units
+        sig_normalized = sig.magnitude.astype(mean.dtype, copy=not inplace)
+        sig_normalized -= mean
+        # items where std is zero are already zero
+        np.divide(sig_normalized, std, out=sig_normalized, where=std != 0)
+        sig_dimless = neo.AnalogSignal(signal=sig_normalized,
+                                       units=pq.dimensionless,
+                                       dtype=sig_normalized.dtype,
+                                       copy=False,
+                                       t_start=sig.t_start,
+                                       sampling_rate=sig.sampling_rate,
+                                       name=sig.name,
+                                       file_origin=sig.file_origin,
+                                       description=sig.description,
+                                       array_annotations=sig.array_annotations,
+                                       **sig.annotations)
         signal_ztransofrmed.append(sig_dimless)
 
     # Return single object, or list of objects
@@ -313,7 +315,10 @@ def cross_correlation_function(signal, channel_pairs, hilbert_envelope=False,
 
     # z-score analog signal and store channel time series in different arrays
     # Cross-correlation will be calculated between xsig and ysig
-    z_transformed = zscore(signal, inplace=False).magnitude
+    z_transformed = signal.magnitude - signal.magnitude.mean(axis=0)
+    z_transformed = np.divide(z_transformed, signal.magnitude.std(axis=0),
+                              out=z_transformed,
+                              where=z_transformed != 0)
     # transpose (nch, xy, nt) -> (xy, nt, nch)
     xsig, ysig = np.transpose(z_transformed.T[pairs], (1, 2, 0))
 

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -295,20 +295,16 @@ class ZscoreTestCase(unittest.TestCase):
         Test if the z-score is correctly calculated even if the input is an
         AnalogSignal of type int, asking for an inplace operation.
         """
-        signal = neo.AnalogSignal(
-            self.test_seq1, units='mV',
-            t_start=0. * pq.ms, sampling_rate=1000. * pq.Hz, dtype=int)
-
         m = np.mean(self.test_seq1)
         s = np.std(self.test_seq1)
         target = (self.test_seq1 - m) / s
 
-        assert_array_almost_equal(
-            elephant.signal_processing.zscore(signal, inplace=True).magnitude,
-            target.reshape(-1, 1).astype(int), decimal=9)
+        signal = neo.AnalogSignal(
+            self.test_seq1, units='mV',
+            t_start=0. * pq.ms, sampling_rate=1000. * pq.Hz, dtype=int)
+        zscored = elephant.signal_processing.zscore(signal, inplace=True)
 
-        # Assert original signal is overwritten
-        self.assertEqual(signal[0].magnitude, target.astype(int)[0])
+        assert_array_almost_equal(zscored.magnitude.squeeze(), target)
 
     def test_zscore_list_dup(self):
         """

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -382,6 +382,16 @@ class ZscoreTestCase(unittest.TestCase):
         self.assertEqual(signal1[0, 0].magnitude, target11[0])
         self.assertEqual(signal2[0, 0].magnitude, target21[0])
 
+    def test_wrong_input(self):
+        # wrong type
+        self.assertRaises(TypeError, elephant.signal_processing.zscore,
+                          signal=[1, 2] * pq.uV)
+        # units mismatch
+        asig1 = neo.AnalogSignal([0, 1], units=pq.uV, sampling_rate=1 * pq.ms)
+        asig2 = neo.AnalogSignal([0, 1], units=pq.V, sampling_rate=1 * pq.ms)
+        self.assertRaises(ValueError, elephant.signal_processing.zscore,
+                          signal=[asig1, asig2])
+
 
 class ButterTestCase(unittest.TestCase):
 

--- a/elephant/utils.py
+++ b/elephant/utils.py
@@ -91,3 +91,34 @@ def is_time_quantity(x, allow_none=False):
     if not isinstance(x, pq.Quantity):
         return False
     return x.dimensionality.simplified == pq.Quantity(1, "s").dimensionality
+
+
+def check_same_units(quantities, object_type=pq.Quantity):
+    """
+    Check that all input quantities are of the same type and share common
+    units. Raise an error if the check is unsuccessful.
+
+    Parameters
+    ----------
+    quantities : list of pq.Quantity or pq.Quantity
+        A list of quantities, neo objects or a single neo object.
+    object_type : type
+        The common type.
+
+    Raises
+    ------
+    TypeError
+        If input objects are not instances of the specified `object_type`.
+    ValueError
+        If input objects do not share common units.
+    """
+    if not isinstance(quantities, (list, tuple)):
+        quantities = [quantities]
+    for quantity in quantities:
+        if not isinstance(quantity, object_type):
+            raise TypeError("The input must be a list of {}. Got {}".format(
+                object_type.__name__, type(quantity).__name__))
+        if quantity.units != quantities[0].units:
+            raise ValueError("The input quantities must have the same units, "
+                             "which is achieved with object.rescale('ms') "
+                             "operation.")


### PR DESCRIPTION
Optimized zscore and related cross_correlation_function.

TODO: don't stack arrays in zscore - calculate mean and std in online fashion once MeanOnline and VarianceOnline objects are introduced.

It breaks test_zscore_single_inplace_int - the logic was incorrect: when the data is int, zscored signal cannot be of type int. It's not logical and not obvious at all to have ints in the output.