### PR TITLE
Fix/instantaneous rate one point less

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -73,6 +73,7 @@ import neo
 import numpy as np
 import quantities as pq
 import scipy.stats
+import scipy.signal
 
 import elephant.conversion as conv
 import elephant.kernels as kernels

--- a/elephant/test/test_spike_train_generation.py
+++ b/elephant/test/test_spike_train_generation.py
@@ -864,7 +864,7 @@ class NonStationaryGammaTestCase(unittest.TestCase):
                 rate_recovered = rate_recovered.flatten().magnitude
                 trim = (rate_profile.shape[0] - rate_recovered.shape[0]) // 2
                 rate_profile_valid = rate_profile.magnitude.squeeze()
-                rate_profile_valid = rate_profile_valid[trim: -trim - 1]
+                rate_profile_valid = rate_profile_valid[trim: -trim]
                 assert_allclose(rate_recovered, rate_profile_valid,
                                 rtol=0, atol=rtol * rate.item())
 

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -20,7 +20,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal, \
 
 import elephant.kernels as kernels
 from elephant import statistics
-from elephant.spike_train_generation import homogeneous_poisson_process
+from elephant.spike_train_generation import StationaryPoissonProcess as SPP
 
 
 class isi_TestCase(unittest.TestCase):
@@ -139,7 +139,7 @@ class mean_firing_rate_TestCase(unittest.TestCase):
 
     def test_mean_firing_rate_typical_use_case(self):
         np.random.seed(92)
-        st = homogeneous_poisson_process(rate=100 * pq.Hz, t_stop=100 * pq.s)
+        st = SPP(rate=100 * pq.Hz, t_stop=100 * pq.s).generate_spiketrain()
         rate1 = statistics.mean_firing_rate(st)
         rate2 = statistics.mean_firing_rate(st, t_start=st.t_start,
                                             t_stop=st.t_stop)
@@ -616,9 +616,9 @@ class InstantaneousRateTest(unittest.TestCase):
     def test_regression_288(self):
         np.random.seed(9)
         sampling_period = 200 * pq.ms
-        spiketrain = homogeneous_poisson_process(10 * pq.Hz,
-                                                 t_start=0 * pq.s,
-                                                 t_stop=10 * pq.s)
+        spiketrain = SPP(10 * pq.Hz,
+                         t_start=0 * pq.s,
+                         t_stop=10 * pq.s).generate_spiketrain()
         kernel = kernels.AlphaKernel(sigma=5 * pq.ms, invert=True)
         # check that instantaneous_rate "works" for kernels with small sigma
         # without triggering an incomprehensible error
@@ -636,9 +636,9 @@ class InstantaneousRateTest(unittest.TestCase):
         sampling_period = 200 * pq.ms
         sigma = 5 * pq.ms
         rate_expected = 10 * pq.Hz
-        spiketrain = homogeneous_poisson_process(rate_expected,
-                                                 t_start=0 * pq.s,
-                                                 t_stop=10 * pq.s)
+        spiketrain = SPP(rate_expected,
+                         t_start=0 * pq.s,
+                         t_stop=10 * pq.s).generate_spiketrain()
         kernel_types = tuple(
             kern_cls for kern_cls in kernels.__dict__.values()
             if isinstance(kern_cls, type) and
@@ -777,8 +777,8 @@ class InstantaneousRateTest(unittest.TestCase):
     def test_instantaneous_rate_grows_with_sampling_period(self):
         np.random.seed(0)
         rate_expected = 10 * pq.Hz
-        spiketrain = homogeneous_poisson_process(rate=rate_expected,
-                                                 t_stop=10 * pq.s)
+        spiketrain = SPP(rate=rate_expected,
+                         t_stop=10 * pq.s).generate_spiketrain()
         kernel = kernels.GaussianKernel(sigma=100 * pq.ms)
         rates_mean = []
         for sampling_period in np.linspace(1, 1000, num=10) * pq.ms:
@@ -909,8 +909,9 @@ class TimeHistogramTestCase(unittest.TestCase):
 
     def test_annotations(self):
         np.random.seed(1)
-        spiketrains = [homogeneous_poisson_process(
-            rate=10 * pq.Hz, t_stop=10 * pq.s) for _ in range(10)]
+        spiketrains = [SPP(rate=10 * pq.Hz,
+                           t_stop=10 * pq.s).generate_spiketrain()
+                       for _ in range(10)]
         for output in ("counts", "mean", "rate"):
             histogram = statistics.time_histogram(spiketrains,
                                                   bin_size=3 * pq.ms,


### PR DESCRIPTION
This PR fixes #374 .
The output size of the calculated instantaneous rate was corrected.

Reproduce with:
```python
import matplotlib.pyplot as plt
import numpy as np
import quantities as pq

from elephant import statistics, kernels
from elephant.spike_train_generation import homogeneous_poisson_process

np.random.seed(0)
spiketrain = homogeneous_poisson_process(rate=10 * pq.Hz,
                                         t_stop=10 * pq.s)
kernel = kernels.GaussianKernel(sigma=300 * pq.ms)
sampling_period = 445 * pq.ms
rate = statistics.instantaneous_rate(
    spiketrain,
    sampling_period=sampling_period,
    kernel=kernel, center_kernel=True, trim=False)

plt.plot(rate.times.simplified.magnitude, rate.magnitude, color='orange',
         label='instantaneous rate')
plt.eventplot(
    [spiketrain.simplified.magnitude, rate.times.simplified.magnitude],
    colors=['black', 'green'], lineoffsets=2, linelengths=1)
plt.legend()
plt.title(f"{kernel.__class__.__name__}: sigma={int(kernel.sigma.item())} ms, "
          f"sampling_period={int(sampling_period.item())} ms")
fig=plt.gcf()
fig.set_size_inches (18.5, 10.5)
plt.show()
```
![fixed](https://user-images.githubusercontent.com/92092328/154702203-81885b40-666e-4f71-b0db-f41d4b311c29.png)

The original bug seemed to be caused by a misconception, when using [scipy.signal.fftconvolve](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.fftconvolve.html#scipy-signal-fftconvolve) in connection with `mode='full'`.

The length of the output (length_output) when calculating the convolution of a kernel with the input is:
`length_output = length_input + length_kernel -1`.

- [ ] merge after reconciling with PR #414 