### PR TITLE
Fix: zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -41,7 +41,6 @@
             "name": "Kramer, Maximilian"
         },
         {
-            "orcid": "",
             "affiliation": "Institute of Neuroscience and Medicine (INM-6) and Institute for Advanced Simulation (IAS-6) and JARA-Institute Brain Structure-Function Relationships (INM-10), Jülich Research Centre, Jülich, Germany",
             "name": "Kloß, Oliver"
         },


### PR DESCRIPTION
## Bug:
- The last trigger upon releasing version 0.11.2 of Elephant (using .zenodo.json as configuration) has provided an error on "release.released" (Server response: "message":"(psycopg2.IntegrityError) duplicate key value violates unique constraint \"uq_github_releases_release_id\"\n)
- the newest release of elephant 0.11.2 is not visible on Zenodo

## Fix
- remove line 44:  `orcid: ""`
- apparently empty fields are not allowed and throw an error on zenodo
