### PR TITLE
unit-less BinnedSpikeTrain

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -771,7 +771,6 @@ class BinnedSpikeTrain(object):
         bst = _BinnedSpikeTrainView(t_start=self._t_start,
                                     t_stop=self._t_stop,
                                     bin_size=self._bin_size,
-                                    n_bins=self.n_bins,
                                     units=self.units,
                                     sparse_matrix=spmat)
         return bst
@@ -852,12 +851,11 @@ class BinnedSpikeTrain(object):
 class _BinnedSpikeTrainView(BinnedSpikeTrain):
     # Experimental feature and should not be public now.
 
-    def __init__(self, t_start, t_stop, bin_size, n_bins, units,
-                 sparse_matrix):
+    def __init__(self, t_start, t_stop, bin_size, units, sparse_matrix):
         self._t_start = t_start
         self._t_stop = t_stop
         self._bin_size = bin_size
-        self.n_bins = n_bins
+        self.n_bins = sparse_matrix.shape[1]
         self.units = units
         self.sparse_matrix = sparse_matrix
 

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -362,6 +362,9 @@ class BinnedSpikeTrain(object):
         """
         if isinstance(units, str):
             units = pq.Quantity(1, units=units)
+        if units == self.units:
+            # do nothing
+            return
         if not isinstance(units, pq.Quantity):
             raise TypeError("The input units must be quantities or string")
         scale = self.units.rescale(units).item()

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -336,6 +336,15 @@ class BinnedSpikeTrain(object):
         warnings.warn("'.num_bins' is deprecated; use '.n_bins'")
         return self.n_bins
 
+    def __repr__(self):
+        return "{klass}(t_start={t_start}, t_stop={t_stop}, " \
+               "bin_size={bin_size}; shape={shape})".format(
+                     klass=type(self).__name__,
+                     t_start=self.t_start,
+                     t_stop=self.t_stop,
+                     bin_size=self.bin_size,
+                     shape=self.shape)
+
     def rescale(self, units):
         """
         Inplace rescaling to the new quantity units.
@@ -535,7 +544,13 @@ class BinnedSpikeTrain(object):
             All center edges in interval (:attr:`start`, :attr:`stop`).
 
         """
-        return self.bin_edges[:-1] + self.bin_size / 2
+        start = self._t_start + self._bin_size / 2
+        stop = start + (self.n_bins - 1) * self._bin_size
+        bin_centers = np.linspace(start=start,
+                                  stop=stop,
+                                  num=self.n_bins, endpoint=True)
+        bin_centers = pq.Quantity(bin_centers, units=self.units, copy=False)
+        return bin_centers
 
     def to_sparse_array(self):
         """

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -352,7 +352,7 @@ def covariance(binned_spiketrain, binary=False, fast=True):
 
     """
     if binary:
-        binned_spiketrain = binned_spiketrain.binarize(copy=True)
+        binned_spiketrain = binned_spiketrain.binarize()
 
     if fast and binned_spiketrain.sparsity > _SPARSITY_MEMORY_EFFICIENT_THR:
         array = binned_spiketrain.to_array()
@@ -452,7 +452,7 @@ def correlation_coefficient(binned_spiketrain, binary=False, fast=True):
 
     """
     if binary:
-        binned_spiketrain = binned_spiketrain.binarize(copy=True)
+        binned_spiketrain = binned_spiketrain.binarize()
 
     if fast and binned_spiketrain.sparsity > _SPARSITY_MEMORY_EFFICIENT_THR:
         array = binned_spiketrain.to_array()
