### PR TITLE
Joint-ISI dithering: fixed a bug regarding first ISI bin

### DIFF
--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -1039,19 +1039,21 @@ class JointISI(object):
         # double_index corresponds to the sum of the indices for the previous
         # and the subsequent ISI.
         for double_index in range(self.n_bins):
-            cum_diag = np.cumsum(np.diagonal(rotated_jisih,
-                                             - self.n_bins
-                                             + double_index + 1))
+            anti_diagonal = np.diagonal(
+                rotated_jisih, - self.n_bins + double_index + 1)
 
             right_padding = jisih_diag_cums.shape[1] - \
-                len(cum_diag) - self._max_change_index
+                len(anti_diagonal) - self._max_change_index
 
-            jisih_diag_cums[double_index] = np.pad(
-                cum_diag,
+            padded_anti_diagonal = np.pad(
+                anti_diagonal,
                 pad_width=(self._max_change_index, right_padding),
                 mode='constant',
-                constant_values=(cum_diag[0], cum_diag[-1])
-            )
+                constant_values=(0., 0.))
+
+            cumulated_diagonal = np.cumsum(padded_anti_diagonal)
+
+            jisih_diag_cums[double_index] = cumulated_diagonal
 
         return jisih_diag_cums
 
@@ -1116,8 +1118,9 @@ class JointISI(object):
                     / (cum_dist_func[new_isi_id] - cum_dist_func[new_isi_id-1])
                 step = self._index_to_isi(new_isi_id - remainder_index)\
                     - compare_isi
-                # old_step = self._index_to_isi(new_isi_id)\
-                #     - compare_isi
+                old_step = self._index_to_isi(new_isi_id)\
+                    - compare_isi
+                return old_step
                 # if i<5:
                 #     print(f'{cum_dist_func=}')
                 #     print(f'{random_number=}')

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -1065,6 +1065,8 @@ class JointISI(object):
         sampling_rhythm = self.alternate + 1
         number_of_isis = len(dithered_isi)
 
+        steps = []
+
         for start in range(sampling_rhythm):
             dithered_isi_indices = self._isi_to_index(dithered_isi)
             for i in range(start, number_of_isis - 1,
@@ -1075,6 +1077,15 @@ class JointISI(object):
                     i)
                 dithered_isi[i] += step
                 dithered_isi[i + 1] -= step
+                steps.append(step)
+
+        if len(steps) > 100:
+            import matplotlib.pyplot as plt
+            plt.figure()
+            plt.hist(steps, bins=np.arange(-0.015, 0.015, 0.0001))
+            plt.show()
+            print(max(steps))
+            print(min(steps))
 
         return dithered_isi
 
@@ -1098,8 +1109,22 @@ class JointISI(object):
             if cum_dist_func[-1] > 0.:
                 # when the method is 'fast', new_isi_id is where the current
                 # ISI id should go to.
-                new_isi_id = np.searchsorted(cum_dist_func, random.random())
-                step = self._index_to_isi(new_isi_id) - compare_isi
+                random_number = random.random()
+                new_isi_id = np.searchsorted(cum_dist_func, random_number)
+                remainder_index = \
+                    (random_number - cum_dist_func[new_isi_id-1])\
+                    / (cum_dist_func[new_isi_id] - cum_dist_func[new_isi_id-1])
+                step = self._index_to_isi(new_isi_id - remainder_index)\
+                    - compare_isi
+                # old_step = self._index_to_isi(new_isi_id)\
+                #     - compare_isi
+                # if i<5:
+                #     print(f'{cum_dist_func=}')
+                #     print(f'{random_number=}')
+                #     print(f'{new_isi_id=}')
+                #     print(f'{remainder_index=}')
+                #     print(f'{step=}')
+                #     print(f'{old_step=}')
                 return step
 
         return self._uniform_dither_not_jisi_movable_spikes(


### PR DESCRIPTION
The first ISI bin was giving a zero probability due to an error in the combination of the cumulated sum and the padding.