### PR TITLE
Fix/numpy >= 1.24.0

### DIFF
--- a/elephant/cell_assembly_detection.py
+++ b/elephant/cell_assembly_detection.py
@@ -440,7 +440,7 @@ def cell_assembly_detection(binned_spiketrain, max_lag, reference_lag=2,
         times = np.where(pattern['times'] > 0)[0] * bin_size + t_start
         pattern['times'] = times
         pattern['lags'] = pattern['lags'] * bin_size
-        pattern['signature'] = np.array(pattern['signature'], dtype=int)
+        pattern['signature'] = np.array(pattern['signature'], dtype=np.int32)
 
     # Give as output only the maximal groups
     if verbose:

--- a/elephant/cell_assembly_detection.py
+++ b/elephant/cell_assembly_detection.py
@@ -257,7 +257,7 @@ def cell_assembly_detection(binned_spiketrain, max_lag, reference_lag=2,
         print('actual significance_level', alpha)
 
     # sign_pairs_matrix is the matrix with entry as 1 for the significant pairs
-    sign_pairs_matrix = np.zeros((n_neurons, n_neurons), dtype=np.int)
+    sign_pairs_matrix = np.zeros((n_neurons, n_neurons), dtype=int)
     assembly = []
     if verbose:
         print('Testing on pairs...')
@@ -440,7 +440,7 @@ def cell_assembly_detection(binned_spiketrain, max_lag, reference_lag=2,
         times = np.where(pattern['times'] > 0)[0] * bin_size + t_start
         pattern['times'] = times
         pattern['lags'] = pattern['lags'] * bin_size
-        pattern['signature'] = np.array(pattern['signature'], dtype=np.int32)
+        pattern['signature'] = np.array(pattern['signature'], dtype=int)
 
     # Give as output only the maximal groups
     if verbose:
@@ -489,15 +489,15 @@ def _chunking(binned_pair, size_chunks, max_lag, best_lag):
     # new chunk size, this is to have all chunks of roughly the same size
     size_chunks = math.floor((length - max_lag) / n_chunks)
 
-    n_chunks = np.int(n_chunks)
-    size_chunks = np.int(size_chunks)
+    n_chunks = int(n_chunks)
+    size_chunks = int(size_chunks)
 
     chunked = [[[], []] for _ in range(n_chunks)]
 
     # cut the time series according to best_lag
 
-    binned_pair_cut = np.array([np.zeros(length - max_lag, dtype=np.int),
-                                np.zeros(length - max_lag, dtype=np.int)])
+    binned_pair_cut = np.array([np.zeros(length - max_lag, dtype=int),
+                                np.zeros(length - max_lag, dtype=int)])
 
     # choose which entries to consider according to the best lag chosen
     if best_lag == 0:
@@ -630,15 +630,15 @@ def _test_pair(ensemble, spiketrain2, n2, max_lag, size_chunks, reference_lag,
 
     # Divide in parallel trials with 0/1 elements
     # max number of spikes in one bin for both neurons
-    maxrate = np.int(max(max(binned_pair[0]), max(binned_pair[1])))
+    maxrate = int(max(max(binned_pair[0]), max(binned_pair[1])))
 
     # creation of the parallel processes, one for each rate up to maxrate
     # and computation of the coincidence count for both neurons
-    par_processes = np.zeros((maxrate, 2, ntp), dtype=np.int)
-    par_proc_expectation = np.zeros(maxrate, dtype=np.int)
+    par_processes = np.zeros((maxrate, 2, ntp), dtype=int)
+    par_proc_expectation = np.zeros(maxrate, dtype=int)
 
     for i in range(maxrate):
-        par_processes[i] = np.array(binned_pair > i, dtype=np.int)
+        par_processes[i] = np.array(binned_pair > i, dtype=int)
         par_proc_expectation[i] = (np.sum(par_processes[i][0]) * np.sum(
             par_processes[i][1])) / float(ntp)
 
@@ -849,16 +849,16 @@ def _test_pair(ensemble, spiketrain2, n2, max_lag, size_chunks, reference_lag,
                                  max_lag=max_lag,
                                  best_lag=best_lag)
 
-        marginal_counts = np.zeros((nch, maxrate, 2), dtype=np.int)
+        marginal_counts = np.zeros((nch, maxrate, 2), dtype=int)
 
         # for every chunk, a vector with in each entry the sum of elements
         # in each parallel binary process, for each unit
 
         # maxrate_t : contains the maxrates for both neurons in each chunk
-        maxrate_t = np.zeros(nch, dtype=np.int)
+        maxrate_t = np.zeros(nch, dtype=int)
 
         # ch_nn : contains the length of the different chunks
-        ch_nn = np.zeros(nch, dtype=np.int)
+        ch_nn = np.zeros(nch, dtype=int)
         count_sum = 0
         # for every chunk build the parallel processes
         # and the coincidence counts
@@ -869,19 +869,19 @@ def _test_pair(ensemble, spiketrain2, n2, max_lag, size_chunks, reference_lag,
                                  max(binned_pair_chunked[1]))
             ch_nn[iii] = len(chunked[iii][0])
             par_processes_chunked = [None for _ in range(
-                np.int(maxrate_t[iii]))]
+                int(maxrate_t[iii]))]
 
-            for i in range(np.int(maxrate_t[iii])):
+            for i in range(int(maxrate_t[iii])):
                 par_processes_chunked[i] = np.zeros(
-                    (2, len(binned_pair_chunked[0])), dtype=np.int)
+                    (2, len(binned_pair_chunked[0])), dtype=int)
                 par_processes_chunked[i] = np.array(binned_pair_chunked > i,
-                                                    dtype=np.int)
+                                                    dtype=int)
 
