### PR TITLE
Improve memory efficiency of _create_sparse_matrix in BinnedSpikeTrain class

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -1091,9 +1091,9 @@ class BinnedSpikeTrain(object):
         scale_units = 1 / self._bin_size
         for idx, st in enumerate(spiketrains):
             times = st.magnitude
-            bins = times[(times >= self._t_start) & (
+            times = times[(times >= self._t_start) & (
                 times <= self._t_stop)] - self._t_start
-            bins *= scale_units
+            bins = times * scale_units
 
             # shift spikes that are very close
             # to the right edge into the next bin


### PR DESCRIPTION
Hi!

I was having some memory problems when running the synchrotool and @Kleinjohann helped me figure out that the highest memory usage was actually happening in the binning. 

We then together made some modifications to _check_neo_spiketrain() that improve the memory efficiency quite a bit. Using this test script for memory profiling:
```
import quantities as pq
import elephant.conversion as conv_old
import elephant.conversion_new as conv_new
from elephant.spike_train_generation import homogeneous_poisson_process as poisson
import ctypes
libc = ctypes.CDLL("libc.so.6")


@profile
def old_binning(sts):
    conv_old.BinnedSpikeTrain(sts, binsize=1*pq.ms, tolerance=1e-8)


@profile
def new_binning(sts):
    conv_new.BinnedSpikeTrain(sts, binsize=1*pq.ms, tolerance=1e-8)


if __name__ == "__main__":
    sts = []
    for i in range(2000):
        st = poisson(10*pq.Hz, t_start=0*pq.ms, t_stop=1000000*pq.ms)
        sts.append(st)

    # Run the old function
    old_binning(sts)

    # Force python to collect garbage, linux-specific
    libc.malloc_trim(0)

    # Run the new function
    new_binning(sts)
    libc.malloc_trim(0)
```

Which we run using the python memory-profiler as such:
```
mprof run --include-children --multiprocess --interval 0.01 --python python binning_linewise_memtest.py --noreload
```

The output is:
![Figure_1](https://user-images.githubusercontent.com/43403140/104047627-3e9f0600-51e2-11eb-884e-db3c94974fa9.png)

So not only did we reduce the highest memory usage spike, but also the runtime went down. This output is possibly exaggerated because I am using a rather large list of spiketrains (2000) as an example, but certainly also the case in smaller runs. With 100 spiketrains it looks like this:
![Figure_2](https://user-images.githubusercontent.com/43403140/104048186-2085d580-51e3-11eb-8c89-ba8d45fbce53.png)

So major improvements to memory efficiency occur in both larger and smaller settings.

No major IO feature was changed, only the dtypes of the arrays, which were also hard coded before (but only in the last step, hence the memory spike). Please have a look and a nice weekend!
Aitor & Alex K