### PR TITLE
add specification with example for entries in bib-file to documentation

### DIFF
--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -307,7 +307,31 @@ Citations
 The citations are in BibTeX format, stored in `doc/bib/elephant.bib
 <https://github.com/NeuralEnsemble/elephant/blob/master/doc/bib/elephant.bib>`_.
 
-To cite Elephant, refer to :doc:`citation`.
+Entries in the .bib are built according to the following specification:
+
+``{Last name of first author}+{last two digits of publication year}+"_"+{first page of article}``
+
+
+.. note::
+
+    According to this specification, the following article:
+
+    S. Grün. Data-driven significance estimation of precise spike correlation. J. Neurophysiol., pages 1126–1140, 2009. doi:10.1152/jn.00093.2008.
+
+    is added to the .bib-file as ``Gruen09_1126``. The complete entry for this example is:
+
+    .. code-block:: rst
+
+        @article{Gruen09_1126,
+          title={Data-driven significance estimation of precise spike correlation},
+          author={Gr\"{u}n, S.},
+          year={2009},
+          journal={J. Neurophysiol.},
+          number={101},
+          pages={1126--1140},
+          doi={10.1152/jn.00093.2008}
+        }
+
 
 Each module in ``doc/reference`` folder ends with the reference section:
 
@@ -327,5 +351,7 @@ where ``<module name>`` is (by convention) the Python source file name, and
 For example, ``:cite:'spade-Torre2013_132'`` will be rendered as ``sp1`` in
 the built HTML documentation, if ``<module name shortcut>`` is set to ``sp``
 and ``<module name>`` - to ``spade``.
+
+To cite Elephant itself, refer to :doc:`citation`.
 
 .. _Issue tracker: https://github.com/NeuralEnsemble/elephant/issues

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -312,7 +312,7 @@ Entries in the .bib are built according to the following specification:
 ``{Last name of first author}+{last two digits of publication year}+"_"+{first page of article}``
 
 
-.. note::
+.. admonition:: Example
 
     According to this specification, the following article:
 


### PR DESCRIPTION
This PR adds the specification and an example on how to add entries to the elephant.bib file to the documentation.

See: https://elephant--504.org.readthedocs.build/en/504/contribute.html