### PR TITLE
[ENH] GPFA with continuous data

### DIFF
--- a/elephant/gpfa/gpfa.py
+++ b/elephant/gpfa/gpfa.py
@@ -378,7 +378,7 @@ class GPFA(sklearn.base.BaseEstimator):
             seq['y'] = seq['y'][self.has_spikes_bool, :]
         return seqs
 
-    def transform(self, trials, returned_data=['latent_variable_orth']):
+    def transform(self, trials, returned_data=('latent_variable_orth',)):
         """
         Obtain trajectories of neural activity in a low-dimensional latent
         variable space by inferring the posterior mean of the obtained GPFA
@@ -386,7 +386,7 @@ class GPFA(sklearn.base.BaseEstimator):
 
         Parameters
         ----------
-        trials : list of list of neo.SpikeTrain
+        trials : list of list of neo.SpikeTrain or np.recarray
             Spike train data to be transformed to latent variables.
             The outer list corresponds to trials and the inner list corresponds
             to the neurons recorded in that trial, such that
@@ -498,20 +498,15 @@ class GPFA(sklearn.base.BaseEstimator):
             return seqs[returned_data[0]]
         return {x: seqs[x] for x in returned_data}
 
-    def fit_transform(self, trials, seqs_train=None,
-                      returned_data=['latent_variable_orth']):
+    def fit_transform(self, trials, returned_data=('latent_variable_orth',)):
         """
         Fit the model with `trials` data and apply the dimensionality
         reduction on `trials`.
 
         Parameters
         ----------
-        trials : list of list of neo.SpikeTrain
+        trials : list of list of neo.SpikeTrain or np.recarray
             Refer to the :func:`GPFA.fit` docstring.
-
-        seqs_train : np.recarray
-            Refer to the :func:`GPFA.fit` docstring.
-            Default: `None`
 
         returned_data : list of str
             Refer to the :func:`GPFA.transform` docstring.
@@ -540,13 +535,13 @@ class GPFA(sklearn.base.BaseEstimator):
             raise ValueError('Must supply either trials as '
                              'np.recarray or List of Lists!')
 
-    def score(self, spiketrains):
+    def score(self, trials):
         """
         Returns the log-likelihood of the given data under the fitted model
 
         Parameters
         ----------
-        spiketrains : list of list of neo.SpikeTrain
+        trials : list of list of neo.SpikeTrain
             Spike train data to be scored.
             The outer list corresponds to trials and the inner list corresponds
             to the neurons recorded in that trial, such that
@@ -561,5 +556,5 @@ class GPFA(sklearn.base.BaseEstimator):
         log_likelihood : float
             Log-likelihood of the given trials under the fitted model.
         """
-        self.transform(spiketrains)
+        self.transform(trials)
         return self.transform_info['log_likelihood']

--- a/elephant/gpfa/gpfa.py
+++ b/elephant/gpfa/gpfa.py
@@ -473,7 +473,6 @@ class GPFA(sklearn.base.BaseEstimator):
                 raise ValueError("'trials' must contain the same number "
                                  "of neurons as the training spiketrain data")
             seqs = gpfa_util.get_seqs(trials, self.bin_size)
-
         elif isinstance(trials,np.ndarray):
             # check some stuff
             if len(trials['y'][0]) != len(self.has_spikes_bool):

--- a/elephant/gpfa/gpfa_util.py
+++ b/elephant/gpfa/gpfa_util.py
@@ -58,12 +58,14 @@ def get_seqs(trials, bin_size, use_sqrt=True):
     if not isinstance(bin_size, pq.Quantity):
         raise ValueError("'bin_size' must be of type pq.Quantity")
 
+    # Create a np.recarray
+    # a generator that generates a tuple (n_bins, neural data)
     seqs = ((BinnedSpikeTrain(trial, bin_size=bin_size).n_bins,
              np.sqrt(BinnedSpikeTrain(trial, bin_size=bin_size).to_array())
              if use_sqrt
              else BinnedSpikeTrain(trial, bin_size=bin_size).to_array())
             for trial in trials)
-
+    # create np.recarray by specifying dtype with np.array()
     seqs = np.array(list(seqs), dtype=[('T', int), ('y', 'O')])
 
     # Remove trials that are shorter than one bin width

--- a/elephant/gpfa/gpfa_util.py
+++ b/elephant/gpfa/gpfa_util.py
@@ -86,12 +86,12 @@ def cut_trials(seq_in, seg_length=20):
     Parameters
     ----------
     seq_in : np.recarray
