### PR TITLE
Fix LvR values from being off when units are in seconds

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -501,7 +501,8 @@ def lvr(time_intervals, R=5*pq.ms, with_nan=False):
     Parameters
     ----------
     time_intervals : pq.Quantity or np.ndarray or list
-        Vector of consecutive time intervals.
+        Vector of consecutive time intervals. Must have time units, if not unit
+        is passed `ms` are assumed.
     R : pq.Quantity or int or float
         Refractoriness constant (R >= 0). If no quantity is passed `ms` are
         assumed.
@@ -548,6 +549,13 @@ def lvr(time_intervals, R=5*pq.ms, with_nan=False):
 
     if R < 0:
         raise ValueError('R must be >= 0')
+
+    # check units of intervals if available
+    if isinstance(time_intervals, pq.Quantity):
+        time_intervals = time_intervals.rescale('ms').magnitude
+    else:
+        warnings.warn('No units specified for time_intervals,'
+                      ' assuming milliseconds (ms)')
 
     # convert to array, cast to float
     time_intervals = np.asarray(time_intervals)

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -412,14 +412,20 @@ class LVRTestCase(unittest.TestCase):
     def test_lvr_with_quantities(self):
         seq = pq.Quantity(self.test_seq, units='ms')
         assert_array_almost_equal(statistics.lvr(seq), self.target, decimal=9)
+        seq = pq.Quantity(self.test_seq, units='ms').rescale('s')
+        assert_array_almost_equal(statistics.lvr(seq), self.target, decimal=9)
 
     def test_lvr_with_plain_array(self):
         seq = np.array(self.test_seq)
-        assert_array_almost_equal(statistics.lvr(seq), self.target, decimal=9)
+        with self.assertWarns(UserWarning):
+            assert_array_almost_equal(statistics.lvr(seq),
+                                      self.target, decimal=9)
 
     def test_lvr_with_list(self):
         seq = self.test_seq
-        assert_array_almost_equal(statistics.lvr(seq), self.target, decimal=9)
+        with self.assertWarns(UserWarning):
+            assert_array_almost_equal(statistics.lvr(seq),
+                                      self.target, decimal=9)
 
     def test_lvr_raise_error(self):
         seq = self.test_seq


### PR DESCRIPTION
Hi! 

I noticed (and fixed) a bug of my own making in the LvR function. When the time units of the time_intervals were not milliseconds the output was way off. I fixed it, added a warning to when there are no explicit units and updated the tests to also check for this. 

I believe this is not a problem in the other ISI variation metrics (Cv, Lv) because they do not have the R parameter which has time units itself. So the issue should be settled with this simple fix.

All best,
Aitor