### PR TITLE
Fix/remove python 3.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,8 +57,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python versions for elephant: [3.7, 3.8, 3.9, "3.10"]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        # python versions for elephant: [3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
         # OS [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
       # do not cancel all in-progress jobs if any matrix job fails
@@ -181,7 +181,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python versions for elephant: [3.6, 3.7, 3.8, 3.9]
+        # python versions for elephant: [3.8, 3.9, 3.10, 3.11]
         python-version: [3.8,]
         # OS [ubuntu-latest, macos-latest, windows-latest]
         os: [windows-latest]
@@ -243,7 +243,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python versions for elephant: [3.6, 3.7, 3.8, 3.9]
+        # python versions for elephant: [3.8, 3.9, 3.10, 3.11]
         python-version: [3.9]
         # OS [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* cp36-* pp*"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* cp36-* cp37-* pp*"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
           CIBW_ARCHS: "auto64"
 
       - uses: actions/upload-artifact@v3

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,7 +14,7 @@ Below is the explanation of how to proceed with these two steps.
 Prerequisites
 *************
 
-Elephant requires `Python <http://python.org/>`_ 3.7, 3.8, 3.9 or 3.10.
+Elephant requires `Python <http://python.org/>`_ 3.8, 3.9, 3.10 or 3.11.
 
 .. tabs::
 
@@ -25,7 +25,7 @@ Elephant requires `Python <http://python.org/>`_ 3.7, 3.8, 3.9 or 3.10.
 
            .. code-block:: sh
 
-              conda create --name elephant python=3.7 numpy scipy tqdm
+              conda create --name elephant python=3.8 numpy scipy tqdm
 
         2. Activate your environment:
 

--- a/requirements/environment-docs.yml
+++ b/requirements/environment-docs.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge  # required for MPI
 
 dependencies:
-  - python>=3.7
+  - python>=3.8
 
   - mpi4py
   - numpy

--- a/requirements/environment-docs.yml
+++ b/requirements/environment-docs.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.8
 
   - mpi4py
-  - numpy
+  - numpy>1.20
   - scipy
   - tqdm
   - pandas

--- a/requirements/environment-tests.yml
+++ b/requirements/environment-tests.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge  # required for MPI
 
 dependencies:
-  - python>=3.7
+  - python>=3.8
 
   - mpi4py
   - numpy

--- a/requirements/environment-tests.yml
+++ b/requirements/environment-tests.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.8
 
   - mpi4py
-  - numpy
+  - numpy>1.20
   - scipy
   - tqdm
   - pandas

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.8
   - mpi4py
-  - numpy
+  - numpy>1.20
   - scipy
   - tqdm
   - pandas

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge  # required for MPI
 
 dependencies:
-  - python>=3.7
+  - python>=3.8
   - mpi4py
   - numpy
   - scipy

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 neo>=0.10.0
-numpy>=1.18.1
+numpy>1.20
 quantities>=0.12.1
 scipy>=1.5.4
 six>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup_kwargs = {
             "Documentation": "https://elephant.readthedocs.io/en/latest/",
             "Source Code": "https://github.com/NeuralEnsemble/elephant",
         },
-    "python_requires": ">=3.7",
+    "python_requires": ">=3.8",
     "classifiers": [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
@@ -89,10 +89,10 @@ setup_kwargs = {
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering']
 }


### PR DESCRIPTION
In accordance with NEP 29 support for Python 3.7 and numpy 1.20 is dropped. 
(https://numpy.org/neps/nep-0029-deprecation_policy.html)