### PR TITLE
fix/#410, UE cast to int in 'unsafe' mode

### DIFF
--- a/elephant/unitary_event_analysis.py
+++ b/elephant/unitary_event_analysis.py
@@ -582,7 +582,7 @@ def gen_pval_anal(mat, pattern_hash, method='analytic_TrialByTrial',
             mat, pattern_hash, method=method, n_surrogates=n_surrogates)
 
         def pval(n_emp):
-            hist = np.bincount(np.int64(n_exp))
+            hist = np.bincount(n_exp.astype(int))
             exp_dist = hist / float(np.sum(hist))
             if len(n_emp) > 1:
                 raise ValueError('In surrogate method the p_value can be'

--- a/elephant/unitary_event_analysis.py
+++ b/elephant/unitary_event_analysis.py
@@ -582,7 +582,7 @@ def gen_pval_anal(mat, pattern_hash, method='analytic_TrialByTrial',
             mat, pattern_hash, method=method, n_surrogates=n_surrogates)
 
         def pval(n_emp):
-            hist = np.bincount(n_exp.astype(int))
+            hist = np.bincount(n_exp.astype(int, casting='unsafe'))
             exp_dist = hist / float(np.sum(hist))
             if len(n_emp) > 1:
                 raise ValueError('In surrogate method the p_value can be'


### PR DESCRIPTION
This PR addresses Issue #410  

The following error occurred in https://github.com/NeuralEnsemble/elephant/blob/0df45812b93229b3186c061cb84ec29fd380e09c/elephant/unitary_event_analysis.py#L585

```
TypeError: Cannot cast array data from dtype('int64') to dtype('int32') according to the rule 'safe'
```

This might be fixed by using np.astype(int) instead of np.in64() to cast to int. 
`np.astype` allows 'unsafe' casting by default, see:
https://numpy.org/doc/stable/reference/generated/numpy.ndarray.astype.html