@@ -745,8 +745,8 @@ def cross_correlation_histogram(
         raise ValueError("Invalid window parameter")
 
     if binary:
-        binned_spiketrain_i = binned_spiketrain_i.binarize(copy=True)
-        binned_spiketrain_j = binned_spiketrain_j.binarize(copy=True)
+        binned_spiketrain_i = binned_spiketrain_i.binarize()
+        binned_spiketrain_j = binned_spiketrain_j.binarize()
 
     cch_builder = _CrossCorrHist(binned_spiketrain_i, binned_spiketrain_j,
                                  window=(left_edge, right_edge))

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -774,10 +774,12 @@ def cross_correlation_histogram(
     annotations = dict(cch_parameters=annotations)
 
     # Transform the array count into an AnalogSignal
+    t_start = pq.Quantity((lags[0] - 0.5) * bin_size,
+                          units=binned_spiketrain_i.units, copy=False)
     cch_result = neo.AnalogSignal(
         signal=np.expand_dims(cross_corr, axis=1),
         units=pq.dimensionless,
-        t_start=(lags[0] - 0.5) * binned_spiketrain_i.bin_size,
+        t_start=t_start,
         sampling_period=binned_spiketrain_i.bin_size, copy=False,
         **annotations)
     return cch_result, lags

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -677,8 +677,11 @@ def cross_correlation_histogram(
     if binned_spiketrain_i.shape[0] != 1 or \
             binned_spiketrain_j.shape[0] != 1:
         raise ValueError("Spike trains must be one dimensional")
-    if binned_spiketrain_j.units != binned_spiketrain_i.units:
-        binned_spiketrain_j.rescale(binned_spiketrain_i.units)
+
+    # rescale to the common units
+    # this does not change the data - only its representation
+    binned_spiketrain_j.rescale(binned_spiketrain_i.units)
+
     if not np.isclose(binned_spiketrain_i._bin_size,
                       binned_spiketrain_j._bin_size):
         raise ValueError("Bin sizes must be equal")

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -924,7 +924,7 @@ def time_histogram(spiketrains, bin_size, t_start=None, t_stop=None,
                           bin_size=bin_size)
 
     if binary:
-        bs = bs.binarize(copy=False)
+        bs = bs.binarize()
     bin_hist = bs.get_num_of_spikes(axis=0)
     # Flatten array
     bin_hist = np.ravel(bin_hist)

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -944,7 +944,7 @@ def time_histogram(spiketrains, bin_size, t_start=None, t_stop=None,
 
     return neo.AnalogSignal(signal=np.expand_dims(bin_hist, axis=1),
                             sampling_period=bin_size, units=bin_hist.units,
-                            t_start=t_start, normalization=output)
+                            t_start=t_start, normalization=output, copy=False)
 
 
 @deprecated_alias(binsize='bin_size')

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -571,6 +571,16 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
         self.assertEqual(bst._t_stop, 1010)  # 1.01 s
         self.assertEqual(bst._bin_size, 1)  # 0.001 s
 
+    def test_repr(self):
+        train = neo.SpikeTrain(times=np.array([1.001, 1.002, 1.005]) * pq.s,
+                               t_start=1 * pq.s, t_stop=1.01 * pq.s)
+        bst = cv.BinnedSpikeTrain(train, t_start=1 * pq.s,
+                                  t_stop=1.01 * pq.s,
+                                  bin_size=1 * pq.ms)
+        self.assertEqual(repr(bst), "BinnedSpikeTrain(t_start=1.0 s, "
+                                    "t_stop=1.01 s, bin_size=0.001 s; "
+                                    "shape=(1, 10))")
+
     def test_binned_sparsity(self):
         train = neo.SpikeTrain(np.arange(10), t_stop=10 * pq.s, units=pq.s)
         bst = cv.BinnedSpikeTrain(train, n_bins=100)

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -792,15 +792,11 @@ class SpikeTrainTimescaleTestCase(unittest.TestCase):
         timescale = 1 / (4 * nu)
         np.random.seed(35)
 
-        timescale_num = []
         for _ in range(10):
             spikes = homogeneous_gamma_process(2, 2 * nu, 0 * pq.ms, T)
             spikes_bin = conv.BinnedSpikeTrain(spikes, bin_size)
             timescale_i = sc.spike_train_timescale(spikes_bin, 10 * timescale)
-            timescale_i.units = timescale.units
-            timescale_num.append(timescale_i.magnitude)
-        assert_array_almost_equal(timescale.magnitude, timescale_num,
-                                  decimal=3)
+            assert_array_almost_equal(timescale, timescale_i, decimal=3)
 
     def test_timescale_errors(self):
         spikes = neo.SpikeTrain([1, 5, 7, 8] * pq.ms, t_stop=10 * pq.ms)

--- a/elephant/utils.py
+++ b/elephant/utils.py
@@ -159,7 +159,6 @@ def check_neo_consistency(neo_objects, object_type, t_start=None,
     """
     if not isinstance(neo_objects, (list, tuple)):
         neo_objects = [neo_objects]
-    units = neo_objects[0].units
     for neo_obj in neo_objects:
         if not isinstance(neo_obj, object_type):
             raise TypeError("The input must be a list of {}. Got {}".format(
@@ -168,7 +167,7 @@ def check_neo_consistency(neo_objects, object_type, t_start=None,
             raise ValueError("The input must have the same t_start.")
         if t_stop is None and neo_obj.t_stop != neo_objects[0].t_stop:
             raise ValueError("The input must have the same t_stop.")
-        if neo_obj.units != units:
+        if neo_obj.units != neo_objects[0].units:
             raise ValueError("The input must have the same units.")
 
 

--- a/elephant/utils.py
+++ b/elephant/utils.py
@@ -159,15 +159,16 @@ def check_neo_consistency(neo_objects, object_type, t_start=None,
     """
     if not isinstance(neo_objects, (list, tuple)):
         neo_objects = [neo_objects]
+    units = neo_objects[0].units
     for neo_obj in neo_objects:
         if not isinstance(neo_obj, object_type):
             raise TypeError("The input must be a list of {}. Got {}".format(
                 object_type.__name__, type(neo_obj).__name__))
-        if t_start is None and not neo_obj.t_start == neo_objects[0].t_start:
+        if t_start is None and neo_obj.t_start != neo_objects[0].t_start:
             raise ValueError("The input must have the same t_start.")
-        if t_stop is None and not neo_obj.t_stop == neo_objects[0].t_stop:
+        if t_stop is None and neo_obj.t_stop != neo_objects[0].t_stop:
             raise ValueError("The input must have the same t_stop.")
-        if not neo_obj.units == neo_objects[0].units:
+        if neo_obj.units != units:
             raise ValueError("The input must have the same units.")
 
 

--- a/elephant/utils.py
+++ b/elephant/utils.py
@@ -159,16 +159,23 @@ def check_neo_consistency(neo_objects, object_type, t_start=None,
     """
     if not isinstance(neo_objects, (list, tuple)):
         neo_objects = [neo_objects]
+    try:
+        units = neo_objects[0].units
+        t_start0 = neo_objects[0].t_start.item()
+        t_stop0 = neo_objects[0].t_stop.item()
+    except AttributeError:
+        raise TypeError("The input must be a list of {}. Got {}".format(
+                object_type.__name__, type(neo_objects[0]).__name__))
     for neo_obj in neo_objects:
         if not isinstance(neo_obj, object_type):
             raise TypeError("The input must be a list of {}. Got {}".format(
                 object_type.__name__, type(neo_obj).__name__))
-        if t_start is None and neo_obj.t_start != neo_objects[0].t_start:
-            raise ValueError("The input must have the same t_start.")
-        if t_stop is None and neo_obj.t_stop != neo_objects[0].t_stop:
-            raise ValueError("The input must have the same t_stop.")
-        if neo_obj.units != neo_objects[0].units:
+        if neo_obj.units != units:
             raise ValueError("The input must have the same units.")
+        if t_start is None and neo_obj.t_start.item() != t_start0:
+            raise ValueError("The input must have the same t_start.")
+        if t_stop is None and neo_obj.t_stop.item() != t_stop0:
+            raise ValueError("The input must have the same t_stop.")
 
 
 def check_same_units(quantities, object_type=pq.Quantity):


### PR DESCRIPTION
To facilitate numpy-like support of data objects in Elephant, a unit-less representation of BinnedSpikeTrain is now supported via the following attributes that are guaranteed to have the same units and therefore they are just magnitudes:
* self._t_start
* self._bin_size
* self._t_stop

If the input is a spiketrain list, its units are used. Otherwise, in case of a binned numpy matrix, `bin_size` units are used. The units are stored in `self.units` attribute.

`.binarize()` function now returns a view of a BinnedSpikeTrain object.

Added a convenient `.rescalte()` method that rescales t_start/stop and bin_size to new units **in-place**.

Optimized `cross_correlation_function` to apply these changes.