### PR TITLE
Account for unidirectional spiketrain->segment links in synchrofact deletion

### DIFF
--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -341,7 +341,6 @@ class Synchrotool(Complexity):
             if mode == 'extract':
                 mask = np.invert(mask)
             new_st = st[mask]
-            spiketrain_list[idx] = new_st
             if in_place:
                 segment = st.segment
                 if segment is None:
@@ -368,6 +367,7 @@ class Synchrotool(Complexity):
 
                     # st found in group, replace with new_st
                     group.spiketrains[idx] = new_st
+            spiketrain_list[idx] = new_st
 
         return spiketrain_list
 

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -356,7 +356,11 @@ class Synchrotool(Complexity):
                                   "input list spiketrains has a "
                                   "unidirectional uplink to a segment in "
                                   "whose segment.spiketrains list it does not "
-                                  "appear.")
+                                  "appear. Only the spiketrains in the input "
+                                  "list will be replaced. You can suppress "
+                                  "this warning by setting "
+                                  "spiketrain.segment=None for the input "
+                                  "spiketrains.")
 
                 block = segment.block
                 if block is not None:

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -18,6 +18,7 @@ Synchrony Measures
 """
 from __future__ import division, print_function, unicode_literals
 
+import warnings
 from collections import namedtuple
 from copy import deepcopy
 
@@ -344,10 +345,18 @@ class Synchrotool(Complexity):
             if in_place and st.segment is not None:
                 segment = st.segment
 
-                # replace link to spiketrain in segment
-                new_index = self._get_spiketrain_index(
-                    segment.spiketrains, st)
-                segment.spiketrains[new_index] = new_st
+                try:
+                    # replace link to spiketrain in segment
+                    new_index = self._get_spiketrain_index(
+                        segment.spiketrains, st)
+                    segment.spiketrains[new_index] = new_st
+                except ValueError:
+                    # st is not in this segment even though it points to it
+                    warnings.warn(f"The SpikeTrain at index {idx} of the "
+                                  "input list spiketrains has a "
+                                  "unidirectional uplink to a segment in "
+                                  "whose segment.spiketrains list it does not "
+                                  "appear.")
 
                 block = segment.block
                 if block is not None:

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -283,6 +283,30 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
                             spread=0, mode='delete', in_place=True,
                             deletion_threshold=2)
 
+    def test_spiketrains_findable(self):
+
+        # same test as `test_spread_0` with the addition of
+        # a neo structure: we must not overwrite the spiketrain
+        # list of the segment before determining the index
+
+        sampling_rate = 1 / pq.s
+
+        segment = neo.Segment()
+
+        segment.spiketrains = [neo.SpikeTrain([1, 5, 9, 11, 16, 19] * pq.s,
+                                              t_stop=20*pq.s),
+                               neo.SpikeTrain([1, 4, 8, 12, 16, 18] * pq.s,
+                                              t_stop=20*pq.s)]
+
+        segment.create_relationship()
+
+        correct_annotations = np.array([[2, 1, 1, 1, 2, 1],
+                                        [2, 1, 1, 1, 2, 1]])
+
+        self._test_template(segment.spiketrains, correct_annotations,
+                            sampling_rate, spread=0, mode='delete',
+                            in_place=True, deletion_threshold=2)
+
     def test_spread_1(self):
 
         # test synchrofact search taking into account adjacent bins

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -307,6 +307,35 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
                             sampling_rate, spread=0, mode='delete',
                             in_place=True, deletion_threshold=2)
 
+    def test_unidirectional_uplinks(self):
+
+        # same test as `test_spiketrains_findable` but the spiketrains
+        # are rescaled first
+        # the rescaled spiketrains have a unidirectional uplink to segment
+        # check that this does not cause an error
+        # check that a UserWarning is issued in this case
+
+        sampling_rate = 1 / pq.s
+
+        segment = neo.Segment()
+
+        segment.spiketrains = [neo.SpikeTrain([1, 5, 9, 11, 16, 19] * pq.s,
+                                              t_stop=20*pq.s),
+                               neo.SpikeTrain([1, 4, 8, 12, 16, 18] * pq.s,
+                                              t_stop=20*pq.s)]
+
+        segment.create_relationship()
+
+        spiketrains = [st.rescale(pq.s) for st in segment.spiketrains]
+
+        correct_annotations = np.array([[2, 1, 1, 1, 2, 1],
+                                        [2, 1, 1, 1, 2, 1]])
+
+        with self.assertWarns(UserWarning):
+            self._test_template(spiketrains, correct_annotations,
+                                sampling_rate, spread=0, mode='delete',
+                                in_place=True, deletion_threshold=2)
+
     def test_spread_1(self):
 
         # test synchrofact search taking into account adjacent bins


### PR DESCRIPTION
See https://github.com/NeuralEnsemble/python-neo/issues/939 for an in-depth description and a minimal example.

This ensures that no error is raised for neo structures with unidirectional uplinks (which can still happen even if this is changed in neo, e.g. if people use an older version or modify the structure manually). The user is warned about the unidirectional link.

This also fixes a bug which occurred when the Synchrotool was initialised with the actual spiketrain list of a segment, so `Synchrotool(segment.spiketrains, ...)`. Due to the execution order in the in-place deletion, the spiketrain was replaced in the list before its index was extracted, resulting in the same error as above.