### PR TITLE
Enh/add dois to documentation

### DIFF
--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -3,27 +3,27 @@ Citing Elephant
 ***************
 To refer to the Elephant software package in publications, please use:
 
-(DOI: `10.5281/zenodo.1186602 <https://doi.org/10.5281/zenodo.4582366>`_;
+(DOI: `doi:10.5281/zenodo.1186602 <https://doi.org/10.5281/zenodo.4582366>`_;
 `RRID:SCR_003833 <https://scicrunch.org/resolver/RRID:SCR_003833>`_)
 
 To cite a specific version of elephant use:
 
-* v0.10.0 `10.5281/zenodo.4582366 <https://doi.org/10.5281/zenodo.4582366>`_
-* v0.9.0 `10.5281/zenodo.4271489 <https://doi.org/10.5281/zenodo.4271489>`_
-* v0.8.0 `10.5281/zenodo.3975676 <https://doi.org/10.5281/zenodo.3975676>`_
-* v0.7.0 `10.5281/zenodo.3695277 <https://doi.org/10.5281/zenodo.3695277>`_
-* v0.6.4 `10.5281/zenodo.3524331 <https://doi.org/10.5281/zenodo.3524331>`_
-* v0.6.3 `10.5281/zenodo.3346596 <https://doi.org/10.5281/zenodo.3346596>`_
-* v0.6.1 `10.5281/zenodo.2620229 <https://doi.org/10.5281/zenodo.2620229>`_
-* v0.5.0 `10.5281/zenodo.1216145 <https://doi.org/10.5281/zenodo.1216145>`_
-* v0.4.3 `10.5281/zenodo.1187084 <https://doi.org/10.5281/zenodo.1187084>`_
-* v0.4.2 `10.5281/zenodo.1186603 <https://doi.org/10.5281/zenodo.1186603>`_
+* v0.10.0 `doi:110.5281/zenodo.4582366 <https://doi.org/10.5281/zenodo.4582366>`_
+* v0.9.0 `doi:110.5281/zenodo.4271489 <https://doi.org/10.5281/zenodo.4271489>`_
+* v0.8.0 `doi:110.5281/zenodo.3975676 <https://doi.org/10.5281/zenodo.3975676>`_
+* v0.7.0 `doi:110.5281/zenodo.3695277 <https://doi.org/10.5281/zenodo.3695277>`_
+* v0.6.4 `doi:110.5281/zenodo.3524331 <https://doi.org/10.5281/zenodo.3524331>`_
+* v0.6.3 `doi:10.5281/zenodo.3346596 <https://doi.org/10.5281/zenodo.3346596>`_
+* v0.6.1 `doi:110.5281/zenodo.2620229 <https://doi.org/10.5281/zenodo.2620229>`_
+* v0.5.0 `doi:110.5281/zenodo.1216145 <https://doi.org/10.5281/zenodo.1216145>`_
+* v0.4.3 `doi:1doi:10.5281/zenodo.1187084 <https://doi.org/10.5281/zenodo.1187084>`_
+* v0.4.2 `doi:1doi:10.5281/zenodo.1186603 <https://doi.org/10.5281/zenodo.1186603>`_
 
 To cite Elephant, please use:
 
 **Denker M, Yegenoglu A, Grün S (2018) Collaborative HPC-enabled workflows on
 the HBP Collaboratory using the Elephant framework. Neuroinformatics 2018, P19.
-doi: 10.12751/incf.ni2018.0019**
+doi:10.12751/incf.ni2018.0019**
 
 A BibTeX entry for LaTeX users is:
 

--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -1,16 +1,24 @@
 ***************
 Citing Elephant
 ***************
-DOI
+DOIs
 ===============
-**Concept DOI**, to cite the concept/ all versions of elephant use:
+**Concept DOI**
 
-* all versions: `10.5281/zenodo.1186602 <https://doi.org/10.5281/zenodo.4582366>`_
+The Concept DOI represents all versions when it is desirable to
+cite the concept of elephant, without being specific about the version.
 
-*This DOI represents all versions, and will always resolve to the latest one.*
-*Use this to refer to the concept of elephant and all versions.*
+* concept: `10.5281/zenodo.1186602 <https://doi.org/10.5281/zenodo.4582366>`_
 
-**Version DOI**, to cite a specific version of elephant use the following:
+*This DOI represents all versions, and will always resolve to the latest
+version.*
+
+**Version DOI**
+
+In most cases it is reasonable to use the Version DOI to refer to a specific
+version of elephant.
+This is to ensure that other researchers can access the exact version for
+reproducibility.
 
 * v0.10.0: `10.5281/zenodo.4582366 <https://doi.org/10.5281/zenodo.4582366>`_
 * v0.9.0: `10.5281/zenodo.4271489 <https://doi.org/10.5281/zenodo.4271489>`_

--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -1,27 +1,15 @@
 ***************
 Citing Elephant
 ***************
-DOIs
-===============
-**Concept DOI**
+To refer to the Elephant software package in publications, please use:
 
-The Concept DOI represents all versions when it is desirable to
-cite the concept of elephant, without being specific about the version.
+(DOI: `10.5281/zenodo.1186602 <https://doi.org/10.5281/zenodo.4582366>`_;
+`RRID:SCR_003833 <https://scicrunch.org/resolver/RRID:SCR_003833>`_)
 
-* concept: `10.5281/zenodo.1186602 <https://doi.org/10.5281/zenodo.4582366>`_
+To cite a specific version of elephant use:
 
-*This DOI represents all versions, and will always resolve to the latest
-version.*
-
-**Version DOI**
-
-In most cases it is reasonable to use the Version DOI to refer to a specific
-version of elephant.
-This is to ensure that other researchers can access the exact version for
-reproducibility.
-
-* v0.10.0: `10.5281/zenodo.4582366 <https://doi.org/10.5281/zenodo.4582366>`_
-* v0.9.0: `10.5281/zenodo.4271489 <https://doi.org/10.5281/zenodo.4271489>`_
+* v0.10.0 `10.5281/zenodo.4582366 <https://doi.org/10.5281/zenodo.4582366>`_
+* v0.9.0 `10.5281/zenodo.4271489 <https://doi.org/10.5281/zenodo.4271489>`_
 * v0.8.0 `10.5281/zenodo.3975676 <https://doi.org/10.5281/zenodo.3975676>`_
 * v0.7.0 `10.5281/zenodo.3695277 <https://doi.org/10.5281/zenodo.3695277>`_
 * v0.6.4 `10.5281/zenodo.3524331 <https://doi.org/10.5281/zenodo.3524331>`_
@@ -30,12 +18,6 @@ reproducibility.
 * v0.5.0 `10.5281/zenodo.1216145 <https://doi.org/10.5281/zenodo.1216145>`_
 * v0.4.3 `10.5281/zenodo.1187084 <https://doi.org/10.5281/zenodo.1187084>`_
 * v0.4.2 `10.5281/zenodo.1186603 <https://doi.org/10.5281/zenodo.1186603>`_
-
-RRID
-===============
-To refer to the Elephant software package in publications, please use:
-**Elephant (RRID:SCR_003833)**.
-
 
 To cite Elephant, please use:
 

--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -1,11 +1,32 @@
 ***************
 Citing Elephant
 ***************
+DOI
+===============
+To cite all versions of elephant use:
 
+* all: `<DOI 10.5281/zenodo.1186602>`_.
+*This DOI represents all versions, and will always resolve to the latest one.*
+
+To cite a specific version use:
+
+* v0.10.0: `<10.5281/zenodo.4582366>`_.
+* v0.9.0: `<10.5281/zenodo.4271489>`_.
+* v0.8.0 `<10.5281/zenodo.3975676>`_.
+* v0.7.0 `<10.5281/zenodo.3695277>`_.
+* v0.6.4 `<10.5281/zenodo.3524331>`_.
+* v0.6.3 `<10.5281/zenodo.3346596>`_.
+* v0.6.1 `<10.5281/zenodo.2620229>`_.
+* v0.5.0 `<10.5281/zenodo.1216145>`_.
+* v0.4.3 `<10.5281/zenodo.1187084>`_.
+* v0.4.2 `<10.5281/zenodo.1186603>`_.
+
+RRID
+===============
 To refer to the Elephant software package in publications, please use:
 **Elephant (RRID:SCR_003833)**.
 
-    
+
 To cite Elephant, please use:
 
 **Denker M, Yegenoglu A, Grün S (2018) Collaborative HPC-enabled workflows on
@@ -27,7 +48,7 @@ A BibTeX entry for LaTeX users is:
     }
 
 
