### PR TITLE
disable mac installs for now in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,6 @@ setup_kwargs = {
 }
 # do not compile external modules on darwin
 if platform.system() in ["Windows", "Linux"]:
-    setup_kwargs["ext_modules"] = fim_module
+    setup_kwargs["ext_modules"] = [fim_module]
 
 setup(**setup_kwargs)


### PR DESCRIPTION
This PR addresses Issue #469 . 
Thanks @heplesser for reporting this.

**Bug:**
 Pip-installing Elephant fails with a compiler error under macOS 12.3.

**Fix:**
Disable mac installs for now in `setup.py`.