-            for i in range(np.int(maxrate_t[iii])):
+            for i in range(int(maxrate_t[iii])):
                 par_processes_a = par_processes_chunked[i][0]
                 par_processes_b = par_processes_chunked[i][1]
-                marginal_counts[iii][i][0] = np.int(np.sum(par_processes_a))
-                marginal_counts[iii][i][1] = np.int(np.sum(par_processes_b))
+                marginal_counts[iii][i][0] = int(np.sum(par_processes_a))
+                marginal_counts[iii][i][1] = int(np.sum(par_processes_b))
                 count_sum = count_sum + min(marginal_counts[iii][i][0],
                                             marginal_counts[iii][i][1])
 

--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -317,9 +317,9 @@ def generate_lfp(csd_profile, x_positions, y_positions=None, z_positions=None,
         y = np.linspace(y_limits[0], y_limits[1], resolution)
         z = np.linspace(z_limits[0], z_limits[1], resolution)
         chrg_x, chrg_y, chrg_z = np.mgrid[
-            x_limits[0]: x_limits[1]: np.complex(0, resolution),
-            y_limits[0]: y_limits[1]: np.complex(0, resolution),
-            z_limits[0]: z_limits[1]: np.complex(0, resolution)
+            x_limits[0]: x_limits[1]: complex(0, resolution),
+            y_limits[0]: y_limits[1]: complex(0, resolution),
+            z_limits[0]: z_limits[1]: complex(0, resolution)
         ]
 
         csd = csd_profile(chrg_x, chrg_y, chrg_z)

--- a/elephant/current_source_density_src/KCSD.py
+++ b/elephant/current_source_density_src/KCSD.py
@@ -394,7 +394,7 @@ class KCSD1D(KCSD):
         None
         """
         nx = (self.xmax - self.xmin)/self.gdx
-        self.estm_x = np.mgrid[self.xmin:self.xmax:np.complex(0,nx)]
+        self.estm_x = np.mgrid[self.xmin:self.xmax:complex(0,nx)]
         self.n_estm = self.estm_x.size
         self.ngx = self.estm_x.shape[0]
 
@@ -558,8 +558,8 @@ class KCSD2D(KCSD):
         """
         nx = (self.xmax - self.xmin)/self.gdx
         ny = (self.ymax - self.ymin)/self.gdy
-        self.estm_x, self.estm_y = np.mgrid[self.xmin:self.xmax:np.complex(0,nx),
-                                            self.ymin:self.ymax:np.complex(0,ny)]
+        self.estm_x, self.estm_y = np.mgrid[self.xmin:self.xmax:complex(0,nx),
+                                            self.ymin:self.ymax:complex(0,ny)]
         self.n_estm = self.estm_x.size
         self.ngx, self.ngy = self.estm_x.shape
 
@@ -848,9 +848,9 @@ class KCSD3D(KCSD):
         nx = (self.xmax - self.xmin)/self.gdx
         ny = (self.ymax - self.ymin)/self.gdy
         nz = (self.zmax - self.zmin)/self.gdz
-        self.estm_x, self.estm_y, self.estm_z = np.mgrid[self.xmin:self.xmax:np.complex(0,nx),
-                                                         self.ymin:self.ymax:np.complex(0,ny),
-                                                         self.zmin:self.zmax:np.complex(0,nz)]
+        self.estm_x, self.estm_y, self.estm_z = np.mgrid[self.xmin:self.xmax:complex(0,nx),
+                                                         self.ymin:self.ymax:complex(0,ny),
+                                                         self.zmin:self.zmax:complex(0,nz)]
         self.n_estm = self.estm_x.size
         self.ngx, self.ngy, self.ngz = self.estm_x.shape
 

--- a/elephant/current_source_density_src/utility_functions.py
+++ b/elephant/current_source_density_src/utility_functions.py
@@ -71,7 +71,7 @@ def distribute_srcs_1D(X, n_src, ext_x, R_init):
         effective radius of the basis element
     """
     X_src = np.mgrid[(np.min(X) - ext_x):(np.max(X) + ext_x):
-                     np.complex(0, n_src)]
+                     complex(0, n_src)]
     R = R_init
     return X_src, R
 
@@ -106,9 +106,9 @@ def distribute_srcs_2D(X, Y, n_src, ext_x, ext_y, R_init):
     ext_x_n = (Lx_nn - Lx) / 2
     ext_y_n = (Ly_nn - Ly) / 2
     X_src, Y_src = np.mgrid[(np.min(X) - ext_x_n):(np.max(X) + ext_x_n):
-                            np.complex(0, nx),
+                            complex(0, nx),
                             (np.min(Y) - ext_y_n):(np.max(Y) + ext_y_n):
-                            np.complex(0, ny)]
+                            complex(0, ny)]
     # d = round(R_init / ds)
     R = R_init  # R = d * ds
     return X_src, Y_src, R
@@ -186,11 +186,11 @@ def distribute_srcs_3D(X, Y, Z, n_src, ext_x, ext_y, ext_z, R_init):
     ext_y_n = (Ly_nn - Ly) / 2
     ext_z_n = (Lz_nn - Lz) / 2
     X_src, Y_src, Z_src = np.mgrid[(np.min(X) - ext_x_n):(np.max(X) + ext_x_n):
-                                   np.complex(0, nx),
+                                   complex(0, nx),
                                    (np.min(Y) - ext_y_n):(np.max(Y) + ext_y_n):
-                                   np.complex(0, ny),
+                                   complex(0, ny),
                                    (np.min(Z) - ext_z_n):(np.max(Z) + ext_z_n):
-                                   np.complex(0, nz)]
+                                   complex(0, nz)]
     # d = np.round(R_init / ds)
     R = R_init
     return (X_src, Y_src, Z_src, R)
@@ -250,19 +250,19 @@ def generate_electrodes(dim, xlims=[0.1, 0.9], ylims=[0.1, 0.9],
 
     """
     if dim == 1:
-        ele_x = np.mgrid[xlims[0]: xlims[1]: np.complex(0, res)]
+        ele_x = np.mgrid[xlims[0]: xlims[1]: complex(0, res)]
         ele_x = ele_x.flatten()
         return ele_x
     elif dim == 2:
-        ele_x, ele_y = np.mgrid[xlims[0]: xlims[1]: np.complex(0, res),
-                                ylims[0]: ylims[1]: np.complex(0, res)]
+        ele_x, ele_y = np.mgrid[xlims[0]: xlims[1]: complex(0, res),
+                                ylims[0]: ylims[1]: complex(0, res)]
         ele_x = ele_x.flatten()
         ele_y = ele_y.flatten()
         return ele_x, ele_y
     elif dim == 3:
-        ele_x, ele_y, ele_z = np.mgrid[xlims[0]: xlims[1]: np.complex(0, res),
-                                       ylims[0]: ylims[1]: np.complex(0, res),
-                                       zlims[0]: zlims[1]: np.complex(0, res)]
+        ele_x, ele_y, ele_z = np.mgrid[xlims[0]: xlims[1]: complex(0, res),
+                                       ylims[0]: ylims[1]: complex(0, res),
+                                       zlims[0]: zlims[1]: complex(0, res)]
         ele_x = ele_x.flatten()
         ele_y = ele_y.flatten()
         ele_z = ele_z.flatten()

--- a/elephant/gpfa/gpfa_core.py
+++ b/elephant/gpfa/gpfa_core.py
@@ -360,8 +360,8 @@ def exact_inference_with_ll(seqs, params, get_ll=True):
 
     # copy the contents of the input data structure to output structure
     dtype_out = [(x, seqs[x].dtype) for x in seqs.dtype.names]
-    dtype_out.extend([('latent_variable', np.object), ('Vsm', np.object),
-                      ('VsmGP', np.object)])
+    dtype_out.extend([('latent_variable', object), ('Vsm', object),
+                      ('VsmGP', object)])
     seqs_latent = np.empty(len(seqs), dtype=dtype_out)
     for dtype_name in seqs.dtype.names:
         seqs_latent[dtype_name] = seqs[dtype_name]
@@ -416,7 +416,7 @@ def exact_inference_with_ll(seqs, params, get_ll=True):
 
         # Compute blkProd = CRinvC_big * invM efficiently
         # blkProd is block persymmetric, so just compute top half
-        t_half = np.int(np.ceil(t / 2.0))
+        t_half = int(np.ceil(t / 2.0))
         blk_prod = np.zeros((x_dim * t_half, x_dim * t))
         idx = range(0, x_dim * t_half + 1, x_dim)
         for i in range(t_half):

--- a/elephant/gpfa/gpfa_util.py
+++ b/elephant/gpfa/gpfa_util.py
@@ -68,7 +68,7 @@ def get_seqs(data, bin_size, use_sqrt=True):
             binned = binned_spiketrain.to_array()
         seqs.append(
             (binned_spiketrain.n_bins, binned))
-    seqs = np.array(seqs, dtype=[('T', np.int), ('y', 'O')])
+    seqs = np.array(seqs, dtype=[('T', int), ('y', 'O')])
 
     # Remove trials that are shorter than one bin width
     if len(seqs) > 0:
@@ -122,8 +122,8 @@ def cut_trials(seq_in, seg_length=20):
         seqOut = seq_in
         return seqOut
 
-    dtype_seqOut = [('segId', np.int), ('T', np.int),
-                    ('y', np.object)]
+    dtype_seqOut = [('segId', int), ('T', int),
+                    ('y', object)]
     seqOut_buff = []
     for n, seqIn_n in enumerate(seq_in):
         T = seqIn_n['T']
@@ -135,14 +135,14 @@ def cut_trials(seq_in, seg_length=20):
                 'skipping'.format(n))
             continue
 
