### PR TITLE
WelchPSD, WelchCohere, replace 'hanning' with 'hann', scipy 1.9.0

### DIFF
--- a/elephant/spectral.py
+++ b/elephant/spectral.py
@@ -13,10 +13,9 @@ spectrum).
 :license: Modified BSD, see LICENSE.txt for details.
 """
 
-from __future__ import division, print_function, unicode_literals
+import warnings
 
 import neo
-import warnings
 import numpy as np
 import quantities as pq
 import scipy.signal

--- a/elephant/spectral.py
+++ b/elephant/spectral.py
@@ -32,7 +32,7 @@ __all__ = [
 @deprecated_alias(num_seg='n_segments', len_seg='len_segment',
                   freq_res='frequency_resolution')
 def welch_psd(signal, n_segments=8, len_segment=None,
-              frequency_resolution=None, overlap=0.5, fs=1.0, window='hanning',
+              frequency_resolution=None, overlap=0.5, fs=1.0, window='hann',
               nfft=None, detrend='constant', return_onesided=True,
               scaling='density', axis=-1):
     """
@@ -91,7 +91,7 @@ def welch_psd(signal, n_segments=8, len_segment=None,
     window : str or tuple or np.ndarray, optional
         Desired window to use.
         See Notes [2].
-        Default: 'hanning'
+        Default: 'hann'
     nfft : int, optional
         Length of the FFT used.
         See Notes [2].
@@ -520,7 +520,7 @@ def multitaper_psd(signal, n_segments=1, len_segment=None,
                   len_seg='len_segment', freq_res='frequency_resolution')
 def welch_coherence(signal_i, signal_j, n_segments=8, len_segment=None,
                     frequency_resolution=None, overlap=0.5, fs=1.0,
-                    window='hanning', nfft=None, detrend='constant',
+                    window='hann', nfft=None, detrend='constant',
                     scaling='density', axis=-1):
     r"""
     Estimates coherence between a given pair of analog signals.
@@ -574,7 +574,7 @@ def welch_coherence(signal_i, signal_j, n_segments=8, len_segment=None,
     window : str or tuple or np.ndarray, optional
         Desired window to use.
         See Notes [1].
-        Default: 'hanning'
+        Default: 'hann'
     nfft : int, optional
         Length of the FFT used.
         See Notes [1].

--- a/elephant/spectral.py
+++ b/elephant/spectral.py
@@ -195,7 +195,13 @@ def welch_psd(signal, n_segments=8, len_segment=None,
         3.14573483e-08, 6.82050475e-09, 1.18183354e-10]]) * mV**2/Hz
 
     """
-
+    # 'hanning' window was removed with release of scipy 1.9.0, it was
+    # deprecated since 1.1.0.
+    if window == 'hanning':
+        warnings.warn("'hanning' is deprecated and was removed from scipy "
+                      "with release 1.9.0. Please use 'hann' instead",
+                      DeprecationWarning)
+        window = 'hann'
     # initialize a parameter dict (to be given to scipy.signal.welch()) with
     # the parameters directly passed on to scipy.signal.welch()
     params = {'window': window, 'nfft': nfft,
@@ -670,6 +676,13 @@ def welch_coherence(signal_i, signal_j, n_segments=8, len_segment=None,
     """
 
     # TODO: code duplication with welch_psd()
+    # 'hanning' window was removed with release of scipy 1.9.0, it was
+    # deprecated since 1.1.0.
+    if window == 'hanning':
+        warnings.warn("'hanning' is deprecated and was removed from scipy "
+                      "with release 1.9.0. Please use 'hann' instead",
+                      DeprecationWarning)
+        window = 'hann'
 
     # initialize a parameter dict for scipy.signal.csd()
     params = {'window': window, 'nfft': nfft,

--- a/elephant/spectral.py
+++ b/elephant/spectral.py
@@ -329,7 +329,7 @@ def multitaper_psd(signal, n_segments=1, len_segment=None,
         Time bandwidth product
         Default: 4.0.
     num_tapers : int, optional
-        Number of tapers used in 1. to obtain estimate of PSD. By default
+        Number of tapers used in 1. to obtain estimate of PSD. By default,
         [2*nw] - 1 is chosen.
         Default: None.
     peak_resolution : pq.Quantity float, optional
@@ -607,7 +607,7 @@ def welch_coherence(signal_i, signal_j, n_segments=8, len_segment=None,
         Estimate of coherency between the input time series. For each
         frequency, coherency takes a value between 0 and 1, with 0 or 1
         representing no or perfect coherence, respectively.
-        When the input arrays `signal_i` and `signal_j` are multi-dimensional,
+        When the input arrays `signal_i` and `signal_j` are multidimensional,
         `coherency` is of the same shape as the inputs, and the frequency is
         indexed depending on the type of the input. If the input is
         `neo.AnalogSignal`, the first axis indexes frequency. Otherwise,

--- a/elephant/test/test_spectral.py
+++ b/elephant/test/test_spectral.py
@@ -139,7 +139,7 @@ class WelchPSDTestCase(unittest.TestCase):
         noise = np.random.normal(size=(num_channel, data_length))
         data_np = np.array(noise)
         # Since row-column order in AnalogSignal is different from the
-        # conventional one, `data_np` needs to be transposed when its used to
+        # conventional one, `data_np` needs to be transposed when it's used to
         # define an AnalogSignal
         data_neo = n.AnalogSignal(data_np.T,
                                   sampling_period=sampling_period * pq.s,
@@ -444,7 +444,7 @@ class WelchCohereTestCase(unittest.TestCase):
         x_np = np.array(np.random.normal(size=(num_channel, data_length)))
         y_np = np.array(np.random.normal(size=(num_channel, data_length)))
         # Since row-column order in AnalogSignal is different from the
-        # convention in NumPy/SciPy, `data_np` needs to be transposed when its
+        # convention in NumPy/SciPy, `data_np` needs to be transposed when it's
         # used to define an AnalogSignal
         x_neo = n.AnalogSignal(x_np.T, units='mV',
                                sampling_period=sampling_period * pq.s)

--- a/elephant/test/test_spectral.py
+++ b/elephant/test/test_spectral.py
@@ -46,6 +46,14 @@ class WelchPSDTestCase(unittest.TestCase):
         self.assertRaises(ValueError, elephant.spectral.welch_psd, data,
                           overlap=1.1)
 
+    def test_welch_psd_warnings(self):
+        # generate a dummy data
+        data = n.AnalogSignal(np.zeros(5000), sampling_period=0.001 * pq.s,
+                              units='mV')
+        # Test deprecation warning for 'hanning' window
+        self.assertWarns(DeprecationWarning, elephant.spectral.welch_psd,
+                         data, window='hanning')
+
     def test_welch_psd_behavior(self):
         # generate data by adding white noise and a sinusoid
         data_length = 5000
@@ -336,6 +344,16 @@ class WelchCohereTestCase(unittest.TestCase):
                           overlap=-1.0)
         self.assertRaises(ValueError, elephant.spectral.welch_coherence, x, y,
                           overlap=1.1)
+
+    def test_welch_cohere_warnings(self):
+        # generate a dummy data
+        x = n.AnalogSignal(np.zeros(5000), sampling_period=0.001 * pq.s,
+                           units='mV')
+        y = n.AnalogSignal(np.zeros(5000), sampling_period=0.001 * pq.s,
+                           units='mV')
+        # Test deprecation warning for 'hanning' window
+        self.assertWarns(DeprecationWarning, elephant.spectral.welch_coherence,
+                         x, y, window='hanning')
 
     def test_welch_cohere_behavior(self):
         # generate data by adding white noise and a sinusoid


### PR DESCRIPTION
**Bug** 
With release of scipy 1.9.0, `signal.windows.hanning` was removed.
See release notes: https://github.com/scipy/scipy/releases/tag/v1.9.0.

Deprecated since: 1.1.0 see: https://github.com/scipy/scipy/pull/8148

See: https://github.com/scipy/scipy/pull/8148

**Fix**  (This fixes #510 )
- Replaced the default value 'hanning' with 'hann', since hanning is an alias for hann.
- added deprecation warning and unit-tests.