### PR TITLE
Updated zscore for in-place operations

### DIFF
--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -195,6 +195,9 @@ class ZscoreTestCase(unittest.TestCase):
         # Assert original signal is untouched
         self.assertEqual(signal[0].magnitude, self.test_seq1[0])
 
+        # Assert original and returned objects are different
+        self.assertIsNot(result, signal)
+
     def test_zscore_single_inplace(self):
         """
         Test z-score on a single AnalogSignal, asking for an inplace
@@ -218,6 +221,9 @@ class ZscoreTestCase(unittest.TestCase):
         # Assert original signal is overwritten
         self.assertEqual(signal[0].magnitude, target[0])
 
+        # Assert original and returned objects are the same
+        self.assertIs(result, signal)
+
     def test_zscore_single_multidim_dup(self):
         """
         Test z-score on a single AnalogSignal with multiple dimensions, asking
@@ -232,12 +238,14 @@ class ZscoreTestCase(unittest.TestCase):
         s = np.std(signal.magnitude, axis=0, keepdims=True)
         target = (signal.magnitude - m) / s
 
-        assert_array_almost_equal(
-            elephant.signal_processing.zscore(
-                signal, inplace=False).magnitude, target, decimal=9)
+        result = elephant.signal_processing.zscore(signal, inplace=False)
+        assert_array_almost_equal(result.magnitude, target, decimal=9)
 
         # Assert original signal is untouched
         self.assertEqual(signal[0, 0].magnitude, self.test_seq1[0])
