### PR TITLE
Add feature to map pairwise distances matrix to disk while computing the cluster matrix in ASSET

### DIFF
--- a/elephant/asset/asset.py
+++ b/elephant/asset/asset.py
@@ -501,7 +501,7 @@ def _stretched_metric_2d(x, y, stretch, ref_angle, working_memory=None,
             # Using an array mapped to disk. Store in the file passed as
             # parameter
             if verbose:
-                print("Creating disk array at '{disk_array}'.")
+                print(f"Creating disk array at '{disk_array.name}'.")
 
             stretch_mat = np.memmap(disk_array, mode='w+',
                                     shape=(len(x), len(y)),
@@ -2453,7 +2453,7 @@ class ASSET(object):
     @staticmethod
     def cluster_matrix_entries(mask_matrix, max_distance, min_neighbors,
                                stretch, working_memory=None, array_file=None,
-                               verbose=False):
+                               keep_file=False, verbose=False):
         r"""
         Given a matrix `mask_matrix`, replaces its positive elements with
         integers representing different cluster IDs. Each cluster comprises
@@ -2523,6 +2523,11 @@ class ASSET(object):
             array). This option should be used when there is not enough memory
             to allocate the full stretched distance matrix needed before DBSCAN.
             Default: None
+        keep_file : bool, optional
+            Delete the temporary file specified in `array_file` automatically.
+            This option can be used to access the distance matrix after the
+            clustering.
+            Default: False
         verbose : bool, optional
             Display log messages and progress bars.
             Default: False
@@ -2559,7 +2564,8 @@ class ASSET(object):
             file_dir = file_path.parent
             file_name = file_path.stem
             disk_array = tempfile.NamedTemporaryFile(prefix=file_name,
-                                                     dir=file_dir)
+                                                     dir=file_dir,
+                                                     delete=not keep_file)
         
         # Compute the matrix D[i, j] of euclidean distances between pixels i
         # and j

--- a/elephant/asset/asset.py
+++ b/elephant/asset/asset.py
@@ -2552,8 +2552,14 @@ class ASSET(object):
         xpos_sgnf, ypos_sgnf = np.where(mask_matrix > 0)
 
         # Allocate temporary file if requested
-        disk_array = tempfile.TemporaryFile(prefix=array_file) if array_file \
-            else None
+        disk_array = None
+        if array_file:
+            file_path = Path(array_file) if isinstance(array_file, str) \
+                else array_file
+            file_dir = file_path.parent
+            file_name = file_path.stem
+            disk_array = tempfile.NamedTemporaryFile(prefix=file_name,
+                                                     dir=file_dir)
         
         # Compute the matrix D[i, j] of euclidean distances between pixels i
         # and j

--- a/elephant/asset/asset.py
+++ b/elephant/asset/asset.py
@@ -124,6 +124,7 @@ import sys
 import tempfile
 import warnings
 from pathlib import Path
+import tempfile
 
 import neo
 import numpy as np
@@ -345,7 +346,8 @@ def _analog_signal_step_interp(signal, times):
 # =============================================================================
 
 
-def _stretched_metric_2d(x, y, stretch, ref_angle, working_memory=None):
+def _stretched_metric_2d(x, y, stretch, ref_angle, working_memory=None,
+        disk_array=None, verbose=False):
     r"""
     Given a list of points on the real plane, identified by their abscissa `x`
     and ordinate `y`, compute a stretched transformation of the Euclidean
@@ -379,11 +381,36 @@ def _stretched_metric_2d(x, y, stretch, ref_angle, working_memory=None):
     ref_angle : float
         Reference angle in degrees (i.e., the inclination along which the
         stretching factor is 1).
+    working_memory : int, optional
+        The sought maximum memory in MiB for temporary distance matrix chunks.
+        When None (default), no chunking is performed. This parameter is passed
+        directly to `sklearn.metrics.pairwise_distances_chunked` function and
+        it has no influence on the outcome matrix. Instead, it control the
+        memory VS speed trade-off.
+        Default: None
+    disk_array : file-like, optional
+        Temporary file, that should be used to store the matrix  of stretched 
+        distances when chunking the computations. This is achieved  using 
+        `np.memmap`. If `working_memory` is None (no chunking), this parameter
+        is ignored. This will not impact the results, but the  operations will
+        be slower (than chunking and storing the final matrix  in a memory
+        array). This option should be used when there is not enough memory to
+        allocate the full stretched distance matrix needed before DBSCAN.
+        Default: None
+    verbose : bool, optional
+        Display progress bars and log messages.
+        Default: False
 
     Returns
     -------
     D : (n,n) np.ndarray
         Square matrix of distances between all pairs of points.
+
+    Raises
+    ------
+    MemoryError
+        If there is not enough memory to allocate the matrix to store the
+        pairwise distances when using chunked computations.
 
     """
     alpha = np.deg2rad(ref_angle)  # reference angle in radians
@@ -432,19 +459,87 @@ def _stretched_metric_2d(x, y, stretch, ref_angle, working_memory=None):
         stretch_mat = calculate_stretch_mat(theta, D)
     else:
         start = 0
+
+        # Depending on the memory size requested, check how many rows can be
+        # processed per iteration. Mininum is 1. Working memory size is in MB.
+        # Size is computed for a float32 matrix. The function
+        # `pairwise_distances_chunked` returns half of the possible size.
+        estimated_chunk = max(
+            ((working_memory * 1024 * 1024) // (len(y) * 4)) // 2, 1)
+        
+        # The number of rows in a chunk cannot be larger than the maximum
+        estimated_chunk = min(len(x), estimated_chunk)
+
+        # Compute the number of iterations needed
+        it_todo = len(x) // estimated_chunk
+        
+        # If size is not a multiple, an extra iteration with smaller size
+        # is needed
+        last_chunk = len(x) % estimated_chunk
+        if last_chunk > 0:
+            it_todo += 1
+        if verbose:
+            print(f"Estimated chunk size: {estimated_chunk}; "
+                  f"Dimension: ({len(x)}, {len(y)}), "
+                  f"Number of chunked iterations: {it_todo}")
+
         # x and y sizes are the same
-        stretch_mat = np.empty((len(x), len(y)), dtype=np.float32)
-        for D_chunk in pairwise_distances_chunked(
-                points, working_memory=working_memory):
+        if disk_array is None:
+            # Create the distance matrix in memory. Raise exception if
+            # it is not possible due to insufficient memory.
+            try:
+                stretch_mat = np.empty((len(x), len(y)), dtype=np.float32)
+            except MemoryError:
+                required_size = (len(x) * len(y) * 4) / (1024 ** 3)
+                raise MemoryError("Can't allocate array in memory. Specify "
+                                  "a temporary disk file to map the array "
+                                  "to the disk. Operations will be slower. "
+                                  f"The required size is {required_size} GiB")
+
+
+        else:
+            # Using an array mapped to disk. Store in the file passed as
+            # parameter
+            if verbose:
+                print("Creating disk array at '{disk_array}'.")
+
+            stretch_mat = np.memmap(disk_array, mode='w+',
+                                    shape=(len(x), len(y)),
+                                    dtype=np.float32)
+
+            # Buffer to store the computations per iteration, to avoid
+            # writing to the file after every single operation
+            chunk_mat = np.empty((estimated_chunk, len(y)), dtype=np.float32)
+
+
+        for D_chunk in tqdm(
+                pairwise_distances_chunked(points,
+                                           working_memory=working_memory),
+                desc='Pairwise distances chunked',
+                total=it_todo, disable=not verbose):
+
             chunk_size = D_chunk.shape[0]
+
+            assert (chunk_size == estimated_chunk or
+                    chunk_size == last_chunk)           # Safety check
+
             dX = x_array[:, start: start + chunk_size].T - x_array
             dY = y_array[:, start: start + chunk_size].T - y_array
 
-            theta_chunk = np.arctan2(
-                dY, dX, out=stretch_mat[start: start + chunk_size, :])
+            # If not using an array mapped to the disk, the output of
+            # the theta computations are written directly to the
+            # stretch_mat. Otherwise, write to the buffer
+            out = stretch_mat[start: start + chunk_size, :] \
+                if disk_array is None else chunk_mat[:chunk_size, :]
+
+            theta_chunk = np.arctan2(dY, dX, out=out)
 
             # stretch_mat (theta_chunk) is updated in-place here
             calculate_stretch_mat(theta_chunk, D_chunk)
+
+            # If mapping to file, transfer from the buffer to stretch_mat
+            if disk_array is not None:
+                stretch_mat[start: start + chunk_size, :] = theta_chunk
 
             start += chunk_size
 
@@ -2357,7 +2452,8 @@ class ASSET(object):
 
     @staticmethod
     def cluster_matrix_entries(mask_matrix, max_distance, min_neighbors,
-                               stretch, working_memory=None):
+                               stretch, working_memory=None, array_file=None,
+                               verbose=False):
         r"""
         Given a matrix `mask_matrix`, replaces its positive elements with
         integers representing different cluster IDs. Each cluster comprises
@@ -2417,6 +2513,19 @@ class ASSET(object):
             has no influence on the outcome matrix. Instead, it control the
             memory VS speed trade-off.
             Default: None
+        array_file : str or path-like, optional
+            Path to a location of a temporary file, that should be used to
+            store the matrix of stretched  distances when chunking the
+            computations. This is achieved using `np.memmap`. If 
+            `working_memory` is None (no chunking), this parameter is ignored.
+            This will not impact the results, but the  operations will  be
+            slower (than chunking and storing the final matrix in a memory
+            array). This option should be used when there is not enough memory
+            to allocate the full stretched distance matrix needed before DBSCAN.
+            Default: None
+        verbose : bool, optional
+            Display log messages and progress bars.
+            Default: False
 
         Returns
         -------
@@ -2442,16 +2551,24 @@ class ASSET(object):
         # List the significant pixels of mat in a 2-columns array
         xpos_sgnf, ypos_sgnf = np.where(mask_matrix > 0)
 
+        # Allocate temporary file if requested
+        disk_array = tempfile.TemporaryFile(prefix=array_file) if array_file \
+            else None
+        
         # Compute the matrix D[i, j] of euclidean distances between pixels i
         # and j
         try:
             D = _stretched_metric_2d(
                 xpos_sgnf, ypos_sgnf, stretch=stretch, ref_angle=45,
-                working_memory=working_memory
+                working_memory=working_memory, disk_array=disk_array,
+                verbose=verbose
             )
         except MemoryError as err:
             raise MemoryError("Set 'working_memory=100' or another value to "
-                              "chunk the data") from err
+                              "chunk the data. If this does not solve, use the"
+                              " 'array_file' parameter to pass a location for "
+                              "a temporary file to map the array to the disk."
+                              ) from err
 
         # Cluster positions of significant pixels via dbscan
         core_samples, config = dbscan(

--- a/elephant/test/test_asset.py
+++ b/elephant/test/test_asset.py
@@ -236,10 +236,10 @@ class AssetTestCase(unittest.TestCase):
         for working_memory in [1, 10, 100, 1000]:
             with tempfile.TemporaryDirectory() as tmpdir:
                 cmat = asset.ASSET.cluster_matrix_entries(
-                mmat, max_distance=max_distance, min_neighbors=min_neighbors,
-                stretch=stretch, working_memory=working_memory,
-                array_file=Path(tmpdir) / f"test_distances_{working_memory}",
-                verbose=True)
+                    mmat, max_distance=max_distance,
+                    min_neighbors=min_neighbors, stretch=stretch,
+                    working_memory=working_memory,
+                    array_file=Path(tmpdir) / f"test_dist_{working_memory}")
                 assert_array_equal(cmat, cmat_true)
 
     def test_pmat_neighbors_gpu(self):

