### PR TITLE
BinnedSpikeTrain optional CSC format

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -1027,21 +1027,28 @@ class BinnedSpikeTrain(object):
         Parameters
         ----------
         copy : bool, optional
-            If True, a view of `BinnedSpikeTrain` is returned with the copied
-            data. Otherwise, the binarization (clipping) is done in-place.
+            If True, a **shallow** copy - a view of `BinnedSpikeTrain` - is
+            returned with the data array filled with zeros and ones. Otherwise,
+            the binarization (clipping) is done in-place. A shallow copy
+            means that :attr:`indices` and :attr:`indptr` of a sparse matrix
+            is shared with the original sparse matrix. Only the data is copied.
+            If you want to perform a deep copy, call
+            :func:`BinnedSpikeTrain.copy` prior to binarizing.
             Default: True
 
         Returns
         -------
         bst : BinnedSpikeTrain or BinnedSpikeTrainView
             A (view of) `BinnedSpikeTrain` with the sparse matrix data clipped
-            to `0`s and `1`s.
+            to zeros and ones.
 
         """
         spmat = self.sparse_matrix
         if copy:
-            spmat = spmat.copy()
-            spmat.data[:] = 1
+            data = np.ones(len(spmat.data), dtype=spmat.data.dtype)
+            spmat = spmat.__class__(
+                (data, spmat.indices, spmat.indptr),
+                shape=spmat.shape, copy=False)
             bst = BinnedSpikeTrainView(t_start=self._t_start,
                                        t_stop=self._t_stop,
                                        bin_size=self._bin_size,

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -918,7 +918,7 @@ def time_histogram(spiketrains, bin_size, t_start=None, t_stop=None,
                           bin_size=bin_size)
 
     if binary:
-        bs = bs.binarize()
+        bs = bs.binarize(copy=False)
     bin_hist = bs.get_num_of_spikes(axis=0)
     # Flatten array
     bin_hist = np.ravel(bin_hist)
@@ -1309,7 +1309,7 @@ class Complexity(object):
                                     tolerance=self.tolerance)
 
         if self.binary:
-            bst = bst.binarize()
+            bst = bst.binarize(copy=False)
         bincount = bst.get_num_of_spikes(axis=0)
 
         nonzero_indices = np.nonzero(bincount)[0]

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -195,6 +195,19 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
         self.bin_size = 1 * pq.s
         self.tolerance = 1e-8
 
+    def test_binarize(self):
+        spiketrains = [self.spiketrain_a, self.spiketrain_b,
+                       self.spiketrain_a, self.spiketrain_b]
+        for sparse_format in ("csr", "csc"):
+            bst = cv.BinnedSpikeTrain(spiketrains=spiketrains,
+                                      bin_size=self.bin_size,
+                                      sparse_format=sparse_format)
+            bst_bin = bst.binarize(copy=True)
+            bst_copy = bst.copy()
+            assert_array_equal(bst_bin.to_array(), bst.to_bool_array())
+            bst_copy.sparse_matrix.data[:] = 1
+            self.assertEqual(bst_bin, bst_copy)
+
     def test_slice(self):
         spiketrains = [self.spiketrain_a, self.spiketrain_b,
                        self.spiketrain_a, self.spiketrain_b]

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -254,32 +254,38 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
 
     def test_to_spike_trains(self):
         np.random.seed(1)
-        bst1 = cv.BinnedSpikeTrain(
-            spiketrains=[self.spiketrain_a, self.spiketrain_b],
-            bin_size=self.bin_size
-        )
         spiketrains = [homogeneous_poisson_process(rate=10 * pq.Hz,
                                                    t_start=-1 * pq.s,
                                                    t_stop=10 * pq.s)]
-        bst2 = cv.BinnedSpikeTrain(spiketrains=spiketrains,
-                                   bin_size=300 * pq.ms)
-        for bst in (bst1, bst2):
-            for spikes in ("random", "left", "center"):
-                spiketrains_gen = bst.to_spike_trains(spikes=spikes,
-                                                      annotate_bins=True)
-                for st, indices in zip(spiketrains_gen, bst.spike_indices):
-                    # check sorted
-                    self.assertTrue((np.diff(st.magnitude) > 0).all())
-                    assert_array_equal(st.array_annotations['bins'], indices)
-                    self.assertEqual(st.annotations['bin_size'], bst.bin_size)
-                    self.assertEqual(st.t_start, bst.t_start)
-                    self.assertEqual(st.t_stop, bst.t_stop)
-                bst_same = cv.BinnedSpikeTrain(spiketrains_gen,
-                                               bin_size=bst.bin_size)
-                self.assertEqual(bst_same, bst)
+        for sparse_format in ("csr", "csc"):
+            bst1 = cv.BinnedSpikeTrain(
+                spiketrains=[self.spiketrain_a, self.spiketrain_b],
+                bin_size=self.bin_size, sparse_format=sparse_format
+            )
+            bst2 = cv.BinnedSpikeTrain(spiketrains=spiketrains,
+                                       bin_size=300 * pq.ms,
+                                       sparse_format=sparse_format)
+            for bst in (bst1, bst2):
+                for spikes in ("random", "left", "center"):
+                    spiketrains_gen = bst.to_spike_trains(spikes=spikes,
+                                                          annotate_bins=True)
+                    for st, indices in zip(spiketrains_gen, bst.spike_indices):
+                        # check sorted
+                        self.assertTrue((np.diff(st.magnitude) > 0).all())
+                        assert_array_equal(st.array_annotations['bins'],
+                                           indices)
+                        self.assertEqual(st.annotations['bin_size'],
+                                         bst.bin_size)
+                        self.assertEqual(st.t_start, bst.t_start)
+                        self.assertEqual(st.t_stop, bst.t_stop)
+                    bst_same = cv.BinnedSpikeTrain(spiketrains_gen,
+                                                   bin_size=bst.bin_size,
+                                                   sparse_format=sparse_format)
+                    self.assertEqual(bst_same, bst)
 
-            # invalid mode
-            self.assertRaises(ValueError, bst.to_spike_trains, spikes='right')
+                # invalid mode
+                self.assertRaises(ValueError, bst.to_spike_trains,
+                                  spikes='right')
 
     def test_get_num_of_spikes(self):
         spiketrains = [self.spiketrain_a, self.spiketrain_b]
@@ -288,14 +294,16 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
                                          bin_size=1 * pq.s, t_start=0 * pq.s)
             self.assertEqual(binned.get_num_of_spikes(),
                              len(binned.spike_indices[0]))
-        binned_matrix = cv.BinnedSpikeTrain(spiketrains, n_bins=10,
-                                            bin_size=1 * pq.s)
-        n_spikes_per_row = binned_matrix.get_num_of_spikes(axis=1)
-        n_spikes_per_row_from_indices = list(map(len,
-                                                 binned_matrix.spike_indices))
-        assert_array_equal(n_spikes_per_row, n_spikes_per_row_from_indices)
-        self.assertEqual(binned_matrix.get_num_of_spikes(),
-                         sum(n_spikes_per_row_from_indices))
+        for sparse_format in ("csr", "csc"):
+            binned_matrix = cv.BinnedSpikeTrain(spiketrains, n_bins=10,
+                                                bin_size=1 * pq.s,
+                                                sparse_format=sparse_format)
+            n_spikes_per_row = binned_matrix.get_num_of_spikes(axis=1)
+            n_spikes_per_row_from_indices = list(
+                map(len, binned_matrix.spike_indices))
+            assert_array_equal(n_spikes_per_row, n_spikes_per_row_from_indices)
+            self.assertEqual(binned_matrix.get_num_of_spikes(),
+                             sum(n_spikes_per_row_from_indices))
 
     def test_binned_spiketrain_sparse(self):
         a = neo.SpikeTrain([1.7, 1.8, 4.3] * pq.s, t_stop=10.0 * pq.s)
@@ -662,7 +670,7 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
                                   bin_size=1 * pq.ms)
         self.assertEqual(repr(bst), "BinnedSpikeTrain(t_start=1.0 s, "
                                     "t_stop=1.01 s, bin_size=0.001 s; "
-                                    "shape=(1, 10))")
+                                    "shape=(1, 10), format=csr_matrix)")
 
     def test_binned_sparsity(self):
         train = neo.SpikeTrain(np.arange(10), t_stop=10 * pq.s, units=pq.s)


### PR DESCRIPTION
Could be useful in ASSET HEAT backend implementation.

Also, `BinnedSpikeTrain.binarize` is refactored: the copy parameter is back.

------

Slicing a scipy CSC matrix does not internally convert it to a CSR matrix.

```python
import time
import tracemalloc

import numpy as np
import scipy.sparse

tracemalloc.start()
start = time.time()


def print_traced_mem(name=''):
    global start
    duration = time.time() - start
    curr, peak = tracemalloc.get_traced_memory()
    print(f">>> [{name}] curr={curr / 2 ** 20:.2f} Mb, peak={peak / 2 ** 20:.2f} Mb; duration={duration:.3f} sec")
    tracemalloc.reset_peak()
    start = time.time()


n = 5_000
a = np.arange(n * n, dtype=np.float32).reshape((n, n))
a_csc = scipy.sparse.csc_matrix(a)
print_traced_mem('begin')
a11 = a_csc[:n//2, :n//2]
print_traced_mem('a11')
a12 = a_csc[:n//2, n//2:]
print_traced_mem('a12')
```
```
>>> [begin] curr=286.14 Mb, peak=762.94 Mb; duration=0.793 sec
>>> [a11] curr=333.84 Mb, peak=333.84 Mb; duration=0.043 sec
>>> [a12] curr=381.53 Mb, peak=381.53 Mb; duration=0.042 sec
```
Same for a CSR matrix.