-        numSeg = np.int(np.ceil(float(T) / seg_length))
+        numSeg = int(np.ceil(float(T) / seg_length))
 
         # Randomize the sizes of overlaps
         if numSeg == 1:
             cumOL = np.array([0, ])
         else:
             totalOL = (seg_length * numSeg) - T
-            probs = np.ones(numSeg - 1, np.float) / (numSeg - 1)
+            probs = np.ones(numSeg - 1, float) / (numSeg - 1)
             randOL = np.random.multinomial(totalOL, probs)
             cumOL = np.hstack([0, np.cumsum(randOL)])
 
@@ -271,7 +271,7 @@ def inv_persymm(M, blk_size):
         Log determinant of M
     """
     T = int(M.shape[0] / blk_size)
-    Thalf = np.int(np.ceil(T / 2.0))
+    Thalf = int(np.ceil(T / 2.0))
     mkr = blk_size * Thalf
 
     invA11 = np.linalg.inv(M[:mkr, :mkr])
@@ -327,8 +327,8 @@ def fill_persymm(p_in, blk_size, n_blocks, blk_size_vert=None):
 
     Nh = blk_size * n_blocks
     Nv = blk_size_vert * n_blocks
-    Thalf = np.int(np.floor(n_blocks / 2.0))
-    THalf = np.int(np.ceil(n_blocks / 2.0))
+    Thalf = int(np.floor(n_blocks / 2.0))
+    THalf = int(np.ceil(n_blocks / 2.0))
 
     Pout = np.empty((blk_size_vert * n_blocks, blk_size * n_blocks))
     Pout[:blk_size_vert * THalf, :] = p_in
@@ -386,8 +386,8 @@ def make_precomp(seqs, xDim):
     # this is computationally cheap, so we keep a few loops in MATLAB
     # for ease of readability.
     precomp = np.empty(xDim, dtype=[(
-        'absDif', np.object), ('difSq', np.object), ('Tall', np.object),
-        ('Tu', np.object)])
+        'absDif', object), ('difSq', object), ('Tall', object),
+        ('Tu', object)])
     for i in range(xDim):
         precomp[i]['absDif'] = np.abs(Tdif)
         precomp[i]['difSq'] = Tdif ** 2
@@ -397,8 +397,8 @@ def make_precomp(seqs, xDim):
     # Loop once for each state dimension (each GP)
     for i in range(xDim):
         precomp_Tu = np.empty(len(trial_lengths_num_unique), dtype=[(
-            'nList', np.object), ('T', np.int), ('numTrials', np.int),
-            ('PautoSUM', np.object)])
+            'nList', object), ('T', int), ('numTrials', int),
+            ('PautoSUM', object)])
         for j, trial_len_num in enumerate(trial_lengths_num_unique):
             precomp_Tu[j]['nList'] = np.where(Tall == trial_len_num)[0]
             precomp_Tu[j]['T'] = trial_len_num
@@ -462,7 +462,7 @@ def grad_betgam(p, pre_comp, const):
     f = 0
     for j in range(len(pre_comp['Tu'])):
         T = pre_comp['Tu'][j]['T']
-        Thalf = np.int(np.ceil(T / 2.0))
+        Thalf = int(np.ceil(T / 2.0))
 
         Kinv = np.linalg.inv(Kmax[:T, :T])
         logdet_K = logdet(Kmax[:T, :T])
@@ -473,7 +473,7 @@ def grad_betgam(p, pre_comp, const):
         dg_KinvM = np.diag(KinvM)
         tr_KinvM = 2 * dg_KinvM.sum() - np.fmod(T, 2) * dg_KinvM[-1]
 
-        mkr = np.int(np.ceil(0.5 * T ** 2))
+        mkr = int(np.ceil(0.5 * T ** 2))
         numTrials = pre_comp['Tu'][j]['numTrials']
         PautoSUM = pre_comp['Tu'][j]['PautoSUM']
 
@@ -562,7 +562,7 @@ def segment_by_trial(seqs, x, fn):
         raise ValueError('size of X incorrect.')
 
     dtype_new = [(i, seqs[i].dtype) for i in seqs.dtype.names]
-    dtype_new.append((fn, np.object))
+    dtype_new.append((fn, object))
     seqs_new = np.empty(len(seqs), dtype=dtype_new)
     for dtype_name in seqs.dtype.names:
         seqs_new[dtype_name] = seqs[dtype_name]

--- a/elephant/phase_analysis.py
+++ b/elephant/phase_analysis.py
@@ -174,8 +174,8 @@ def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
                 # Save hilbert_transform (interpolate on circle)
                 p1 = np.angle(hilbert_transform[phase_i][ind_at_spike_j])
                 p2 = np.angle(hilbert_transform[phase_i][ind_at_spike_j + 1])
-                interpolation = (1 - z) * np.exp(np.complex(0, p1)) \
-                                    + z * np.exp(np.complex(0, p2))
+                interpolation = (1 - z) * np.exp(complex(0, p1)) \
+                                    + z * np.exp(complex(0, p2))
                 p12 = np.angle([interpolation])
                 result_phases[spiketrain_i].append(p12)
 

--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -167,7 +167,7 @@ def zscore(signal, inplace=True):
     for sig in signal:
         # Perform inplace operation only if array is of dtype float.
         # Otherwise, raise an error.
-        if inplace and not np.issubdtype(np.float, sig.dtype):
+        if inplace and not np.issubdtype(float, sig.dtype):
             raise ValueError(f"Cannot perform inplace operation as the "
                              f"signal dtype is not float. Source: {sig.name}")
 
@@ -673,7 +673,7 @@ def wavelet_transform(signal, frequency, n_cycles=6.0, sampling_frequency=1.0,
         # in Le van Quyen et al. J Neurosci Meth 111:83-98 (2001).
         sigma = n_cycles / (6. * freq)
         freqs = np.fft.fftfreq(n, 1.0 / fs)
-        heaviside = np.array(freqs > 0., dtype=np.float)
+        heaviside = np.array(freqs > 0., dtype=float)
         ft_real = np.sqrt(2 * np.pi * freq) * sigma * np.exp(
             -2 * (np.pi * sigma * (freqs - freq)) ** 2) * heaviside * fs
         ft_imag = np.zeros_like(ft_real)
@@ -717,7 +717,7 @@ def wavelet_transform(signal, frequency, n_cycles=6.0, sampling_frequency=1.0,
         n = n_orig
 
     # generate Morlet wavelets (in the frequency domain)
-    wavelet_fts = np.empty([len(freqs), n], dtype=np.complex)
+    wavelet_fts = np.empty([len(freqs), n], dtype=complex)
     for i, f in enumerate(freqs):
         wavelet_fts[i] = _morlet_wavelet_ft(f, n_cycles, sampling_frequency, n)
 

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -510,8 +510,8 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
     def test_to_array(self):
         x = cv.BinnedSpikeTrain(self.spiketrain_a, bin_size=1 * pq.s,
                                 n_bins=10, t_stop=10. * pq.s)
-        arr_float = x.to_array(dtype=np.float32)
-        assert_array_equal(arr_float, x.to_array().astype(np.float32))
+        arr_float = x.to_array(dtype=float)
+        assert_array_equal(arr_float, x.to_array().astype(float))
 
     # Test if error is raised when providing insufficient number of
     # parameters
@@ -666,11 +666,11 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
                                   bin_size=1 * pq.ms)
         self.assertEqual(bst.units, pq.s)
         target_edges = np.array([1000, 1001, 1002, 1003, 1004, 1005, 1006,
-                                 1007, 1008, 1009, 1010], dtype=np.float
+                                 1007, 1008, 1009, 1010], dtype=float
                                 ) * pq.ms
         target_centers = np.array(
             [1000.5, 1001.5, 1002.5, 1003.5, 1004.5, 1005.5, 1006.5, 1007.5,
-             1008.5, 1009.5], dtype=np.float) * pq.ms
+             1008.5, 1009.5], dtype=float) * pq.ms
         assert_array_almost_equal(bst.bin_edges, target_edges)
         assert_array_almost_equal(bst.bin_centers, target_centers)
 

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -510,8 +510,8 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
     def test_to_array(self):
         x = cv.BinnedSpikeTrain(self.spiketrain_a, bin_size=1 * pq.s,
                                 n_bins=10, t_stop=10. * pq.s)
-        arr_float = x.to_array(dtype=float)
-        assert_array_equal(arr_float, x.to_array().astype(float))
+        arr_float = x.to_array(dtype=np.float32)
+        assert_array_equal(arr_float, x.to_array().astype(np.float32))
 
     # Test if error is raised when providing insufficient number of
     # parameters

--- a/elephant/test/test_neo_tools.py
+++ b/elephant/test/test_neo_tools.py
@@ -21,7 +21,7 @@ from neo.test.generate_datasets import generate_one_simple_block, \
     random_event, random_epoch, random_spiketrain
 from neo.test.tools import assert_same_sub_schema
 
-from numpy.testing.utils import assert_array_equal
+from numpy.testing import assert_array_equal
 
 import elephant.neo_tools as nt
 

--- a/elephant/test/test_spade.py
+++ b/elephant/test/test_spade.py
@@ -12,7 +12,7 @@ import neo
 from neo.core.spiketrainlist import SpikeTrainList
 import numpy as np
 import quantities as pq
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_equal
 
 import elephant.conversion as conv
 import elephant.spade as spade
@@ -175,11 +175,11 @@ class SpadeTestCase(unittest.TestCase):
         occ_msip = sorted(occ_msip, key=len)
         lags_msip = sorted(lags_msip, key=len)
         # check neurons in the patterns
-        assert_array_equal(elements_msip, self.elements_msip)
+        assert_equal(elements_msip, self.elements_msip)
         # check the occurrences time of the patters
-        assert_array_equal(occ_msip, self.occ_msip)
+        assert_equal(occ_msip, self.occ_msip)
         # check the lags
-        assert_array_equal(lags_msip, self.lags_msip)
+        assert_equal(lags_msip, self.lags_msip)
 
     # Testing with multiple patterns input
     def test_spade_msip_spiketrainlist(self):
@@ -204,11 +204,11 @@ class SpadeTestCase(unittest.TestCase):
         occ_msip = sorted(occ_msip, key=len)
         lags_msip = sorted(lags_msip, key=len)
         # check neurons in the patterns
-        assert_array_equal(elements_msip, self.elements_msip)
+        assert_equal(elements_msip, self.elements_msip)
         # check the occurrences time of the patters
-        assert_array_equal(occ_msip, self.occ_msip)
+        assert_equal(occ_msip, self.occ_msip)
         # check the lags
-        assert_array_equal(lags_msip, self.lags_msip)
+        assert_equal(lags_msip, self.lags_msip)
 
     def test_parameters(self):
         """
