### PR TITLE
remove version cap for jinja2

### DIFF
--- a/requirements/environment-docs.yml
+++ b/requirements/environment-docs.yml
@@ -13,7 +13,7 @@ dependencies:
   - pandas
   - scikit-learn
   - statsmodels
-  - jinja2==3.0.3 # prevent bug happening in 3.1.0 for docs
+  - jinja2
   - pip:
     - neo>=0.10.0
     - viziphant


### PR DESCRIPTION
This version cap was introduced with PR #441  to fix an error occurring in connection with jinja 3.1.0.
With current jinja2 3.1.2 this no longer occurs.

See reathedocs build: https://elephant-docs-development.readthedocs.io/en/fix-jinja2_version/