### PR TITLE
Fix: math rendering with sphinx 5.3.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -349,9 +349,6 @@ intersphinx_mapping = {
 # The name of math_renderer extension for HTML output.
 html_math_renderer = 'mathjax'
 
-# Use more reliable mathjax source
-mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
-
 # Remove the copyright notice from docstrings:
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -347,8 +347,11 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable', None)
 }
 
+# The name of math_renderer extension for HTML output.
+html_math_renderer = 'mathjax'
+
 # Use more reliable mathjax source
-mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
 # Remove the copyright notice from docstrings:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,7 +33,6 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
-    'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
     'sphinx.ext.mathjax',
     'sphinxcontrib.bibtex',


### PR DESCRIPTION
# Bug
Documenation build with sphinx 5.3.0 (5.2.3 works) does not render math expressions properly, see:
https://elephant.readthedocs.io/en/v0.11.2/reference/_toctree/signal_processing/elephant.signal_processing.cross_correlation_function.html#elephant.signal_processing.cross_correlation_function

# Fix
In previous Sphinx releases, mathjax was the default html math renderer. With release 5.3.0, math expressions are no longer rendered properly, defining mathjax as the renderer fixes this Issue. 

- defined mathjax as html renderer
- removed source for mathjax (old link ist deprecated, see: https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML)
- removed sphinx extension `imgmath`