### PR TITLE
Add a function to discretise spiketimes

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -1246,3 +1246,64 @@ def _check_neo_spiketrain(matrix):
     if isinstance(matrix, (list, tuple)):
         return all(map(_check_neo_spiketrain, matrix))
     return False
+
+
+def discretise_spiketimes(spiketrains, sampling_rate):
+    """
+    Rounds down all spike times in the input spike train(s)
+    to multiples of the sampling_rate
+
+    Parameters
+    ----------
+    spiketrains : neo.SpikeTrain or list of neo.SpikeTrain
+        The spiketrain(s) to discretise
+    sampling_rate : pq.Quantity
+        The desired sampling rate
+
+    Returns
+    -------
+    neo.SpikeTrain or list of neo.SpikeTrain
+        The discretised spiketrain(s)
+    """
+    # spiketrains type check
+    was_single_spiketrain = False
+    if isinstance(spiketrains, (neo.SpikeTrain)):
+        spiketrains = [spiketrains]
+        was_single_spiketrain = True
+    elif isinstance(spiketrains, list):
+        for st in spiketrains:
+            if not isinstance(st, (np.ndarray, neo.SpikeTrain)):
+                raise TypeError(
+                    "spiketrains must be a SpikeTrain, a numpy ndarray, or a "
+                    "list of one of those, not %s." % type(spiketrains))
+    else:
+        raise TypeError(
+            "spiketrains must be a SpikeTrain or a list of SpikeTrain objects,"
+            " not %s." % type(spiketrains))
+
+    units = spiketrains[0].times.units
+    mag_sampling_rate = sampling_rate.rescale(1/units).magnitude.flatten()
+
+    new_spiketrains = []
+    for spiketrain in spiketrains:
+        mag_t_start = spiketrain.t_start.rescale(units).magnitude.flatten()
+        mag_times = spiketrain.times.magnitude.flatten()
+        discrete_times = (mag_times // (1 / mag_sampling_rate)
+                          / mag_sampling_rate)
+        mask = discrete_times < mag_t_start
+
+        if np.any(mask):
+            warnings.warn(f'{mask.sum()} spike(s) would be before t_start '
+                          'and are set to t_start instead.')
+            discrete_times[mask] = mag_t_start
+
+        discrete_times *= units
+        new_spiketrain = spiketrain.duplicate_with_new_data(discrete_times)
+        new_spiketrain.annotations = spiketrain.annotations
+        new_spiketrain.sampling_rate = sampling_rate
+        new_spiketrains.append(new_spiketrain)
+
+    if was_single_spiketrain:
+        new_spiketrains = new_spiketrains[0]
+
+    return new_spiketrains

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -1281,6 +1281,11 @@ def discretise_spiketimes(spiketrains, sampling_rate):
             "spiketrains must be a SpikeTrain or a list of SpikeTrain objects,"
             " not %s." % type(spiketrains))
 
+    if not isinstance(sampling_rate, pq.Quantity):
+        raise TypeError(
+             "The 'sampling_rate' must be pq.Quantity.\n"
+             "Found: %s." % type(sampling_rate))
+
     units = spiketrains[0].times.units
     mag_sampling_rate = sampling_rate.rescale(1/units).magnitude.flatten()
 

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -1267,7 +1267,7 @@ def discretise_spiketimes(spiketrains, sampling_rate):
     """
     # spiketrains type check
     was_single_spiketrain = False
-    if isinstance(spiketrains, (neo.SpikeTrain)):
+    if isinstance(spiketrains, neo.SpikeTrain):
         spiketrains = [spiketrains]
         was_single_spiketrain = True
     elif isinstance(spiketrains, list):


### PR DESCRIPTION
Adds a function to `conversion.py` which takes a `SpikeTrain` or a list of `SpikeTrain`s as input and returns copies with discretised times. 
This is useful for using `spike_train_synchrony.Synchrotool` with artificial spike trains which do not have a sampling rate, e.g. for Monte Carlo significance computations. It applies a sampling rate to those spike trains to make them resemble experimental spike trains recorded in a setup with an intrinsic sampling rate.