### PR TITLE
Fix condition to run sync to ebrains workflow

### DIFF
--- a/.github/workflows/ebrains.yml
+++ b/.github/workflows/ebrains.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   sync_to_ebrains:
+    if: github.repository_owner == 'NeuralEnsemble'
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'NeuralEnsemble' }}
     steps:
       - name: syncmaster
         uses: wei/git-sync@v3


### PR DESCRIPTION
Fix condition to run sync to ebrains workflow only on NeuralEnsemble and not on forks.