### PR TITLE
Fix/add nixio to test requirements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -153,6 +153,7 @@ jobs:
         run: |
           python --version
           conda env list
+          conda install mpi4py openmpi
           conda install pytest
           conda install pytest-cov coveralls
           pip install -e .[extras]

--- a/requirements/environment-tests.yml
+++ b/requirements/environment-tests.yml
@@ -16,5 +16,6 @@ dependencies:
   - jinja2
   - pip:
     - neo>=0.10.0
+    - nixio>=1.5.0
     # - viziphant
     # neo, viziphant can be removed once it is integrated into requirements-tutorials.txt

--- a/requirements/environment-tests.yml
+++ b/requirements/environment-tests.yml
@@ -10,7 +10,7 @@ dependencies:
   - numpy
   - scipy
   - tqdm
-  - pandas<=1.4.3
+  - pandas
   - scikit-learn
   - statsmodels
   - jinja2

--- a/requirements/environment-tests.yml
+++ b/requirements/environment-tests.yml
@@ -10,7 +10,7 @@ dependencies:
   - numpy
   - scipy
   - tqdm
-  - pandas
+  - pandas<=1.4.3
   - scikit-learn
   - statsmodels
   - jinja2

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -1,1 +1,2 @@
 pytest
+nixio>=1.5.0


### PR DESCRIPTION
This PR adds the nixio package to elephants test requirements.

Until now, `.nix`-files and the corresponding nixio were only use for tutorials.  

Since datasets for unit-tests, (more specifically for validation tests) might come as `.nix`-files, this is a neccessary addition.

nixio: https://pypi.org/project/nixio/

This came up in with PR #491, thanks @ojoenlanuca  for the hint.