@@ -269,7 +269,7 @@ class SpadeTestCase(unittest.TestCase):
             occ_msip_min_occ.append(list(out['times'].magnitude))
         occ_msip_min_occ = sorted(occ_msip_min_occ, key=len)
         # test occurrences time
-        assert_array_equal(occ_msip_min_occ, [
+        assert_equal(occ_msip_min_occ, [
             occ for occ in self.occ_msip if len(occ) >= self.min_occ])
 
         # test max_spikes parameter
@@ -371,11 +371,11 @@ class SpadeTestCase(unittest.TestCase):
         occ_msip = sorted(occ_msip, key=len)
         lags_msip = sorted(lags_msip, key=len)
         # check neurons in the patterns
-        assert_array_equal(elements_msip, self.elements_msip)
+        assert_equal(elements_msip, self.elements_msip)
         # check the occurrences time of the patters
-        assert_array_equal(occ_msip, self.occ_msip)
+        assert_equal(occ_msip, self.occ_msip)
         # check the lags
-        assert_array_equal(lags_msip, self.lags_msip)
+        assert_equal(lags_msip, self.lags_msip)
 
     # test under different configuration of parameters than the default one
     def test_parameters_3d(self):
@@ -432,7 +432,7 @@ class SpadeTestCase(unittest.TestCase):
             occ_msip_min_occ.append(list(out['times'].magnitude))
         occ_msip_min_occ = sorted(occ_msip_min_occ, key=len)
         # test occurrences time
-        assert_array_equal(occ_msip_min_occ, [
+        assert_equal(occ_msip_min_occ, [
             occ for occ in self.occ_msip if len(occ) >= self.min_occ])
 
     # Test computation spectrum
@@ -608,7 +608,7 @@ class SpadeTestCase(unittest.TestCase):
                           corr='invalid_key')
         # Test negative number of subset for stability
         self.assertRaises(ValueError, spade.approximate_stability, (),
-                          np.array([]), n_subsets=-3)
+                          np.ndarray([]), n_subsets=-3)
 
     def test_pattern_set_reduction(self):
         winlen = 6

--- a/elephant/test/test_spade.py
+++ b/elephant/test/test_spade.py
@@ -608,7 +608,7 @@ class SpadeTestCase(unittest.TestCase):
                           corr='invalid_key')
         # Test negative number of subset for stability
         self.assertRaises(ValueError, spade.approximate_stability, (),
-                          np.ndarray([]), n_subsets=-3)
+                          np.array([]), n_subsets=-3)
 
     def test_pattern_set_reduction(self):
         winlen = 6

