### PR TITLE
[Enhancement] Set complexity dtypes for memory efficiency

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1361,11 +1361,12 @@ class Complexity(object):
                           'Note that using the complexity epoch to get '
                           'precise spike times can lead to rounding errors.')
 
+        complexity = self.time_histogram.magnitude.flatten()
+        complexity = complexity.astype(np.uint16)
+
         epoch = neo.Epoch(left_edges,
                           durations=durations,
-                          array_annotations={
-                              'complexity':
-                              self.time_histogram.magnitude.flatten()})
+                          array_annotations={'complexity': complexity})
         return epoch
 
     def _epoch_with_spread(self):
@@ -1428,6 +1429,8 @@ class Complexity(object):
         # Ensure that an epoch does not start before the minimum t_start.
         # Note: all spike trains share the same t_start and t_stop.
         left_edges[0] = max(self.t_start, left_edges[0])
+
+        complexities = complexities.astype(np.uint16)
 
         complexity_epoch = neo.Epoch(times=left_edges,
                                      durations=right_edges - left_edges,

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1414,7 +1414,7 @@ class Complexity(object):
         sorting = np.argsort(combined_starts, kind='mergesort')
         left_edges = bst.bin_edges[combined_starts[sorting]]
         right_edges = bst.bin_edges[combined_stops[sorting]]
-        complexities = combined_complexities[sorting].astype(int)
+        complexities = combined_complexities[sorting].astype(np.uint16)
 
         if self.sampling_rate:
             # ensure that spikes are not on the bin edges
@@ -1429,8 +1429,6 @@ class Complexity(object):
         # Ensure that an epoch does not start before the minimum t_start.
         # Note: all spike trains share the same t_start and t_stop.
         left_edges[0] = max(self.t_start, left_edges[0])
-
-        complexities = complexities.astype(np.uint16)
 
         complexity_epoch = neo.Epoch(times=left_edges,
                                      durations=right_edges - left_edges,

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -219,6 +219,8 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
                        for st in spiketrains]
 
         assert_array_equal(annotations, correct_complexities)
+        for a in annotations:
+            self.assertEqual(a.dtype, np.dtype(np.uint16).type)
 
         if mode == 'extract':
             correct_spike_times = [

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -919,7 +919,7 @@ class TimeHistogramTestCase(unittest.TestCase):
             self.assertEqual(histogram.annotations['normalization'], output)
 
 
-class ComplexityPdfTestCase(unittest.TestCase):
+class ComplexityTestCase(unittest.TestCase):
     def test_complexity_pdf_deprecated(self):
         spiketrain_a = neo.SpikeTrain(
             [0.5, 0.7, 1.2, 2.3, 4.3, 5.5, 6.7] * pq.s, t_stop=10.0 * pq.s)


### PR DESCRIPTION
Hey!

@Kleinjohann and I have made minor changes to the Complexity class to use `np.uint16` type values in the complexity arrays, this should be able to represent complexities all the way to 65,535 which not even the largest recording systems can achieve right now. 

We also updated the tests to check that this dtype is kept all the way to the single spike train annotations, reducing the memory usage by a factor of 4. 

Let us know if we should change somethings

Best,
Aitor&Alex