### PR TITLE
Superimpose spike trains to estimate the optimal kernel for the inst. rate

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -750,7 +750,7 @@ def instantaneous_rate(spiketrains, sampling_period, kernel='auto',
         duration = 0
         times_concat = []
         for st in spiketrains:
-            times_concat.append(st.magnitude + duration)
+            times_concat.append(st.magnitude - st.t_start.item() + duration)
             duration += st.duration.item()
         times_concat = np.concatenate(times_concat)
         kernel = optimal_kernel(times_concat, units=spiketrains[0].units)

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -561,10 +561,16 @@ class InstantaneousRateTest(unittest.TestCase):
             TypeError, statistics.instantaneous_rate, spiketrains=st,
             sampling_period=0.01 * pq.ms, kernel=self.kernel, trim=1)
 
-        # cannot estimate a kernel for a list of spiketrains
-        self.assertRaises(ValueError, statistics.instantaneous_rate,
-                          spiketrains=[st, st], sampling_period=10 * pq.ms,
-                          kernel='auto')
+    def test_auto_kernel_multispiketrains(self):
+        sampling_period = 10 * pq.ms
+        rate1 = statistics.instantaneous_rate(self.spike_train,
+                                              sampling_period=sampling_period,
+                                              kernel='auto')
+        rate2 = statistics.instantaneous_rate(
+            [self.spike_train, self.spike_train],
+            sampling_period=sampling_period, kernel='auto')
+        # check the mean firing rate
+        self.assertAlmostEqual(rate1.mean(), rate2.mean(), places=2)
 
     def test_rate_estimation_consistency(self):
         """


### PR DESCRIPTION
The PR is closed because the fix I made here is wrong (at first, I misunderstood the term "superimpose"). A correct fix would be to rewrite the `optimal_kernel_bandwidth` such that it accepts a list of spike trains, as it should have been done in the first place.

----

The cited paper states the first step clearly:

> Superimpose n spike sequences.

In fact, their method finds an optimal kernel bandwidth (fixed or variable) for any varying dynamics of the input spike trains. Of course, the best match, esp. for fixed kernels, is when the dynamics is homogeneous.

The optimal kernel estimation must be invariant to the shift of t_start. Therefore, we assume that all spike trains start from 0 sec.

Note, however, that our implementation of the optimal kernel width may return the widths that differ in the order of magnitude when the input is a doubled spike train (i.e, the same spike train is shifted by its `t_stop` and concatenated) - this is an issue with our implementation rather than with the idea of superimposing input spike trains.

-----

What superimpose means in [Shimazaki et al., 2010](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2940025/pdf/10827_2009_Article_180.pdf)

> mixed spikes are statistically independent and
the superimposed sequence can be approximated as a
single inhomogeneous Poisson point process (Cox 1962;
Snyder 1975; Daley and Vere-Jones 1988; Kass et al.
2005).

[Kass et al. 2005](http://stat.columbia.edu/~liam/teaching/neurostat-spr11/papers/kass-et-al/Kass_JN_2005.pdf):

>  a general theorem (Daley and
Vere-Jones 1988, Theorem 9.2.V) shows that, as the number of
replications (trials) of a non-Poisson process increases, the
pooled observations will approximately follow a Poisson process. It may be verified statistically that spikes times pooled
across trials are nearly Poisson (e.g., Olson et al. 2000; Ventura
et al. 2001)