+
+        # Assert original and returned objects are different
+        self.assertIsNot(result, signal)
 
     def test_zscore_array_annotations(self):
         signal = neo.AnalogSignal(
@@ -269,6 +277,9 @@ class ZscoreTestCase(unittest.TestCase):
         # Assert original signal is overwritten
         self.assertAlmostEqual(signal[0, 0].magnitude, ground_truth[0, 0])
 
+        # Assert original and returned objects are the same
+        self.assertIs(result, signal)
+
     def test_zscore_single_dup_int(self):
         """
         Test if the z-score is correctly calculated even if the input is an
@@ -283,28 +294,28 @@ class ZscoreTestCase(unittest.TestCase):
         s = np.std(self.test_seq1)
         target = (self.test_seq1 - m) / s
 
-        assert_array_almost_equal(
-            elephant.signal_processing.zscore(signal, inplace=False).magnitude,
-            target.reshape(-1, 1), decimal=9)
+        result = elephant.signal_processing.zscore(signal, inplace=False)
+        assert_array_almost_equal(result.magnitude, target.reshape(-1, 1),
+                                  decimal=9)
 
         # Assert original signal is untouched
         self.assertEqual(signal.magnitude[0], self.test_seq1[0])
 
+        # Assert original and returned objects are different
+        self.assertIsNot(result, signal)
+
     def test_zscore_single_inplace_int(self):
         """
-        Test if the z-score is correctly calculated even if the input is an
-        AnalogSignal of type int, asking for an inplace operation.
+        Test if the z-score operation fails if the input is an
+        AnalogSignal of type int, when asking for an inplace operation.
         """
-        m = np.mean(self.test_seq1)
-        s = np.std(self.test_seq1)
-        target = (self.test_seq1 - m) / s
 
         signal = neo.AnalogSignal(
             self.test_seq1, units='mV',
             t_start=0. * pq.ms, sampling_rate=1000. * pq.Hz, dtype=int)
-        zscored = elephant.signal_processing.zscore(signal, inplace=True)
 
-        assert_array_almost_equal(zscored.magnitude.squeeze(), target)
+        with self.assertRaises(ValueError):
+            elephant.signal_processing.zscore(signal, inplace=True)
 
     def test_zscore_list_dup(self):
         """
@@ -344,6 +355,10 @@ class ZscoreTestCase(unittest.TestCase):
         self.assertEqual(signal1.magnitude[0, 0], self.test_seq1[0])
         self.assertEqual(signal2.magnitude[0, 1], self.test_seq2[0])
 
+        # Assert original and returned objects are different
+        self.assertIsNot(result[0], signal_list[0])
+        self.assertIsNot(result[1], signal_list[1])
+
     def test_zscore_list_inplace(self):
         """
         Test zscore on a list of AnalogSignal objects, asking for an
@@ -381,6 +396,10 @@ class ZscoreTestCase(unittest.TestCase):
         # Assert original signal is overwritten
         self.assertEqual(signal1[0, 0].magnitude, target11[0])
         self.assertEqual(signal2[0, 0].magnitude, target21[0])
+
+        # Assert original and returned objects are the same
+        self.assertIs(result[0], signal_list[0])
+        self.assertIs(result[1], signal_list[1])
 
     def test_wrong_input(self):
         # wrong type


### PR DESCRIPTION
The `zscore` function has a parameter `inplace`, to allow storing the z-scored values in the original `AnalogSignal` object(s).
The function always returns the `AnalogSignal` objects, whether or not an in-place operation is performed.

However, the in-place operation only operated at the level of the data array, i.e., whenever the NumPy array from the original `AnalogSignal` was modified with the z-scored values, a new `AnalogSignal` object was created pointing to that NumPy array. Therefore, this has never been a true in-place operation, as the returned objects differed from the inputs.

This PR fixes that by returning the original `AnalogSignal` when `inplace` is True, and a new object (also using a different data array) when `inplace` is False.

Moreover, the units in the original `AnalogSignal` object were not modified when `inplace` is True and only the returned object was dimensionless (see #384). Therefore, the original `AnalogSignal` ended up with z-scored values with a unit such as `uV`, which is misleading. The code in the PR now sets the unit to `dimensionless` in the original `AnalogSignal`.

Finally, the docstring mentioned that the in-place operation was not attempted if the `AnalogSignal` data type did not allow it (i.e., whenever the type was not float). The PR code now checks, for every object in the input list, whether the type allows the in-place operation. If `inplace` is True and this is not allowed, the parameter is ignored for that `AnalogSignal` (i.e., a copy will be returned along with a new `AnalogSignal` object), and a warning to the user is shown. Alternatively, this could be done before the main loop, checking if there is at least one object in the input list that does not allow the operation, and then setting `inplace` to False in that case (i.e., preventing any in-place operation at all).

To test the behavior of the updated function:

```
import numpy as np
import quantities as pq
import neo
from elephant.signal_processing import zscore

for inplace, dtype in ((True, np.int64), (False, np.int64),
                       (True, np.float64), (False, np.float64)):

    print("=======================")
    print(f"Inplace: {inplace}; dtype: {dtype}")

    test = neo.AnalogSignal(np.random.normal(10, 2, (60000, 96)),
                   units='uV', dtype=dtype, sampling_rate=30000*pq.Hz)

    zscored = zscore(test, inplace=inplace)

    print("IDs", id(test), id(zscored))
    print("Same object?", test is zscored)

    print(test[:1, :5])
    print(zscored[:1, :5])
    print("Equal data?", np.array_equal(test, zscored))
```
which produces

```
=======================
Inplace: True; dtype: <class 'numpy.int64'>
/home/koehler/PycharmProjects/elephant_fix/elephant/signal_processing.py:172: UserWarning: Could not perform inplace operation as the original signal dtype is not float. Source: None
  warnings.warn("Could not perform inplace operation as the "
IDs 139982366671472 139982321011504
Same object? False
[[11 10  8  8 10]] uV
[[ 0.73385822  0.25246159 -0.74701266 -0.74680096  0.24532251]] dimensionless
Equal data? False
=======================
Inplace: False; dtype: <class 'numpy.int64'>
IDs 139982321011840 139982321011728
Same object? False
[[13 12  8  5 10]] uV
[[ 1.74665356  1.23204397 -0.73947224 -2.22643084  0.24853166]] dimensionless
Equal data? False
=======================
Inplace: True; dtype: <class 'numpy.float64'>
IDs 139982321011616 139982321011616
Same object? True
[[ 0.4987234  -0.25468458 -1.32321378  0.41974894  0.32817535]] dimensionless
[[ 0.4987234  -0.25468458 -1.32321378  0.41974894  0.32817535]] dimensionless
Equal data? True
=======================
Inplace: False; dtype: <class 'numpy.float64'>
IDs 139982333189472 139982321011840
Same object? False
[[11.18127483  8.5491104  11.8618302  13.54534356 11.8022081 ]] uV
[[ 0.58965413 -0.73046345  0.93888403  1.77151628  0.89908117]] dimensionless
Equal data? False
```