### PR TITLE
Fix pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,3 +74,4 @@ install:
 
 script:
   pytest --cov=elephant --import-mode=importlib
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ install:
 
   - pip -V
   - pip install -r requirements/requirements-tests.txt
+  - pip install pytest==6.2.5 # hotfix as pytest 7.0.0 breaks CI workflows with --import-mode=importlib
   - pip install pytest-cov coveralls
   - pip install .
   - python -c "import sys; sys.path.remove(''); import elephant; print(elephant.__file__, elephant.__version__)"


### PR DESCRIPTION
This PR implements a fix for a bug related to pytest 7.0.0 when running pytest with `--import-mode=importlib`

**Solution:**
- fixed pytest version to 6.2.5