### PR TITLE
Fixed MANIFEST.in to include CUDA/OpenCL sources when installing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,8 @@ include elephant/current_source_density_src/test_data.mat
 include elephant/spade_src/LICENSE
 include elephant/spade_src/src/fim.cpp
 recursive-include elephant/spade_src/include *.h
+include elephant/asset/*.cu
+include elephant/asset/*.cl
 include elephant/test/spike_extraction_test_data.txt
 recursive-include doc *
 prune doc/_build


### PR DESCRIPTION
Currently, when installing Elephant, the CUDA/OpenCL sources in `elephant/asset` are not copied. This leads to failure when trying to run ASSET using GPU acceleration.

This PR fixes the manifest file so that all required files are copied.