-Further publications directly related to Elephant development 
+Further publications directly related to Elephant development
 :cite:`citations-Rostami17_3,citations-Stella19_104022` (see a list of full
 `BibTex references <https://github.com/NeuralEnsemble/elephant/blob/master/doc/bib/elephant.bib>`_
 used in Elephant documentation).

--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -3,23 +3,25 @@ Citing Elephant
 ***************
 DOI
 ===============
-To cite all versions of elephant use:
+**Concept DOI**, to cite the concept/ all versions of elephant use:
 
-* all: `<DOI 10.5281/zenodo.1186602>`_.
+* all versions: `10.5281/zenodo.1186602 <https://doi.org/10.5281/zenodo.4582366>`_
+
 *This DOI represents all versions, and will always resolve to the latest one.*
+*Use this to refer to the concept of elephant and all versions.*
 
-To cite a specific version use:
+**Version DOI**, to cite a specific version of elephant use the following:
 
-* v0.10.0: `<10.5281/zenodo.4582366>`_.
-* v0.9.0: `<10.5281/zenodo.4271489>`_.
-* v0.8.0 `<10.5281/zenodo.3975676>`_.
-* v0.7.0 `<10.5281/zenodo.3695277>`_.
-* v0.6.4 `<10.5281/zenodo.3524331>`_.
-* v0.6.3 `<10.5281/zenodo.3346596>`_.
-* v0.6.1 `<10.5281/zenodo.2620229>`_.
-* v0.5.0 `<10.5281/zenodo.1216145>`_.
-* v0.4.3 `<10.5281/zenodo.1187084>`_.
-* v0.4.2 `<10.5281/zenodo.1186603>`_.
+* v0.10.0: `10.5281/zenodo.4582366 <https://doi.org/10.5281/zenodo.4582366>`_
+* v0.9.0: `10.5281/zenodo.4271489 <https://doi.org/10.5281/zenodo.4271489>`_
+* v0.8.0 `10.5281/zenodo.3975676 <https://doi.org/10.5281/zenodo.3975676>`_
+* v0.7.0 `10.5281/zenodo.3695277 <https://doi.org/10.5281/zenodo.3695277>`_
+* v0.6.4 `10.5281/zenodo.3524331 <https://doi.org/10.5281/zenodo.3524331>`_
+* v0.6.3 `10.5281/zenodo.3346596 <https://doi.org/10.5281/zenodo.3346596>`_
+* v0.6.1 `10.5281/zenodo.2620229 <https://doi.org/10.5281/zenodo.2620229>`_
+* v0.5.0 `10.5281/zenodo.1216145 <https://doi.org/10.5281/zenodo.1216145>`_
+* v0.4.3 `10.5281/zenodo.1187084 <https://doi.org/10.5281/zenodo.1187084>`_
+* v0.4.2 `10.5281/zenodo.1186603 <https://doi.org/10.5281/zenodo.1186603>`_
 
 RRID
 ===============

