### PR TITLE
Fix/onedimensional sigma

### DIFF
--- a/elephant/kernels.py
+++ b/elephant/kernels.py
@@ -147,8 +147,8 @@ class Kernel(object):
             raise TypeError("'sigma' must be a quantity")
 
         if sigma.ndim > 0:
-            # handle the one-dimensional case
-            if sigma.size == 1:
+            # handle the one-dimensional case of size 1
+            if sigma.ndim == 1 & sigma.size == 1:
                 sigma = sigma[0]
             else:
                 raise TypeError("'sigma' cannot be multidimensional")

--- a/elephant/kernels.py
+++ b/elephant/kernels.py
@@ -132,6 +132,10 @@ class Kernel(object):
     TypeError
         If `sigma` is not `pq.Quantity`.
 
+        If `sigma` is a multidimensional array
+
+    ValueError
+
         If `sigma` is negative.
 
         If `invert` is not `bool`.
@@ -141,6 +145,13 @@ class Kernel(object):
     def __init__(self, sigma, invert=False):
         if not isinstance(sigma, pq.Quantity):
             raise TypeError("'sigma' must be a quantity")
+
+        if sigma.ndim > 0:
+            # handle the one-dimensional case
+            if sigma.size == 1:
+                sigma = sigma[0]
+            else:
+                raise TypeError("'sigma' cannot be multidimensional")
 
         if sigma.magnitude < 0:
             raise ValueError("'sigma' cannot be negative")

--- a/elephant/test/test_kernels.py
+++ b/elephant/test/test_kernels.py
@@ -31,8 +31,13 @@ class kernel_TestCase(unittest.TestCase):
         """
         Test of various error cases in the kernels module.
         """
-        self.assertRaises(
-            TypeError, kernels.RectangularKernel, sigma=2.0)
+        # pass multidimensional sigma
+        self.assertRaises(TypeError, kernels.RectangularKernel,
+                          sigma=[2.0, 2.3] * pq.s)
+        # pass one-dimensional sigma, this should be handled
+        self.assertEqual(
+            kernels.RectangularKernel(sigma=[2.0] * pq.s).sigma.ndim, 0)
+        self.assertRaises(TypeError, kernels.RectangularKernel, sigma=2.0)
         self.assertRaises(
             ValueError, kernels.RectangularKernel, sigma=-0.03 * pq.s)
         self.assertRaises(


### PR DESCRIPTION
This PR addresses Issue #455 .

### Changes
- check dimensions of sigma, if dimension > 0 , raise `typeError`
- handle unambiguous case `ndim=1` , `size = 1` with `sigma = sigma[0]`
- added tests for both above cases

### Test
The following code snippet should no longer throw an error

```python
import neo
import elephant
import quantities as pq

st = neo.SpikeTrain([1]*pq.s, t_stop=2*pq.s)
kernel = elephant.kernels.GaussianKernel(sigma=[20]*pq.ms)

rate = elephant.statistics.instantaneous_rate(st,
                                              sampling_period=1*pq.ms,
                                              kernel=kernel)
```