--- a/elephant/test/test_unitary_event_analysis.py
+++ b/elephant/test/test_unitary_event_analysis.py
@@ -319,8 +319,8 @@ class UETestCase(unittest.TestCase):
                         item1))
 
     def test_jointJ_window_analysis(self):
-        sts1 = self.sts1_neo
-        sts2 = self.sts2_neo
+        sts1 = np.asarray(self.sts1_neo, dtype=object)
+        sts2 = np.asarray(self.sts2_neo, dtype=object)
         data = np.vstack((sts1, sts2)).T
         win_size = 100 * pq.ms
         bin_size = 5 * pq.ms
@@ -423,7 +423,9 @@ class UETestCase(unittest.TestCase):
                         [] * pq.ms, t_start=0 * pq.ms,
                         t_stop=t_pre + t_post))
             data_tr.append(data_sel_units)
+
         data_tr.reverse()
+        data_tr=np.asarray(data_tr, dtype=object)
         spiketrain = np.vstack([i for i in data_tr]).T
         return spiketrain
 
@@ -492,10 +494,10 @@ class UETestCase(unittest.TestCase):
 
     def test_multiple_neurons(self):
         np.random.seed(12)
-        spiketrains = \
+        spiketrains = np.asarray(
             [StationaryPoissonProcess(
                 rate=50 * pq.Hz, t_stop=1 * pq.s).generate_n_spiketrains(5)
-             for neuron in range(3)]
+             for neuron in range(3)],dtype=object)
 
         spiketrains = np.stack(spiketrains, axis=1)
         UE_dic = ue.jointJ_window_analysis(spiketrains, bin_size=5 * pq.ms,

--- a/elephant/test/test_unitary_event_analysis.py
+++ b/elephant/test/test_unitary_event_analysis.py
@@ -319,9 +319,13 @@ class UETestCase(unittest.TestCase):
                         item1))
 
     def test_jointJ_window_analysis(self):
