### PR TITLE
fix headings for release notes, elephant versions < 0.10.0

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,7 +6,7 @@ Elephant 0.11.1 release notes
 =============================
 
 Bug fixes
--------------
+---------
 * Fix installation on macOS (#472)
 
 Documentation
@@ -23,19 +23,19 @@ Other changes
 * Fixed failing unit test asset on macOS (#474)
 
 Selected dependency changes
--------------
+---------------------------
 * scipy >=1.5.4 (#473)
 
 Elephant 0.11.0 release notes
 =============================
 
 Breaking changes
--------------
+----------------
 
 * For current source density measures electrode coordinates can no longer be supplied via a `RecordingChannelGroup` object as it is no longer supported in Neo v0.10.0 (#447)
 
 New functionality and features
--------------
+------------------------------
 
 * Redesigned `elephant.spike_train_generation` module using classes (old API is retained for compatibility) (#416)
 * Added function to calculate the multitaper power spectral density estimate in `elephant.spectral` (#417)
@@ -44,7 +44,7 @@ New functionality and features
 * Support for the new `SpikeTrainList` object of Neo (#447)
 
 Bug fixes
--------------
+---------
 
 * Issue with unit scaling in `BinnedSpikeTrain` (#425)
 * Changed `BinnedSpikeTrain` to support quantities<0.12.4 (#418)
@@ -79,7 +79,7 @@ Other changes
 
 
 Selected dependency changes
--------------
+---------------------------
 * nixio >= 1.5.0
 * neo >= 0.10.0
 * python >= 3.7
@@ -123,8 +123,7 @@ Bug fixes
 
 
 Elephant 0.9.0 release notes
-****************************
-
+============================
 This release is titled to accompany the [2nd Elephant User Workshop](https://www.humanbrainproject.eu/en/education/participatecollaborate/infrastructure-events-trainings/2nd-elephant-user-workshop/)
 
 Viziphant
@@ -189,10 +188,8 @@ Bug fixes
   - surrogates get arbitrary sampling_rate (https://github.com/NeuralEnsemble/elephant/pull/353), which relates to the provenance tracking issue;
 
 
-
 Elephant 0.8.0 release notes
-****************************
-
+============================
 New features
 ------------
 * The `parallel` module is a new experimental module (https://github.com/NeuralEnsemble/elephant/pull/307) to run python functions concurrently. Supports native (pythonic) ProcessPollExecutor and MPI. Not limited to Elephant functional.
@@ -218,7 +215,7 @@ Breaking changes
 * Naming convention changes (`binsize` -> `bin_size`, etc.) in almost all Elephant functions (https://github.com/NeuralEnsemble/elephant/pull/316).
 
 Elephant 0.7.0 release notes
-****************************
+============================
 
 Breaking changes
 ----------------
@@ -264,7 +261,7 @@ Performance
 
 
 Elephant 0.6.4 release notes
-****************************
+============================
 
 This release has been made for the "1st Elephant User Workshop" (https://www.humanbrainproject.eu/en/education/participatecollaborate/infrastructure-events-trainings/1st-elephant-user-workshop-accelerate-structured-and-reproducibl).
 
@@ -296,7 +293,7 @@ Improvements
 
 
 Elephant 0.6.3 release notes
-****************************
+============================
 July 22nd 2019
 
 The release v0.6.3 is mostly about improving maintenance.
@@ -319,7 +316,7 @@ Other changes
 * Single VERSION file (https://github.com/NeuralEnsemble/elephant/pull/231)
 
 Elephant 0.6.2 release notes
-****************************
+============================
 April 23rd 2019
 
 New functions
@@ -334,7 +331,7 @@ Other changes
 
 
 Elephant 0.6.1 release notes
-****************************
+============================
 April 1st 2019
 
 New functions
@@ -352,7 +349,7 @@ Other changes
 
 
 Elephant 0.6.0 release notes
-****************************
+============================
 October 12th 2018
 
 New functions
@@ -370,7 +367,7 @@ Other changes
 
 
 Elephant 0.5.0 release notes
-****************************
+============================
 April 4nd 2018
 
 New functions
@@ -390,7 +387,7 @@ Other changes
 
 
 Elephant 0.4.3 release notes
-****************************
+============================
 March 2nd 2018
 
 Other changes
@@ -400,7 +397,7 @@ Other changes
 
 
 Elephant 0.4.2 release notes
-****************************
+============================
 March 1st 2018
 
 New functions
@@ -426,7 +423,7 @@ Other changes
 
 
 Elephant 0.4.1 release notes
-****************************
+============================
 March 23rd 2017
 
 Other changes
@@ -435,7 +432,7 @@ Other changes
 
 
 Elephant 0.4.0 release notes
-****************************
+============================
 March 22nd 2017
 
 New functions
@@ -461,7 +458,7 @@ Other changes
 
 
 Elephant 0.3.0 release notes
-****************************
+============================
 April 12st 2016
 
 New functions
@@ -490,7 +487,7 @@ Other changes
 
 
 Elephant 0.2.1 release notes
-****************************
+============================
 February 18th 2016
 
 Other changes
@@ -499,7 +496,7 @@ Minor bug fixes.
 
 
 Elephant 0.2.0 release notes
-****************************
+============================
 September 22nd 2015
 
 New functions


### PR DESCRIPTION
This PR fixes the drop-down for the elephant release notes on readthedocs, furthermore the following warning:
```
potentially wrong underline length... 
``` 
was fixed.

## Before:
![Screenshot from 2022-04-14 18-41-50](https://user-images.githubusercontent.com/92092328/163439479-b6d0fac8-bc2c-47e2-97ed-753da357ae66.png)
 ----
## After:
![Screenshot from 2022-04-14 19-09-45](https://user-images.githubusercontent.com/92092328/163439505-9c8a7248-d64b-4e13-9261-26465bcc95fb.png)