--- a/elephant/test/test_asset.py
+++ b/elephant/test/test_asset.py
@@ -11,6 +11,8 @@ import os
 import random
 import unittest
 import warnings
+import tempfile
+from pathlib import Path
 
 import neo
 import numpy as np
@@ -220,6 +222,25 @@ class AssetTestCase(unittest.TestCase):
                 mmat, max_distance=max_distance, min_neighbors=min_neighbors,
                 stretch=stretch, working_memory=working_memory)
             assert_array_equal(cmat, cmat_true)
+
+    def test_cluster_matrix_entries_chunked_array_file(self):
+        np.random.seed(12)
+        mmat = np.random.randn(100, 100) > 0
+        max_distance = 2
+        min_neighbors = 2
+        stretch = 2
+        cmat_true = asset.ASSET.cluster_matrix_entries(
+            mmat, max_distance=max_distance, min_neighbors=min_neighbors,
+            stretch=stretch)
+
+        for working_memory in [1, 10, 100, 1000]:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                cmat = asset.ASSET.cluster_matrix_entries(
+                mmat, max_distance=max_distance, min_neighbors=min_neighbors,
+                stretch=stretch, working_memory=working_memory,
+                array_file=Path(tmpdir) / f"test_distances_{working_memory}",
+                verbose=True)
+                assert_array_equal(cmat, cmat_true)
 
     def test_pmat_neighbors_gpu(self):
         np.random.seed(12)


### PR DESCRIPTION
The `cluster_matrix_entries` step in ASSET uses DBSCAN on the generated mask matrix, to extract the clusters associated with the SSEs being identified. As a custom distance metric was used, the implementation in ASSET first precomputes all pairwise distances and passes them to the `sklearn` function that performs DBSCAN.

Depending on the number of significant points being clustered, the memory requirements for this distance matrix increase. An option to compute the distances in chunks is available when memory errors occurred, but this still requires the allocation of an NxN matrix with `float32` precision in memory (where N is the number of significant points found in the mask matrix). As the data length increases, it is expected that the number of significant points will also increase, and the computation would be unfeasible as this matrix can quickly reach TiB sizes.

This PR adds an option to pass a location for a file on the disk, that will be used to map the pairwise distance matrix to a file. Therefore, no allocation in memory is needed, but the operations will be slower. This was implemented to be used only if already using chunking (`working_memory` parameter). As additional options, the user can produce verbose messages for debugging, and also has the option of keeping the file (which could be useful if the user wants to do some analyses on the distances, such as k-distance graphs).