-        sts1 = np.asarray(self.sts1_neo, dtype=object)
-        sts2 = np.asarray(self.sts2_neo, dtype=object)
-        data = np.vstack((sts1, sts2)).T
+        sts1 = self.sts1_neo
+        sts2 = self.sts2_neo
+
+        # joinJ_window_analysis requires the following:
+        # A list of spike trains(neo.SpikeTrain objects) in different trials:
+        data = list(zip(*[sts1,sts2]))
+
         win_size = 100 * pq.ms
         bin_size = 5 * pq.ms
         win_step = 20 * pq.ms

--- a/elephant/test/test_unitary_event_analysis.py
+++ b/elephant/test/test_unitary_event_analysis.py
@@ -498,12 +498,13 @@ class UETestCase(unittest.TestCase):
 
     def test_multiple_neurons(self):
         np.random.seed(12)
-        spiketrains = np.asarray(
+        # Create a list of lists containing 3 Trials with 5 spiketrains
+        spiketrains = \
             [StationaryPoissonProcess(
                 rate=50 * pq.Hz, t_stop=1 * pq.s).generate_n_spiketrains(5)
-             for neuron in range(3)],dtype=object)
+             for _ in range(3)]
 
-        spiketrains = np.stack(spiketrains, axis=1)
+        spiketrains = list(zip(*spiketrains))
         UE_dic = ue.jointJ_window_analysis(spiketrains, bin_size=5 * pq.ms,
                                            win_size=300 * pq.ms,
                                            win_step=100 * pq.ms)

