### PR TITLE
fix Issue #481, ASSET tries to use a backend that is not present in the environment

### DIFF
--- a/elephant/asset/asset.py
+++ b/elephant/asset/asset.py
@@ -136,7 +136,7 @@ from tqdm import trange, tqdm
 
 import elephant.conversion as conv
 from elephant import spike_train_surrogates
-from elephant.utils import get_cuda_capability_major
+from elephant.utils import get_cuda_capability_major, get_opencl_capability
 
 try:
     from mpi4py import MPI
@@ -513,9 +513,11 @@ class _GPUBackend:
         use_cuda = int(os.getenv("ELEPHANT_USE_CUDA", '1'))
         use_opencl = int(os.getenv("ELEPHANT_USE_OPENCL", '1'))
         cuda_detected = get_cuda_capability_major() != 0
+        opencl_detected = get_opencl_capability()
+
         if use_cuda and cuda_detected:
             return self.pycuda
-        if use_opencl:
+        if use_opencl and opencl_detected:
             return self.pyopencl
         return self.cpu
 

--- a/elephant/test/test_asset.py
+++ b/elephant/test/test_asset.py
@@ -420,8 +420,8 @@ class AssetTestCase(unittest.TestCase):
         if HAVE_PYOPENCL:
             self.assertEqual(backend_obj.backend(), 'opencl')
         else:
-            # if environment variable is set but no module pyopencl or device
-            # is found: choose cpu backend
+            # if environment variable is not set and no module pyopencl or
+            # device is found: choose cpu backend
             self.assertEqual(backend_obj.backend(), 'cpu')
 
         os.environ['ELEPHANT_USE_OPENCL'] = '0'

--- a/elephant/test/test_asset.py
+++ b/elephant/test/test_asset.py
@@ -33,7 +33,7 @@ else:
 
 try:
     import pyopencl
-    HAVE_PYOPENCL = True
+    HAVE_PYOPENCL = asset.get_opencl_capability()
 except ImportError:
     HAVE_PYOPENCL = False
 

--- a/elephant/utils.py
+++ b/elephant/utils.py
@@ -340,3 +340,25 @@ def get_cuda_capability_major():
                                    ctypes.byref(cc_minor),
                                    device)
     return cc_major.value
+
+
+def get_opencl_capability():
+    """
+    Return a list of available OpenCL devices.
+
+    Returns
+    -------
+    bool
+        True: if openCL platform detected, False: if OpenCL is not found or if
+        no OpenCL devices are found
+    """
+    try:
+        import pyopencl
+        platforms = pyopencl.get_platforms()
+
+        if len(platforms) == 0:
+            return False
+        if len(platforms) > 0:
+            return True
+    except ImportError:
+        return False

--- a/elephant/utils.py
+++ b/elephant/utils.py
@@ -349,8 +349,8 @@ def get_opencl_capability():
     Returns
     -------
     bool
-        True: if openCL platform detected, False: if OpenCL is not found or if
-        no OpenCL devices are found
+        True: if openCL platform detected and at least one device is found,
+        False: if OpenCL is not found or if no OpenCL devices are found
     """
     try:
         import pyopencl
@@ -358,7 +358,7 @@ def get_opencl_capability():
 
         if len(platforms) == 0:
             return False
-        if len(platforms) > 0:
-            return True
+        # len(platforms) is > 0, if it is not == 0
+        return True
     except ImportError:
         return False


### PR DESCRIPTION
This PR introduces a check for openCL similar to `get_cuda_capability_major()` to detect openCL devices.
Issue #481 is addressed with this.

- [x] add regression test