### PR TITLE
Allow passing spike rates directly to gpfa

### DIFF
--- a/elephant/gpfa/gpfa.py
+++ b/elephant/gpfa/gpfa.py
@@ -460,7 +460,7 @@ class GPFA(sklearn.base.BaseEstimator):
                 raise ValueError("'spiketrains' must contain the same number of "
                                 "neurons as the training spiketrain data")
             seqs = gpfa_util.get_seqs(spiketrains, self.bin_size)
-        elif seq_trains is not None:
+        elif seqs is not None:
             # check some stuff
             pass
 

--- a/elephant/gpfa/gpfa.py
+++ b/elephant/gpfa/gpfa.py
@@ -449,15 +449,16 @@ class GPFA(sklearn.base.BaseEstimator):
             If `returned_data` contains keys different from the ones in
             `self.valid_data_names`.
         """
+        
+        invalid_keys = set(returned_data).difference(self.valid_data_names)
+        if len(invalid_keys) > 0:
+            raise ValueError("'returned_data' can only have the following "
+                                "entries: {}".format(self.valid_data_names))
 
         if spiketrains is not None:
             if len(spiketrains[0]) != len(self.has_spikes_bool):
                 raise ValueError("'spiketrains' must contain the same number of "
                                 "neurons as the training spiketrain data")
-            invalid_keys = set(returned_data).difference(self.valid_data_names)
-            if len(invalid_keys) > 0:
-                raise ValueError("'returned_data' can only have the following "
-                                "entries: {}".format(self.valid_data_names))
             seqs = gpfa_util.get_seqs(spiketrains, self.bin_size)
         elif seq_trains is not None:
             # check some stuff

--- a/elephant/gpfa/gpfa.py
+++ b/elephant/gpfa/gpfa.py
@@ -376,7 +376,7 @@ class GPFA(sklearn.base.BaseEstimator):
             seq['y'] = seq['y'][self.has_spikes_bool, :]
         return seqs
 
-    def transform(self, spiketrains, seq_trains=None, returned_data=['latent_variable_orth']):
+    def transform(self, spiketrains, seqs=None, returned_data=['latent_variable_orth']):
         """
         Obtain trajectories of neural activity in a low-dimensional latent
         variable space by inferring the posterior mean of the obtained GPFA


### PR DESCRIPTION
Hi there -- I made a little edit to the gpfa class that allows spike rates to be passed in directly, bypassing the first step of the processing. This would allow gpfa to be used on df/f traces, or pre-interpolated spike rates, or really any continuous set of values.

I don't know if the downstream analysis assumes things specific to spike rates, eg only positive values, but if so, might be good to add checks to that effect in 

Also, it seemed like the check in transform() `if len(spiketrains[0]) != len(self.has_spikes_bool)` was redundant / conflicting with the line a few lines later `seq['y'] = seq['y'][self.has_spikes_bool, :]`, so I didn't add any checks there, but it feels like it ought to check something about `seq`.

Anyways, hope this helps someone :)