### PR TITLE
Include spike_train_synchrony in the init of elephant

### DIFF
--- a/elephant/__init__.py
+++ b/elephant/__init__.py
@@ -8,6 +8,7 @@ Elephant is a package for the analysis of neurophysiology data, based on Neo.
 
 from . import (statistics,
                spike_train_generation,
+               spike_train_synchrony,
                spike_train_correlation,
                unitary_event_analysis,
                cubic,


### PR DESCRIPTION
This fixes an issue where
```
import elephant
```
did not automatically import the `spike_train_synchrony` module reported by @essink .