### PR TITLE
Fixed random seed selection to use numpy

### DIFF
--- a/doc/tutorials/spade.ipynb
+++ b/doc/tutorials/spade.ipynb
@@ -18,12 +18,12 @@
    },
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "import quantities as pq\n",
     "import neo\n",
     "import elephant\n",
     "import viziphant\n",
-    "import random\n",
-    "random.seed(4542)"
+    "np.random.seed(4542)"
    ]
   },
   {
@@ -115,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output `patterns` of the method contains information on the found patterns. In this case, we retrieve the pattern we put into the data: a pattern involving the first 10 neurons (IDs 0 to 9), occuring 4 times."
+    "The output `patterns` of the method contains information on the found patterns. In this case, we retrieve the pattern we put into the data: a pattern involving the first 10 neurons (IDs 0 to 9), occuring 5 times."
    ]
   },
   {
@@ -148,6 +148,13 @@
    "source": [
     "viziphant.spade.plot_patterns(spiketrains, patterns)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
This is a bug fix to the SPADE tutorial, where the random number generator was incorrectly initialized, leading to inconsistent realizations of the point processes.