### PR TITLE
Support SpikeTrainList object and deprecate RecordingChannel in Elephant

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -1244,6 +1244,8 @@ def _check_neo_spiketrain(query):
         return True
     # Check for list, tuple, or SpikeTrainList
     try:
-         return all(map(_check_neo_spiketrain, query))
-    except:
-        return False
+        return all(map(_check_neo_spiketrain, query))
+    except TypeError:
+        pass
+
+    return False

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -1223,14 +1223,14 @@ class BinnedSpikeTrainView(BinnedSpikeTrain):
         self.tolerance = tolerance
 
 
-def _check_neo_spiketrain(matrix):
+def _check_neo_spiketrain(query):
     """
     Checks if given input contains neo.SpikeTrain objects
 
     Parameters
     ----------
-    matrix
-        Object to test for `neo.SpikeTrain`s
+    query
+        Object to test for `neo.SpikeTrain` objects
 
     Returns
     -------
@@ -1240,9 +1240,10 @@ def _check_neo_spiketrain(matrix):
 
     """
     # Check for single spike train
-    if isinstance(matrix, neo.SpikeTrain):
+    if isinstance(query, neo.SpikeTrain):
         return True
-    # Check for list or tuple
-    if isinstance(matrix, (list, tuple)):
-        return all(map(_check_neo_spiketrain, matrix))
-    return False
+    # Check for list, tuple, or SpikeTrainList
+    try:
+         return all(map(_check_neo_spiketrain, query))
+    except:
+        return False

--- a/elephant/spade.py
+++ b/elephant/spade.py
@@ -97,6 +97,7 @@ from functools import reduce
 from itertools import chain, combinations
 
 import neo
+from neo.core.spiketrainlist import SpikeTrainList
 import numpy as np
 import quantities as pq
 from scipy import sparse
@@ -614,7 +615,7 @@ def concepts_mining(spiketrains, bin_size, winlen, min_spikes=2, min_occ=2,
             "report has to assume of the following values:" +
             "  'a', '#' and '3d#,' got {} instead".format(report))
     # if spiketrains is list of neo.SpikeTrain convert to conv.BinnedSpikeTrain
-    if isinstance(spiketrains, list) and \
+    if isinstance(spiketrains, (list, SpikeTrainList)) and \
             isinstance(spiketrains[0], neo.SpikeTrain):
         spiketrains = conv.BinnedSpikeTrain(
             spiketrains, bin_size=bin_size, tolerance=None)

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -349,7 +349,11 @@ class Synchrotool(Complexity):
                     # replace link to spiketrain in segment
                     new_index = self._get_spiketrain_index(
                         segment.spiketrains, st)
