### PR TITLE
BUG-Fix #424: t_start information was lost while transposing lfp

### DIFF
--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -185,8 +185,7 @@ def estimate_csd(lfp, coordinates=None, method=None,
                 raise ValueError("The order of {} filter must be \
                                   specified".format(kwargs['f_type']))
 
-        lfp = neo.AnalogSignal(np.asarray(lfp).T, units=lfp.units,
-                               sampling_rate=lfp.sampling_rate)
+        lfp = lfp.T
         csd_method = getattr(icsd, method)  # fetch class from icsd.py file
         csd_estimator = csd_method(lfp=lfp.magnitude * lfp.units,
                                    coord_electrode=coordinates.flatten(),

--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -185,9 +185,8 @@ def estimate_csd(lfp, coordinates=None, method=None,
                 raise ValueError("The order of {} filter must be \
                                   specified".format(kwargs['f_type']))
 
-        lfp = lfp.T
         csd_method = getattr(icsd, method)  # fetch class from icsd.py file
-        csd_estimator = csd_method(lfp=lfp.magnitude * lfp.units,
+        csd_estimator = csd_method(lfp=lfp.T.magnitude * lfp.units,
                                    coord_electrode=coordinates.flatten(),
                                    **kwargs)
         csd_pqarr = csd_estimator.get_csd()


### PR DESCRIPTION
This bug appeared in line 188 of 'current_source_density.py',  because t_start was not set in the new neo.AnalogSignal object, which should be the transpose of the neo.AnalogSignal object 'lfp'. 
Therefore  the default value for t_start = 0s was used. 
It was fixed by transposing the neo.AnalogSignal 'lfp' directly with lfp = lfp.T, which preserves all set attributes of the neo.AnalogSignal. 