--- a/requirements/environment-docs.yml
+++ b/requirements/environment-docs.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.7
 
   - mpi4py
-  - numpy
+  - numpy>=1.19.5
   - scipy
   - tqdm
   - pandas

--- a/requirements/environment-tests.yml
+++ b/requirements/environment-tests.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.7
 
   - mpi4py
-  - numpy
+  - numpy>=1.19.5
   - scipy
   - tqdm
   - pandas

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.7
   - mpi4py
-  - numpy
+  - numpy>=1.19.5
   - scipy
   - tqdm
   - pandas

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 neo>=0.10.0
-numpy>=1.18.1
+numpy>=1.19.5
 quantities>=0.12.1
 scipy>=1.5.4
 six>=1.10.0


### PR DESCRIPTION
## Deprecations
With release of numpy v1.24 several deprecations expired, see: 
https://numpy.org/devdocs/release/1.24.0-notes.html#deprecations

The following are relevant for this PR:
- Ragged array creation will now always raise a `ValueError` unless `dtype=object` is passed. This includes nested sequences.
- As of numpy v1.20, `numpy.float` as well as similar aliases (including `numpy.int`) were deprecated, with numpy 1.24 those have been completely removed

## Fix
- replaced the numpy aliases for builtin types with the buitlin types
- rewritten UE unit tests (replaced `np.vstack()`)
- In accordance with NEP 29 + 1 year support for numpy 1.18 was dropped.