--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -8,16 +8,16 @@ To refer to the Elephant software package in publications, please use:
 
 To cite a specific version of elephant use:
 
-* v0.10.0 `doi:110.5281/zenodo.4582366 <https://doi.org/10.5281/zenodo.4582366>`_
-* v0.9.0 `doi:110.5281/zenodo.4271489 <https://doi.org/10.5281/zenodo.4271489>`_
-* v0.8.0 `doi:110.5281/zenodo.3975676 <https://doi.org/10.5281/zenodo.3975676>`_
-* v0.7.0 `doi:110.5281/zenodo.3695277 <https://doi.org/10.5281/zenodo.3695277>`_
-* v0.6.4 `doi:110.5281/zenodo.3524331 <https://doi.org/10.5281/zenodo.3524331>`_
+* v0.10.0 `doi:10.5281/zenodo.4582366 <https://doi.org/10.5281/zenodo.4582366>`_
+* v0.9.0 `doi:10.5281/zenodo.4271489 <https://doi.org/10.5281/zenodo.4271489>`_
+* v0.8.0 `doi:10.5281/zenodo.3975676 <https://doi.org/10.5281/zenodo.3975676>`_
+* v0.7.0 `doi:10.5281/zenodo.3695277 <https://doi.org/10.5281/zenodo.3695277>`_
+* v0.6.4 `doi:10.5281/zenodo.3524331 <https://doi.org/10.5281/zenodo.3524331>`_
 * v0.6.3 `doi:10.5281/zenodo.3346596 <https://doi.org/10.5281/zenodo.3346596>`_
