### PR TITLE
remove version cap for scipy

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,6 @@
 neo>=0.10.0
 numpy>=1.18.1
 quantities>=0.12.1
-scipy<1.7.0
-#scipy>=1.5.4
+scipy>=1.5.4
 six>=1.10.0
 tqdm


### PR DESCRIPTION
This PR removes the version cap for scipy (<1.7.0).

This cap was introduced here: https://github.com/NeuralEnsemble/elephant/pull/419/commits/1d295504f56183b96137554230c3ec0afb6b6006 .