### PR TITLE
Changed __repr__ in BinnedSpikeTrain to support quantities<0.12.4

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -405,8 +405,8 @@ class BinnedSpikeTrain(object):
         return self.n_bins
 
     def __repr__(self):
-        return f"{type(self).__name__}(t_start={self.t_start}, " \
-               f"t_stop={self.t_stop}, bin_size={self.bin_size}; " \
+        return f"{type(self).__name__}(t_start={str(self.t_start)}, " \
+               f"t_stop={str(self.t_stop)}, bin_size={str(self.bin_size)}; " \
                f"shape={self.shape}, " \
                f"format={self.sparse_matrix.__class__.__name__})"
 


### PR DESCRIPTION
The unit test for method `__repr__` in `conversion.BinnedSpikeTrain` fails if `quantities` is `0.12.3` or below.

The old method was using `Quantity` scalars inside an f-string. This required the `__format__` method implemented in `quantities==0.12.4` to generate the correct string representation of `BinnedSpikeTrain` with magnitudes and units.

This PR changes the string generation by casting the `Quantity` scalars to string, which uses the `__str__` method in `Quantity` and displays the magnitudes and units as expected. This does not rely on any formatting method and thereby it is compatible with older versions of `quantities`.

This addresses issue #409.