-* v0.6.1 `doi:110.5281/zenodo.2620229 <https://doi.org/10.5281/zenodo.2620229>`_
-* v0.5.0 `doi:110.5281/zenodo.1216145 <https://doi.org/10.5281/zenodo.1216145>`_
-* v0.4.3 `doi:1doi:10.5281/zenodo.1187084 <https://doi.org/10.5281/zenodo.1187084>`_
-* v0.4.2 `doi:1doi:10.5281/zenodo.1186603 <https://doi.org/10.5281/zenodo.1186603>`_
+* v0.6.1 `doi:10.5281/zenodo.2620229 <https://doi.org/10.5281/zenodo.2620229>`_
+* v0.5.0 `doi:10.5281/zenodo.1216145 <https://doi.org/10.5281/zenodo.1216145>`_
+* v0.4.3 `doi:10.5281/zenodo.1187084 <https://doi.org/10.5281/zenodo.1187084>`_
+* v0.4.2 `doi:10.5281/zenodo.1186603 <https://doi.org/10.5281/zenodo.1186603>`_
 
 To cite Elephant, please use:
 

--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -3,10 +3,10 @@ Citing Elephant
 ***************
 To refer to the Elephant software package in publications, please use:
 
-(DOI: `doi:10.5281/zenodo.1186602 <https://doi.org/10.5281/zenodo.4582366>`_;
+Elephant (`doi:10.5281/zenodo.1186602 <https://doi.org/10.5281/zenodo.4582366>`_;
 `RRID:SCR_003833 <https://scicrunch.org/resolver/RRID:SCR_003833>`_)
 
-To cite a specific version of elephant use:
+To cite a specific version of Elephant use:
 
 * v0.10.0 `doi:10.5281/zenodo.4582366 <https://doi.org/10.5281/zenodo.4582366>`_
 * v0.9.0 `doi:10.5281/zenodo.4271489 <https://doi.org/10.5281/zenodo.4271489>`_

--- a/doc/tutorials.rst
+++ b/doc/tutorials.rst
@@ -94,3 +94,4 @@ Additional
     tutorials/statistics.ipynb
     tutorials/unitary_event_analysis.ipynb
     tutorials/granger_causality.ipynb
+    tutorials/spade.ipynb


### PR DESCRIPTION
# add Zenodo DOIs to docs
This PR adds the DOIs created with Zenodo to the documentation under [Citing Elephant](https://elephant.readthedocs.io/en/latest/citation.html) (current version).

see new version: https://elephant-docs-development.readthedocs.io/en/enh-add_doi_to_doc/citation.html

**additional small fix**
- added `tutorials/spade.ipynb` to toctree (fix warning in `make html`)