-                    segment.spiketrains[new_index] = new_st
+                    # Todo: Simplify following lines once Neo SpikeTrainList
+                    # implments indexed assignment of entries (i.e., stl[i]=st)
+                    spiketrainlist = list(segment.spiketrains)
+                    spiketrainlist[new_index] = new_st
+                    segment.spiketrains = spiketrainlist
                 except ValueError:
                     # st is not in this segment even though it points to it
                     warnings.warn(f"The SpikeTrain at index {idx} of the "

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -70,6 +70,7 @@ import math
 import warnings
 
 import neo
+from neo.core.spiketrainlist import SpikeTrainList
 import numpy as np
 import quantities as pq
 import scipy.stats
@@ -769,7 +770,7 @@ def instantaneous_rate(spiketrains, sampling_period, kernel='auto',
         if kernel == 'auto':
             kernel = optimal_kernel(spiketrains)
         spiketrains = [spiketrains]
-    elif not isinstance(spiketrains, (list, tuple)):
+    elif not isinstance(spiketrains, (list, tuple, SpikeTrainList)):
         raise TypeError(
             "'spiketrains' must be a list of neo.SpikeTrain's or a single "
             "neo.SpikeTrain. Found: '{}'".format(type(spiketrains)))

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -189,7 +189,8 @@ class binarize_TestCase(unittest.TestCase):
     def test_regression_431(self):
         """
         Addresses issue 431
-        This unittest addresses an issue where a SpikeTrainList obejct was not correctly handled by the constructor
+        This unittest addresses an issue where a SpikeTrainList obejct was not
+        correctly handled by the constructor
         """
         st1 = neo.SpikeTrain(
             times=np.array([1, 2, 3]) * pq.ms,
@@ -201,9 +202,11 @@ class binarize_TestCase(unittest.TestCase):
         spiketrainlist = SpikeTrainList([st1, st2])
 
         real_list_binary = cv.BinnedSpikeTrain(real_list, bin_size=1*pq.ms)
-        spiketrainlist_binary = cv.BinnedSpikeTrain(spiketrainlist, bin_size=1 * pq.ms)
+        spiketrainlist_binary = cv.BinnedSpikeTrain(
+            spiketrainlist, bin_size=1 * pq.ms)
 
-        assert_array_equal(real_list_binary.to_array(), spiketrainlist_binary.to_array())
+        assert_array_equal(
+            real_list_binary.to_array(), spiketrainlist_binary.to_array())
 
 
 class BinnedSpikeTrainTestCase(unittest.TestCase):

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -9,6 +9,7 @@ Unit tests for the conversion module.
 import unittest
 
 import neo
+from neo.core.spiketrainlist import SpikeTrainList
 import numpy as np
 import quantities as pq
 from numpy.testing import (assert_array_almost_equal, assert_array_equal)
@@ -184,6 +185,25 @@ class binarize_TestCase(unittest.TestCase):
         assert_array_equal(bst.bin_edges, [0., 2.] * pq.s)
         assert_array_equal(bst.spike_indices, [[]])  # no binned spikes
         self.assertEqual(bst.get_num_of_spikes(), 0)
+
+    def test_regression_431(self):
+        """
+        Addresses issue 431
+        This unittest addresses an issue where a SpikeTrainList obejct was not correctly handled by the constructor
+        """
+        st1 = neo.SpikeTrain(
+            times=np.array([1, 2, 3]) * pq.ms,
+            t_start=0 * pq.ms, t_stop=10 * pq.ms)
+        st2 = neo.SpikeTrain(
+            times=np.array([4, 5, 6]) * pq.ms,
+            t_start=0 * pq.ms, t_stop=10 * pq.ms)
+        real_list = [st1, st2]
+        spiketrainlist = SpikeTrainList([st1, st2])
+
+        real_list_binary = cv.BinnedSpikeTrain(real_list, bin_size=1*pq.ms)
+        spiketrainlist_binary = cv.BinnedSpikeTrain(spiketrainlist, bin_size=1 * pq.ms)
+
+        assert_array_equal(real_list_binary.to_array(), spiketrainlist_binary.to_array())
 
 
 class BinnedSpikeTrainTestCase(unittest.TestCase):

--- a/elephant/test/test_kcsd.py
+++ b/elephant/test/test_kcsd.py
@@ -32,11 +32,7 @@ class KCSD1D_TestCase(unittest.TestCase):
             temp_signals.append(self.pots[ii])
         self.an_sigs = neo.AnalogSignal(np.array(temp_signals).T * pq.mV,
                                         sampling_rate=1000 * pq.Hz)
-        chidx = neo.ChannelIndex(range(len(self.pots)))
-        chidx.analogsignals.append(self.an_sigs)
-        chidx.coordinates = self.ele_pos * pq.mm
-
-        chidx.create_relationship()
+        self.an_sigs.annotate(coordinates=self.ele_pos * pq.mm)
 
     def test_kcsd1d_estimate(self, cv_params={}):
         self.test_params.update(cv_params)
@@ -86,11 +82,7 @@ class KCSD2D_TestCase(unittest.TestCase):
             temp_signals.append(self.pots[ii])
         self.an_sigs = neo.AnalogSignal(np.array(temp_signals).T * pq.mV,
                                         sampling_rate=1000 * pq.Hz)
-        chidx = neo.ChannelIndex(range(len(self.pots)))
-        chidx.analogsignals.append(self.an_sigs)
-        chidx.coordinates = self.ele_pos * pq.mm
-
-        chidx.create_relationship()
+        self.an_sigs.annotate(coordinates=self.ele_pos * pq.mm)
 
     def test_kcsd2d_estimate(self, cv_params={}):
         self.test_params.update(cv_params)
@@ -149,11 +141,7 @@ class KCSD3D_TestCase(unittest.TestCase):
             temp_signals.append(self.pots[ii])
         self.an_sigs = neo.AnalogSignal(np.array(temp_signals).T * pq.mV,
                                         sampling_rate=1000 * pq.Hz)
-        chidx = neo.ChannelIndex(range(len(self.pots)))
-        chidx.analogsignals.append(self.an_sigs)
-        chidx.coordinates = self.ele_pos * pq.mm
-
-        chidx.create_relationship()
+        self.an_sigs.annotate(coordinates=self.ele_pos * pq.mm)
 
     def test_kcsd3d_estimate(self, cv_params={}):
         self.test_params.update(cv_params)

--- a/elephant/test/test_spade.py
+++ b/elephant/test/test_spade.py
@@ -10,6 +10,7 @@ import unittest
 import random
 
 import neo
+from neo.core.spiketrainlist import SpikeTrainList
 import numpy as np
 import quantities as pq
 from numpy.testing.utils import assert_array_equal
@@ -155,6 +156,34 @@ class SpadeTestCase(unittest.TestCase):
     # Testing with multiple patterns input
     def test_spade_msip(self):
         output_msip = spade.spade(self.msip, self.bin_size, self.winlen,
+                                  approx_stab_pars=dict(
+                                      n_subsets=self.n_subset,
+                                      stability_thresh=self.stability_thresh),
+                                  n_surr=self.n_surr, alpha=self.alpha,
+                                  psr_param=self.psr_param,
+                                  stat_corr='no',
+                                  output_format='patterns')['patterns']
+        elements_msip = []
+        occ_msip = []
+        lags_msip = []
+        # collecting spade output
+        for out in output_msip:
+            elements_msip.append(out['neurons'])
+            occ_msip.append(list(out['times'].magnitude))
+            lags_msip.append(list(out['lags'].magnitude))
+        elements_msip = sorted(elements_msip, key=len)
+        occ_msip = sorted(occ_msip, key=len)
+        lags_msip = sorted(lags_msip, key=len)
+        # check neurons in the patterns
+        assert_array_equal(elements_msip, self.elements_msip)
+        # check the occurrences time of the patters
+        assert_array_equal(occ_msip, self.occ_msip)
+        # check the lags
+        assert_array_equal(lags_msip, self.lags_msip)
+
+    # Testing with multiple patterns input
+    def test_spade_msip_spiketrainlist(self):
+        output_msip = spade.spade(SpikeTrainList(self.msip), self.bin_size, self.winlen,
                                   approx_stab_pars=dict(
                                       n_subsets=self.n_subset,
                                       stability_thresh=self.stability_thresh),

--- a/elephant/test/test_spade.py
+++ b/elephant/test/test_spade.py
@@ -183,14 +183,15 @@ class SpadeTestCase(unittest.TestCase):
 
     # Testing with multiple patterns input
     def test_spade_msip_spiketrainlist(self):
-        output_msip = spade.spade(SpikeTrainList(self.msip), self.bin_size, self.winlen,
-                                  approx_stab_pars=dict(
-                                      n_subsets=self.n_subset,
-                                      stability_thresh=self.stability_thresh),
-                                  n_surr=self.n_surr, alpha=self.alpha,
-                                  psr_param=self.psr_param,
-                                  stat_corr='no',
-                                  output_format='patterns')['patterns']
+        output_msip = spade.spade(
+            SpikeTrainList(self.msip), self.bin_size, self.winlen,
+            approx_stab_pars=dict(
+            n_subsets=self.n_subset,
+            stability_thresh=self.stability_thresh),
+            n_surr=self.n_surr, alpha=self.alpha,
+            psr_param=self.psr_param,
+            stat_corr='no',
+            output_format='patterns')['patterns']
         elements_msip = []
         occ_msip = []
         lags_msip = []

--- a/elephant/utils.py
+++ b/elephant/utils.py
@@ -16,6 +16,7 @@ import warnings
 from functools import wraps
 
 import neo
+from neo.core.spiketrainlist import SpikeTrainList
 import numpy as np
 import quantities as pq
 
@@ -188,7 +189,7 @@ def check_neo_consistency(neo_objects, object_type, t_start=None,
     ValueError
         If input object units, t_start, or t_stop do not match across trials.
     """
-    if not isinstance(neo_objects, (list, tuple)):
+    if not isinstance(neo_objects, (list, tuple, SpikeTrainList)):
         neo_objects = [neo_objects]
     try:
         units = neo_objects[0].units

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-neo>=0.9.0,<0.10.0
+neo>=0.10.0
 numpy>=1.18.1
 quantities>=0.12.1
 scipy<1.7.0


### PR DESCRIPTION
Since Neo 0.10.0, there is a new `SpikeTrainList` object. While this new construct behaves like a list, there are a couple of instances where Elephant directly tests if an input is explicitly a list of SpikeTrains. This PR adds support for allowing SpikeTrainList objects as well as lists of SpikeTrains in these circumstances. 

Fixes:
- `conversion.BinnedSpiketrain` (wtih regression test, where SpikeTrainLists would lead to incorrect binned matrices)
- `spike_train_synchrony.Synchrotool` class
- `spade` module
- `statistics` module, `instantaneous_rate()`

This PR fixes #431.

Also, in Neo 0.10.0, `RecordingChannelGroup` objects are no longer supported. This affects the `current_source_density`, where electrode coordinates where optionally extracted form this object. This PR fixes CSD methods by taking electrode positions from an annotation of the signal. As in the previous version of Elephant, CSD methods alternatively take electrodes as a direct parameter. By nature of the API break in Neo, this also necessarily breaks API in Elephant.