### PR TITLE
Fix/changes in documentation

### DIFF
--- a/doc/reference/phase_analysis.rst
+++ b/doc/reference/phase_analysis.rst
@@ -1,5 +1,5 @@
-=========================
-Spike-triggered LFP phase
-=========================
+==============
+Phase Analysis
+==============
 
 .. automodule:: elephant.phase_analysis

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -40,7 +40,7 @@ Statistics across spike trains
 
 
 Tutorial
-********
+========
 
 :doc:`View tutorial <../tutorials/statistics>`
 


### PR DESCRIPTION
This PR changes:
- change heading from "Spike-triggered LFP phase" to "Phase Analysis"
- removed statistics tutorial from function reference