### PR TITLE
Fixing index selection in spike_triggered_phase (see issue #381)

### DIFF
--- a/elephant/phase_analysis.py
+++ b/elephant/phase_analysis.py
@@ -125,14 +125,13 @@ def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
         sttimeind = np.where(np.logical_and(
             spiketrain >= start[phase_i], spiketrain < stop[phase_i]))[0]
 
-        # Find index into signal for each spike
-        ind_at_spike = np.searchsorted(hilbert_trials[trial].times,
-                                       spike_trials[trial],
-                                       side='right') - 1
-
         # Extract times for speed reasons
         times = hilbert_transform[phase_i].times
 
+        # Find index into signal for each spike
+        ind_at_spike = np.searchsorted(times, spiketrain[sttimeind],
+                                       side='right') - 1
+                                       
         # Append new list to the results for this spiketrain
         result_phases.append([])
         result_amps.append([])

--- a/elephant/phase_analysis.py
+++ b/elephant/phase_analysis.py
@@ -126,10 +126,9 @@ def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
             spiketrain >= start[phase_i], spiketrain < stop[phase_i]))[0]
 
         # Find index into signal for each spike
-        ind_at_spike = np.round(
-            (spiketrain[sttimeind] - hilbert_transform[phase_i].t_start) /
-            hilbert_transform[phase_i].sampling_period). \
-            simplified.magnitude.astype(int)
+        ind_at_spike = np.searchsorted(hilbert_trials[trial].times,
+                                       spike_trials[trial],
+                                       side='right') - 1
 
         # Extract times for speed reasons
         times = hilbert_transform[phase_i].times
@@ -144,10 +143,6 @@ def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
             # Difference vector between actual spike time and sample point,
             # positive if spike time is later than sample point
             dv = spiketrain[sttimeind[spike_i]] - times[ind_at_spike_j]
-
-            # Make sure ind_at_spike is to the left of the spike time
-            if dv < 0 and ind_at_spike_j > 0:
-                ind_at_spike_j = ind_at_spike_j - 1
 
             if interpolate:
                 # Get relative spike occurrence between the two closest signal

--- a/elephant/phase_analysis.py
+++ b/elephant/phase_analysis.py
@@ -130,8 +130,8 @@ def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
 
         # Find index into signal for each spike
         ind_at_spike = np.searchsorted(times, spiketrain[sttimeind],
-                                       side='right') - 1
-                                       
+                                       side='right').magnitude - 1
+
         # Append new list to the results for this spiketrain
         result_phases.append([])
         result_amps.append([])
@@ -139,11 +139,8 @@ def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
 
         # Step through all spikes
         for spike_i, ind_at_spike_j in enumerate(ind_at_spike):
-            # Difference vector between actual spike time and sample point,
-            # positive if spike time is later than sample point
-            dv = spiketrain[sttimeind[spike_i]] - times[ind_at_spike_j]
 
-            if interpolate:
+            if interpolate and ind_at_spike_j+1 < len(times):
                 # Get relative spike occurrence between the two closest signal
                 # sample points
                 # if z->0 spike is more to the left sample
@@ -152,6 +149,7 @@ def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
                     hilbert_transform[phase_i].sampling_period
 
                 # Save hilbert_transform (interpolate on circle)
+                print(ind_at_spike_j)
                 p1 = np.angle(hilbert_transform[phase_i][ind_at_spike_j])
                 p2 = np.angle(hilbert_transform[phase_i][ind_at_spike_j + 1])
                 result_phases[spiketrain_i].append(


### PR DESCRIPTION
This fixes replaces the mechanism of finding the indices of the array of sample times left to each spike.
Previously, this was done by calculating the spike position in the times-array via the sampling rate, rounding, and checking if the sampling point is actually to the left of the spike. This approach is a bit convoluted and may cause errors in some conditions (issue #381).
The PR replaces this with the numpy function `searchsorted()` which fixes the bug, is more straightforward, and computes faster.