### PR TITLE
updated spade tutorial to work with viziphant 0.2.0 (#88)

### DIFF
--- a/doc/tutorials/spade.ipynb
+++ b/doc/tutorials/spade.ipynb
@@ -146,27 +146,13 @@
    },
    "outputs": [],
    "source": [
-    "viziphant.spade.plot_patterns(spiketrains, patterns)"
+    "viziphant.patterns.plot_patterns(spiketrains, patterns)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -180,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.10"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
This PR updates the spade tutorial to work with viziphant v0.2.0.

With the new version of viziphant a new modul called `patterns` was introduced, see: https://github.com/INM-6/viziphant/releases/tag/v0.2.0 .

With this PR, cell [6] from the spade tutorial 
```python
viziphant.spade.plot_patterns(spiketrains, patterns)
```
is changed to:
```python
viziphant.patterns.plot_patterns(spiketrains, patterns)
```