### PR TITLE
spike-contrast: store bin_size in the trace output

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -461,11 +461,10 @@ class BinnedSpikeTrain(object):
         # At this point, all spiketrains share the same units.
         self.units = spiketrains[0].units
 
-        try:
-            self._t_start = self._t_start.rescale(self.units).item()
-            self._t_stop = self._t_stop.rescale(self.units).item()
-        except AttributeError:
-            raise ValueError("'t_start' and 't_stop' must be quantities")
+        # t_start and t_stop are checked to be time quantities in the
+        # check_neo_consistency call.
+        self._t_start = self._t_start.rescale(self.units).item()
+        self._t_stop = self._t_stop.rescale(self.units).item()
 
         start_shared, stop_shared = get_common_start_stop_times(spiketrains)
         start_shared = start_shared.rescale(self.units).item()

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -77,6 +77,9 @@ def spike_contrast(spiketrains, t_start=None, t_stop=None,
 
     Original implementation by: Philipp Steigerwald [s160857@th-ab.de]
 
+    Visualization is covered in
+    :func:`viziphant.spike_train_synchrony.plot_spike_contrast`.
+
     Parameters
     ----------
     spiketrains : list of neo.SpikeTrain

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -417,12 +417,12 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
         a = self.spiketrain_a
         b = neo.SpikeTrain([-2, -1] * pq.s, t_start=-2 * pq.s,
                            t_stop=-1 * pq.s)
-        self.assertRaises(ValueError, cv.BinnedSpikeTrain, [a, b], t_start=5,
+        self.assertRaises(TypeError, cv.BinnedSpikeTrain, [a, b], t_start=5,
                           t_stop=0, bin_size=pq.s, n_bins=10)
 
         b = neo.SpikeTrain([-7, -8, -9] * pq.s, t_start=-9 * pq.s,
                            t_stop=-7 * pq.s)
-        self.assertRaises(ValueError, cv.BinnedSpikeTrain, b, t_start=0,
+        self.assertRaises(TypeError, cv.BinnedSpikeTrain, b, t_start=None,
                           t_stop=10, bin_size=pq.s, n_bins=10)
         self.assertRaises(ValueError, cv.BinnedSpikeTrain, a, t_start=0 * pq.s,
                           t_stop=10 * pq.s, bin_size=3 * pq.s, n_bins=10)

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -89,10 +89,14 @@ class TestSpikeContrast(unittest.TestCase):
         spike_train_2 = stgen.homogeneous_poisson_process(rate=20 * Hz,
                                                           t_stop=1000. * ms)
         synchrony, trace = spike_contrast([spike_train_1, spike_train_2],
-                                              return_trace=True)
+                                          return_trace=True)
         self.assertEqual(synchrony, max(trace.synchrony))
         self.assertEqual(len(trace.contrast), len(trace.active_spiketrains))
         self.assertEqual(len(trace.active_spiketrains), len(trace.synchrony))
+        self.assertEqual(len(trace.bin_size), len(trace.synchrony))
+        self.assertIsInstance(trace.bin_size, pq.Quantity)
+        self.assertEqual(trace.bin_size[0], 500 * pq.ms)
+        self.assertAlmostEqual(trace.bin_size[-1], 10.1377798 * pq.ms)
 
     def test_invalid_data(self):
         # invalid spiketrains


### PR DESCRIPTION
`.bin_size` is added in the trace output namedtuple to track the provenance used in viziphant later on.