-        data structure, whose nth entry (corresponding to the nth experimental
+        trials structure, whose nth entry (corresponding to the nth experimental
         trial) has fields
         T : int
             number of timesteps in trial
         y : (yDim, T) np.ndarray
-            neural data
+            neural trials
 
     seg_length : int
         length of segments to extract, in number of timesteps. If infinite,
@@ -101,12 +101,12 @@ def cut_trials(seq_in, seg_length=20):
     Returns
     -------
     seqOut : np.recarray
-        data structure, whose nth entry (corresponding to the nth experimental
+        trials structure, whose nth entry (corresponding to the nth experimental
         trial) has fields
         T : int
             number of timesteps in segment
         y : (yDim, T) np.ndarray
-            neural data
+            neural trials
 
     Raises
     ------
@@ -498,7 +498,7 @@ def orthonormalize(x, l):
     """
     Orthonormalize the columns of the loading matrix and apply the
     corresponding linear transform to the latent variables.
-    In the following description, yDim and xDim refer to data dimensionality
+    In the following description, yDim and xDim refer to trials dimensionality
     and latent dimensionality, respectively.
 
     Parameters
@@ -534,7 +534,7 @@ def orthonormalize(x, l):
 
 def segment_by_trial(seqs, x, fn):
     """
-    Segment and store data by trial.
+    Segment and store trials by trial.
 
     Parameters
     ----------

--- a/elephant/test/test_gpfa.py
+++ b/elephant/test/test_gpfa.py
@@ -222,7 +222,7 @@ class GPFATestCase(unittest.TestCase):
 
     def test_equality_spiketrains_seqs_train(self):
         gpfa_seqs = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
-        gpfa_seqs.fit_transform(None, seqs_train=self.seqs_train)
+        gpfa_seqs.fit_transform(self.seqs_train)
 
         gpfa_spiketrains = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
         gpfa_spiketrains.fit_transform(self.data1)
@@ -233,22 +233,22 @@ class GPFATestCase(unittest.TestCase):
 
     def test_fit_seqs_train(self):
         gpfa = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
-        gpfa.fit(None, seqs_train=self.seqs_train)
-        target = [0.07919926, 0.07546947, 0.07397758, 0.0780272,  0.07773862,
+        gpfa.fit(self.seqs_train)
+        target = [0.07919926, 0.07546947, 0.07397758, 0.0780272, 0.07773862,
                   0.07695879, 0.07469927, 0.07867749]
         res = gpfa.params_estimated['d']
         assert_array_almost_equal(res, target, decimal=5)
 
     def test_transform_seqs_train(self):
         gpfa = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
-        gpfa.fit(None, seqs_train=self.seqs_train)
-        gpfa.transform(None, seqs=self.seqs_train)
+        gpfa.fit(self.seqs_train)
+        gpfa.transform(self.seqs_train)
         self.assertAlmostEqual(gpfa.transform_info['log_likelihood'],
                                -8172.004695554373, places=5)
 
     def test_fit_transform_seqs_train(self):
         gpfa = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
-        gpfa.fit_transform(None, seqs_train=self.seqs_train)
+        gpfa.fit_transform(self.seqs_train)
         self.assertAlmostEqual(gpfa.transform_info['log_likelihood'],
                                -8172.004695554373, places=5)
 

--- a/elephant/test/test_gpfa.py
+++ b/elephant/test/test_gpfa.py
@@ -71,6 +71,7 @@ class GPFATestCase(unittest.TestCase):
             n8 = neo.SpikeTrain(gen_test_data(rates_b, durs), units=1 * pq.s,
                                 t_start=0 * pq.s, t_stop=10 * pq.s)
             self.data0.append([n1, n2, n3, n4, n5, n6, n7, n8])
+
         self.x_dim = 4
 
         self.data1 = self.data0[:20]
@@ -135,9 +136,9 @@ class GPFATestCase(unittest.TestCase):
             _ = GPFA(tau_init=invalid_tau_init)
         gpfa = GPFA()
         with self.assertRaises(ValueError):
-            gpfa.fit(spiketrains=invalid_data)
+            gpfa.fit(trials=invalid_data)
         with self.assertRaises(ValueError):
-            gpfa.fit(spiketrains=[])
+            gpfa.fit(trials=[])
 
     def test_data2(self):
         gpfa = GPFA(bin_size=self.bin_size, x_dim=8, em_max_iters=self.n_iters)

--- a/elephant/test/test_gpfa.py
+++ b/elephant/test/test_gpfa.py
@@ -84,7 +84,7 @@ class GPFATestCase(unittest.TestCase):
 
         self.data2 =[[StationaryPoissonProcess(rate=rate * pq.Hz,
                         t_stop=1000*pq.ms).generate_spiketrain()
-                       for rate in rates()]for trial in range(n_trials)]
+                       for rate in rates()] for _ in range(n_trials)]
 
         # generate seqs_train data
         self.seqs_train = gpfa_util.get_seqs(self.data1,

--- a/elephant/test/test_gpfa.py
+++ b/elephant/test/test_gpfa.py
@@ -86,6 +86,10 @@ class GPFATestCase(unittest.TestCase):
                            for rate in rates]
             self.data2.append(spike_times)
 
+        # generate seqs_train data
+        self.seqs_train = gpfa_util.get_seqs(self.data1,
+                                             bin_size=self.bin_size)
+
     def test_data1(self):
         gpfa = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
         gpfa.fit(self.data1)
@@ -215,6 +219,38 @@ class GPFATestCase(unittest.TestCase):
         logdet_fast = gpfa_util.logdet(matrix)
         logdet_ground_truth = np.log(np.linalg.det(matrix))
         assert_array_almost_equal(logdet_fast, logdet_ground_truth)
+
+    def test_equality_spiketrains_seqs_train(self):
+        gpfa_seqs = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
+        gpfa_seqs.fit_transform(None, seqs_train=self.seqs_train)
+
+        gpfa_spiketrains = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
+        gpfa_spiketrains.fit_transform(self.data1)
+
+        self.assertAlmostEqual(
+            gpfa_seqs.transform_info['log_likelihood'],
+            gpfa_spiketrains.transform_info['log_likelihood'], places=5)
+
+    def test_fit_seqs_train(self):
+        gpfa = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
+        gpfa.fit(None, seqs_train=self.seqs_train)
+        target = [0.07919926, 0.07546947, 0.07397758, 0.0780272,  0.07773862,
+                  0.07695879, 0.07469927, 0.07867749]
+        res = gpfa.params_estimated['d']
+        assert_array_almost_equal(res, target, decimal=5)
+
+    def test_transform_seqs_train(self):
+        gpfa = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
+        gpfa.fit(None, seqs_train=self.seqs_train)
+        gpfa.transform(None, seqs=self.seqs_train)
+        self.assertAlmostEqual(gpfa.transform_info['log_likelihood'],
+                               -8172.004695554373, places=5)
+
+    def test_fit_transform_seqs_train(self):
+        gpfa = GPFA(x_dim=self.x_dim, em_max_iters=self.n_iters)
+        gpfa.fit_transform(None, seqs_train=self.seqs_train)
+        self.assertAlmostEqual(gpfa.transform_info['log_likelihood'],
+                               -8172.004695554373, places=5)
 
 
 if __name__ == "__main__":

--- a/elephant/test/test_gpfa.py
+++ b/elephant/test/test_gpfa.py
@@ -166,7 +166,7 @@ class GPFATestCase(unittest.TestCase):
         self.assertTrue(len(returned_data) == len(seqs))
         self.assertTrue(isinstance(seqs, dict))
         with self.assertRaises(ValueError):
-            seqs = gpfa.transform(self.data2, returned_data=['invalid_name'])
+            gpfa.transform(self.data2, returned_data=['invalid_name'])
 
     def test_fit_transform(self):
         gpfa1 = GPFA(bin_size=self.bin_size, x_dim=self.x_dim,

--- a/elephant/test/test_gpfa.py
+++ b/elephant/test/test_gpfa.py
@@ -30,10 +30,9 @@ except ImportError:
 class GPFATestCase(unittest.TestCase):
     def setUp(self):
         def gen_gamma_spike_train(k, theta, t_max):
-            x = []
-            for i in range(int(3 * t_max / (k * theta))):
-                x.append(np.random.gamma(k, theta))
-            s = np.cumsum(x)
+            x = (np.random.gamma(k, theta) for _ in
+                 range(int(3 * t_max / (k * theta))))
+            s = np.cumsum(list(x))
             return s[s < t_max]
 
         def gen_test_data(rates, durs, shapes=(1, 1, 1, 1)):
@@ -52,25 +51,26 @@ class GPFATestCase(unittest.TestCase):
         durs = (2.5, 2.5, 2.5, 2.5)
         np.random.seed(0)
         n_trials = 100
-        self.data0 = []
-        for trial in range(n_trials):
-            n1 = neo.SpikeTrain(gen_test_data(rates_a, durs), units=1 * pq.s,
-                                t_start=0 * pq.s, t_stop=10 * pq.s)
-            n2 = neo.SpikeTrain(gen_test_data(rates_a, durs), units=1 * pq.s,
-                                t_start=0 * pq.s, t_stop=10 * pq.s)
-            n3 = neo.SpikeTrain(gen_test_data(rates_b, durs), units=1 * pq.s,
-                                t_start=0 * pq.s, t_stop=10 * pq.s)
-            n4 = neo.SpikeTrain(gen_test_data(rates_b, durs), units=1 * pq.s,
-                                t_start=0 * pq.s, t_stop=10 * pq.s)
-            n5 = neo.SpikeTrain(gen_test_data(rates_a, durs), units=1 * pq.s,
-                                t_start=0 * pq.s, t_stop=10 * pq.s)
-            n6 = neo.SpikeTrain(gen_test_data(rates_a, durs), units=1 * pq.s,
-                                t_start=0 * pq.s, t_stop=10 * pq.s)
-            n7 = neo.SpikeTrain(gen_test_data(rates_b, durs), units=1 * pq.s,
-                                t_start=0 * pq.s, t_stop=10 * pq.s)
-            n8 = neo.SpikeTrain(gen_test_data(rates_b, durs), units=1 * pq.s,
-                                t_start=0 * pq.s, t_stop=10 * pq.s)
-            self.data0.append([n1, n2, n3, n4, n5, n6, n7, n8])
+
+        self.data0 = [[
+            neo.SpikeTrain(gen_test_data(rates_a, durs), units=1 * pq.s,
+                                        t_start=0 * pq.s, t_stop=10 * pq.s),
+            neo.SpikeTrain(gen_test_data(rates_a, durs), units=1 * pq.s,
+                                        t_start=0 * pq.s, t_stop=10 * pq.s),
+            neo.SpikeTrain(gen_test_data(rates_b, durs), units=1 * pq.s,
+                                        t_start=0 * pq.s, t_stop=10 * pq.s),
+            neo.SpikeTrain(gen_test_data(rates_b, durs), units=1 * pq.s,
+                                        t_start=0 * pq.s, t_stop=10 * pq.s),
+            neo.SpikeTrain(gen_test_data(rates_a, durs), units=1 * pq.s,
+                                        t_start=0 * pq.s, t_stop=10 * pq.s),
+            neo.SpikeTrain(gen_test_data(rates_a, durs), units=1 * pq.s,
+                                        t_start=0 * pq.s, t_stop=10 * pq.s),
+            neo.SpikeTrain(gen_test_data(rates_b, durs), units=1 * pq.s,
+                                        t_start=0 * pq.s, t_stop=10 * pq.s),
+            neo.SpikeTrain(gen_test_data(rates_b, durs), units=1 * pq.s,
+                                        t_start=0 * pq.s, t_stop=10 * pq.s)]
+        for _ in range(n_trials)]
+
 
         self.x_dim = 4
 

--- a/elephant/test/test_gpfa.py
+++ b/elephant/test/test_gpfa.py
@@ -78,15 +78,13 @@ class GPFATestCase(unittest.TestCase):
 
         # generate data2
         np.random.seed(27)
-        self.data2 = []
         n_trials = 10
         n_channels = 20
-        for trial in range(n_trials):
-            rates = np.random.randint(low=1, high=100, size=n_channels)
-            spike_times = [StationaryPoissonProcess(rate=rate * pq.Hz,
-                            t_stop=1000*pq.ms).generate_spiketrain()
-                           for rate in rates]
-            self.data2.append(spike_times)
+        rates = lambda : np.random.randint(low=1, high=100, size=n_channels)
+
+        self.data2 =[[StationaryPoissonProcess(rate=rate * pq.Hz,
+                        t_stop=1000*pq.ms).generate_spiketrain()
+                       for rate in rates()]for trial in range(n_trials)]
 
         # generate seqs_train data
         self.seqs_train = gpfa_util.get_seqs(self.data1,


### PR DESCRIPTION
This pull request extends the functionality of the GPFA classes methods to accept continuous data. 

The changes are done to the methods `fit`, `transform`  and `fit_transform`, which now accept continuous data. 

Unit tests and docstrings have been written to ensure that the changes are properly implemented.

This PR seeks a continuation of the previously started development in PR #507. 

The current input for continuous data to `fit`, `transform` and `fit_transform` is a [numpy recarray](https://numpy.org/doc/stable/reference/generated/numpy.recarray.html)

**Todo**
- [ ] decide on input type for continuous data
- [ ] integrate with trial object

---------

Co-authored-by: Jonah Pearl <jonahpearl@g.harvard.edu>