### PR TITLE
updated documentation from nosetests to pytest

### DIFF
--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -92,12 +92,12 @@ your local machine.
 3. Before you make any changes, run the test suite to make sure all the tests
    pass on your system::
 
-    $ nosetests .
+    $ pytest .
 
    You can specify a particular module to test, for example
    ``test_statistics.py``::
 
-    $ nosetests elephant/test/test_statistics.py
+    $ pytest elephant/test/test_statistics.py
 
    At the end, if you see "OK", then all the tests passed (or were skipped
    because certain dependencies are not installed), otherwise it will report


### PR DESCRIPTION
Updated documentation on running the test suite for elephant from nosetest to pytest.

See: https://elephant--505.org.readthedocs.build/en/505/contribute.html

This is related to PR #413 .