### PR TITLE
Fix complexity for binary=False and spread=0

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1152,8 +1152,9 @@ class Complexity(object):
 
         Default: None
     binary : bool, optional
-        *  If True then the time histograms will be binary.
-        *  If False the total number of synchronous spikes is counted in the
+        *  If True then the time histograms will only count the number of
+           neurons which spike in each bin.
+        *  If False the total number of spikes per bin is counted in the
            time histogram.
 
         Default: True
@@ -1360,10 +1361,13 @@ class Complexity(object):
                                    self.bin_size,
                                    binary=self.binary)
 
+        time_hist_magnitude = time_hist.magnitude.flatten()
+        max_hist_entry = max(time_hist_magnitude)
+
         # Computing the histogram of the entries of pophist
         complexity_hist = np.histogram(
-            time_hist.magnitude,
-            bins=range(0, len(self.input_spiketrains) + 2))[0]
+            time_hist_magnitude,
+            bins=range(0, max_hist_entry + 2))[0]
 
         return time_hist, complexity_hist
 

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1362,12 +1362,9 @@ class Complexity(object):
                                    binary=self.binary)
 
         time_hist_magnitude = time_hist.magnitude.flatten()
-        max_hist_entry = max(time_hist_magnitude)
 
         # Computing the histogram of the entries of pophist
-        complexity_hist = np.histogram(
-            time_hist_magnitude,
-            bins=range(0, max_hist_entry + 2))[0]
+        complexity_hist = np.bincount(time_hist_magnitude)
 
         return time_hist, complexity_hist
 

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -1118,6 +1118,31 @@ class ComplexityTestCase(unittest.TestCase):
             complexity_obj.time_histogram.magnitude.flatten().astype(int),
             correct_time_histogram)
 
+    def test_complexity_histogram_spread_0_nonbinary(self):
+        sampling_rate = 1 / pq.s
+
+        spiketrains = [neo.SpikeTrain([1, 5, 5, 9, 11, 16, 19] * pq.s,
+                                      t_stop=20 * pq.s),
+                       neo.SpikeTrain([1, 4, 8, 12, 16, 16, 18] * pq.s,
+                                      t_stop=20 * pq.s)]
+
+        correct_histogram = np.array([10, 7, 2, 1])
+
+        correct_time_histogram = np.array([0, 2, 0, 0, 1, 2, 0, 0, 1, 1,
+                                           0, 1, 1, 0, 0, 0, 3, 0, 1, 1])
+
+        complexity_obj = statistics.Complexity(spiketrains,
+                                               sampling_rate=sampling_rate,
+                                               binary=False,
+                                               spread=0)
+
+        assert_array_equal(complexity_obj.complexity_histogram,
+                           correct_histogram)
+
+        assert_array_equal(
+            complexity_obj.time_histogram.magnitude.flatten().astype(int),
+            correct_time_histogram)
+
     def test_complexity_epoch_spread_0(self):
         sampling_rate = 1 / pq.s
 
@@ -1157,6 +1182,31 @@ class ComplexityTestCase(unittest.TestCase):
             complexity_obj.time_histogram.magnitude.flatten().astype(int),
             correct_time_histogram)
 
+    def test_complexity_histogram_spread_1_nonbinary(self):
+        sampling_rate = 1 / pq.s
+
+        spiketrains = [neo.SpikeTrain([0, 1, 5, 5, 9, 11, 13, 20] * pq.s,
+                                      t_stop=21 * pq.s),
+                       neo.SpikeTrain([1, 4, 7, 12, 16, 16, 18] * pq.s,
+                                      t_stop=21 * pq.s)]
+
+        correct_histogram = np.array([9, 4, 1, 3])
+
+        correct_time_histogram = np.array([3, 3, 0, 0, 3, 3, 0, 1, 0, 1, 0,
+                                           3, 3, 3, 0, 0, 2, 0, 1, 0, 1])
+
+        complexity_obj = statistics.Complexity(spiketrains,
+                                               sampling_rate=sampling_rate,
+                                               binary=False,
+                                               spread=1)
+
+        assert_array_equal(complexity_obj.complexity_histogram,
+                           correct_histogram)
+
+        assert_array_equal(
+            complexity_obj.time_histogram.magnitude.flatten().astype(int),
+            correct_time_histogram)
+
     def test_complexity_histogram_spread_2(self):
         sampling_rate = 1 / pq.s
 
@@ -1172,6 +1222,31 @@ class ComplexityTestCase(unittest.TestCase):
 
         complexity_obj = statistics.Complexity(spiketrains,
                                                sampling_rate=sampling_rate,
+                                               spread=2)
+
+        assert_array_equal(complexity_obj.complexity_histogram,
+                           correct_histogram)
+
+        assert_array_equal(
+            complexity_obj.time_histogram.magnitude.flatten().astype(int),
+            correct_time_histogram)
+
+    def test_complexity_histogram_spread_2_nonbinary(self):
+        sampling_rate = 1 / pq.s
+
+        spiketrains = [neo.SpikeTrain([1, 5, 5, 9, 11, 13, 20] * pq.s,
+                                      t_stop=21 * pq.s),
+                       neo.SpikeTrain([1, 4, 7, 12, 16, 16, 18] * pq.s,
+                                      t_stop=21 * pq.s)]
+
+        correct_histogram = np.array([5, 0, 1, 0, 1, 0, 0, 0, 1])
+
+        correct_time_histogram = np.array([0, 2, 0, 0, 8, 8, 8, 8, 8, 8, 8,
+                                           8, 8, 8, 0, 0, 4, 4, 4, 4, 4])
+
+        complexity_obj = statistics.Complexity(spiketrains,
+                                               sampling_rate=sampling_rate,
+                                               binary=False,
                                                spread=2)
 
         assert_array_equal(complexity_obj.complexity_histogram,


### PR DESCRIPTION
I noticed that the complexity class actually does not work reliably for `spread=0` and `binary=False`, because the length of the complexity histogram is hard-coded to the number of input spiketrains, which limits the maximum complexity that can be detected. Firstly, this is inconsistent with the `spread>0` case in which the histogram always has the minimal length which accommodates the highest entry. Secondly, this may lead to errors, because for `binary=False` the complexity can take arbitrarily high values, so the required size of the histogram cannot be known in advance.

I set the length of the histogram to the minimal value which accommodates the maximal complexity, made the documentation of the `binary` parameter clearer and added tests for `binary=False`.