### PR TITLE
enh/upload docs .html-files as artifact

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -372,3 +372,9 @@ jobs:
         run: |
           cd doc
           make html
+
+      - name: Upload HTML
+        uses: actions/upload-artifact@v3
+        with:
+           name: docs-html
+           path: doc/_build/html


### PR DESCRIPTION
**Upload docs html-files as artifact to github**

This PR adds [upload-a-build-artifact](https://github.com/marketplace/actions/upload-a-build-artifact) action to build-docs workflow.

After docs are build on github actions, the html-files can be downloaded as a  build artifact.