### PR TITLE
Run all test cases in test_spectral.py

### DIFF
--- a/elephant/test/test_spectral.py
+++ b/elephant/test/test_spectral.py
@@ -322,11 +322,5 @@ class WelchCohereTestCase(unittest.TestCase):
             np.all(phase_lag_neo_1dim[:, 0] == phase_lag_neo[:, 0]))
 
 
-def suite():
-    suite = unittest.makeSuite(WelchPSDTestCase, 'test')
-    return suite
-
-
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(suite())
+    unittest.main(verbosity=2)


### PR DESCRIPTION
test_spectral.py was scheduling tests only for the `WelchPSDTestCase` using a custom test suite. This PR replaces it with `unittest.main()` to run tests for both `WelchPSDTestCase` and `WelchCohereTestCase`.