### PR TITLE
[Feature] Merging "Total spiking probability edges" into elephant

### DIFF
--- a/elephant/functional_connectivity.py
+++ b/elephant/functional_connectivity.py
@@ -1,0 +1,5 @@
+from elephant.functional_connectivity_src.total_spiking_probability_edges import total_spiking_probability_edges
+
+__all__ = [
+    "total_spiking_probability_edges"
+]

--- a/elephant/functional_connectivity.py
+++ b/elephant/functional_connectivity.py
@@ -1,5 +1,6 @@
-from elephant.functional_connectivity_src.total_spiking_probability_edges import total_spiking_probability_edges
+from elephant.functional_connectivity_src.total_spiking_probability_edges import (
+    total_spiking_probability_edges,
+    get_connectivity_matrix,
+)
 
-__all__ = [
-    "total_spiking_probability_edges"
-]
+__all__ = ["total_spiking_probability_edges", "get_connectivity_matrix"]

--- a/elephant/functional_connectivity_src/total_spiking_probability_edges.py
+++ b/elephant/functional_connectivity_src/total_spiking_probability_edges.py
@@ -1,3 +1,9 @@
+import itertools
+from typing import List, NamedTuple
+
+import numpy as np
+
+
 def total_spiking_probability_edges():
     """
     Performs the Total spiking probability edges (TSPE) :cite:`tspe-de_blasi2007_???` on spiketrains ...
@@ -21,3 +27,71 @@ def normalized_cross_correlation():
 
 def filter_edges():
     pass
+
+
+def generate_edge_filter(
+    a: int,
+    b: int,
+    c: int,
+) -> np.ndarray:
+    r"""Generate an edge filter
+
+    The edge filter is generated using following piecewise defined function:
+
+    .. math::
+        g_{(i)} = \begin{cases}
+            - \frac{1}{a} & 0 \lt i \leq a \\
+            \frac{2}{b} & a+c \lt i \leq a + b + c \\
+            - \frac{1}{a} & a+b+2c \lt i \leq 2a + b + 2c
+            \end{cases}
+
+    """
+    filter_length = (2 * a) + b + (2 * c)
+    i = np.arange(1, filter_length + 1, dtype=np.float64)
+
+    conditions = [
+        (i > 0) & (i <= a),
+        (i > (a + c)) & (i <= a + b + c),
+        (i > a + b + (2 * c)) & (i <= (2 * a) + b + (2 * c)),
+    ]
+
+    values = [-(1 / a), 2 / b, -(1 / a), 0]  # Default Value
+
+    filter = np.piecewise(i, conditions, values)
+
+    return filter
+
+
+def generate_running_total_filter(b: int) -> np.ndarray:
+    return np.ones(b)
+
+
+class tspe_filter_pair(NamedTuple):
+    edge_filter: np.ndarray
+    running_total_filter: np.ndarray
+    needed_padding: int
+    a: int
+    b: int
+    c: int
+
+
+def generate_filter_pairs(
+    a: List[int],
+    b: List[int],
+    c: List[int],
+) -> List[tspe_filter_pair]:
+    """Generates filter pairs of edge and running total filter using all
+    permutations of given parameters
+    """
+    filter_pairs = []
+
+    for _a, _b, _c in itertools.product(a, b, c):
+        edge_filter = generate_edge_filter(_a, _b, _c)
+        running_total_filter = generate_running_total_filter(_b)
+        needed_padding = _a + _c
+        filter_pair = tspe_filter_pair(
+            edge_filter, running_total_filter, needed_padding, _a, _b, _c
+        )
+        filter_pairs.append(filter_pair)
+
+    return filter_pairs

--- a/elephant/functional_connectivity_src/total_spiking_probability_edges.py
+++ b/elephant/functional_connectivity_src/total_spiking_probability_edges.py
@@ -1,24 +1,68 @@
 import itertools
-from typing import Iterable, List, NamedTuple, Union
+from typing import Iterable, List, NamedTuple, Union, Optional
 
 import numpy as np
+from scipy.signal import oaconvolve
 
 from elephant.conversion import BinnedSpikeTrain
 
 
-def total_spiking_probability_edges():
+def total_spiking_probability_edges(
+    spike_trains: BinnedSpikeTrain,
+    a: Optional[List[int]] = None,
+    b: Optional[List[int]] = None,
+    c: Optional[List[int]] = None,
+    max_delay: int = 25,
+    normalize: bool = False
+        ):
     """
     Performs the Total spiking probability edges (TSPE) :cite:`tspe-de_blasi2007_???` on spiketrains ...
 
     Parameters
     ----------
     spiketrains: neo.spiketrains
+
     Returns
     -------
     tspe_matrix
     """
 
-    tspe_matrix = filter_edges()
+    if not a:
+        a = [3, 4, 5, 6, 7, 8]
+
+    if not b:
+        b = [2, 3, 4, 5, 6]
+
+    if not c:
+        c = [0]
+
+    n_neurons, n_bins = spike_trains.shape
+
+    filter_pairs = generate_filter_pairs(a, b, c)
+
+    # Calculate normalized cross corelation for different delays
+    # The delay range ranges from 0 to max-delay and includes
+    # padding for the filter convolution
+    max_padding = max(a) + max(c)
+    delay_times = list(range(-max_padding,max_delay + max_padding))
+    NCC_d = normalized_cross_correlation(spike_trains, delay_times=delay_times)
+
+    # Normalize to counter network-bursts
+    if normalize:
+        for delay_time in delay_times:
+            NCC_d[:,:,delay_time] /= np.sum(NCC_d[:,:,delay_time][~np.identity(NCC_d.shape[0],dtype=bool)])
+
+    # Apply edge and running total filter
+    tspe_matrix = np.zeros((n_neurons, n_neurons, max_delay))
+    for filter in filter_pairs:
+        # Select ncc_window based on needed filter padding
+        NCC_window = NCC_d[:,:,max_padding-filter.needed_padding:max_delay+max_padding+filter.needed_padding]
+
+        # Compute two convolutions with edge- and running total filter
+        x1 = oaconvolve(NCC_window, np.expand_dims(filter.edge_filter,(0,1)), mode="valid",axes=2)
+        x2 = oaconvolve(x1, np.expand_dims(filter.running_total_filter,(0,1)), mode="full",axes=2)
+
+        tspe_matrix += x2
 
     return tspe_matrix
 
@@ -88,10 +132,6 @@ def normalized_cross_correlation(
     NCC_d = np.moveaxis(NCC_d, 0, -1)
 
     return NCC_d
-
-
-def filter_edges():
-    pass
 
 
 def generate_edge_filter(

--- a/elephant/functional_connectivity_src/total_spiking_probability_edges.py
+++ b/elephant/functional_connectivity_src/total_spiking_probability_edges.py
@@ -1,0 +1,23 @@
+def total_spiking_probability_edges():
+    """
+    Performs the Total spiking probability edges (TSPE) :cite:`tspe-de_blasi2007_???` on spiketrains ...
+
+    Parameters
+    ----------
+    spiketrains: neo.spiketrains
+    Returns
+    -------
+    tspe_matrix
+    """
+
+    tspe_matrix = filter_edges()
+
+    return tspe_matrix
+
+
+def normalized_cross_correlation():
+    pass
+
+
+def filter_edges():
+    pass

--- a/elephant/functional_connectivity_src/total_spiking_probability_edges.py
+++ b/elephant/functional_connectivity_src/total_spiking_probability_edges.py
@@ -1,11 +1,32 @@
 import itertools
-from typing import Iterable, List, NamedTuple, Union, Optional
+from typing import Iterable, List, NamedTuple, Union, Optional, Tuple
 
 import numpy as np
 from scipy.signal import oaconvolve
 
 from elephant.conversion import BinnedSpikeTrain
 
+def get_connectivity_matrix(tspe_matrix: np.ndarray) -> Tuple[np.ndarray,np.ndarray]:
+    """
+    Takes a tspe_matrix and computes the connectivity- and delay-matrix
+
+    Parameters
+    ----------
+    tspe_matrix: np.array
+
+    Returns
+    -------
+    connectivity_matrix
+    delay-matrix
+
+    """
+
+    # Take maxima of absolute of delays to get estimation for connectivity
+    connectivity_matrix_index = np.argmax(np.abs(tspe_matrix),axis=2,keepdims=True)
+    connectivity_matrix = np.take_along_axis(tspe_matrix,connectivity_matrix_index,axis=2).squeeze(axis=2)
+    delay_matrix = connectivity_matrix_index
+
+    return connectivity_matrix, delay_matrix
 
 def total_spiking_probability_edges(
     spike_trains: BinnedSpikeTrain,
@@ -20,11 +41,12 @@ def total_spiking_probability_edges(
 
     Parameters
     ----------
-    spiketrains: neo.spiketrains
+    spiketrains: BinnedSpikeTrain
 
     Returns
     -------
     tspe_matrix
+
     """
 
     if not surrounding_window_sizes:

--- a/elephant/functional_connectivity_src/total_spiking_probability_edges.py
+++ b/elephant/functional_connectivity_src/total_spiking_probability_edges.py
@@ -1,7 +1,9 @@
 import itertools
-from typing import List, NamedTuple
+from typing import Iterable, List, NamedTuple, Union
 
 import numpy as np
+
+from elephant.conversion import BinnedSpikeTrain
 
 
 def total_spiking_probability_edges():
@@ -21,8 +23,71 @@ def total_spiking_probability_edges():
     return tspe_matrix
 
 
-def normalized_cross_correlation():
-    pass
+def normalized_cross_correlation(
+    spike_trains: BinnedSpikeTrain,
+    delay_times: Union[int, List[int], Iterable[int]] = 0,
+) -> np.ndarray:
+    r"""normalized cross correlation using std deviation
+
+    Computes the normalized_cross_correlation between all
+    Spiketrains inside a BinnedSpikeTrain-Object at a given delay_time
+
+    The underlying formula is:
+
+    .. math::
+        NCC_{X\arrY(d)} = \frac{1}{N_{bins}}\sum_{i=-\inf}^{\inf}{\frac{(y_{(i)} - \bar{y}) \cdot (x_{(i-d) - \bar{x})}{\sigma_x \cdot \sigma_y}}}
+
+    """
+
+    n_neurons, n_bins = spike_trains.shape
+
+    # Get sparse array of BinnedSpikeTrain
+    spike_trains_array = spike_trains.sparse_matrix
+
+    # Get std deviation of spike trains
+    spike_trains_zeroed = spike_trains_array - spike_trains_array.mean(axis=1)
+    spike_trains_std = np.std(spike_trains_zeroed, ddof=1, axis=1)
+    std_factors = spike_trains_std @ spike_trains_std.T
+
+    # Loop over delay times
+    if isinstance(delay_times, int):
+        delay_times = [delay_times]
+    elif isinstance(delay_times, list):
+        pass
+    elif isinstance(delay_times, Iterable):
+        delay_times = list(delay_times)
+
+    NCC_d = np.zeros((len(delay_times), n_neurons, n_neurons))
+
+    for index, delay_time in enumerate(delay_times):
+        # Uses theoretical zero-padding for shifted values,
+        # but since $0 \cdot x = 0$ values can simply be omitted
+        if delay_time == 0:
+            CC = spike_trains_array[:, :] @ spike_trains_array[:, :].transpose()
+
+        elif delay_time > 0:
+            CC = (
+                spike_trains_array[:, delay_time:]
+                @ spike_trains_array[:, :-delay_time].transpose()
+            )
+
+        else:
+            CC = (
+                spike_trains_array[:, :delay_time]
+                @ spike_trains_array[:, -delay_time:].transpose()
+            )
+
+        # Normalize using std deviation
+        NCC = CC / std_factors / n_bins
+
+        # Compute cross correlation at given delay time
+        NCC_d[index, :, :] = NCC
+
+    # Move delay_time axis to back of array
+    # Makes index using neurons more intuitive → (n_neuron, n_neuron, delay_times)
+    NCC_d = np.moveaxis(NCC_d, 0, -1)
+
+    return NCC_d
 
 
 def filter_edges():

--- a/elephant/test/test_total_spiking_probability_edges.py
+++ b/elephant/test/test_total_spiking_probability_edges.py
@@ -22,9 +22,9 @@ def test_generate_filter_pairs():
             edge_filter=np.array([-1.0, 0.0, 2.0, 0.0, -1.0]),
             running_total_filter=np.array([1.0]),
             needed_padding=2,
-            a=1,
-            b=1,
-            c=1,
+            surrounding_window_size=1,
+            observed_window_size=1,
+            crossover_window_size=1,
         )
     ]
 
@@ -39,9 +39,18 @@ def test_generate_filter_pairs():
             filter_pair_test.running_total_filter,
         )
         assert filter_pair_function.needed_padding == filter_pair_test.needed_padding
-        assert filter_pair_function.a == filter_pair_test.a
-        assert filter_pair_function.b == filter_pair_test.b
-        assert filter_pair_function.c == filter_pair_test.c
+        assert (
+            filter_pair_function.surrounding_window_size
+            == filter_pair_test.surrounding_window_size
+        )
+        assert (
+            filter_pair_function.observed_window_size
+            == filter_pair_test.observed_window_size
+        )
+        assert (
+            filter_pair_function.crossover_window_size
+            == filter_pair_test.crossover_window_size
+        )
 
 
 def test_normalized_cross_correlation():
@@ -64,4 +73,4 @@ def test_normalized_cross_correlation():
         spiketrains, [-delay_time, delay_time]
     )
 
-    assert np.allclose(function_output, test_output,0.1)
+    assert np.allclose(function_output, test_output, 0.1)

--- a/elephant/test/test_total_spiking_probability_edges.py
+++ b/elephant/test/test_total_spiking_probability_edges.py
@@ -1,0 +1,40 @@
+from typing import List
+
+import numpy as np
+import pytest
+
+from elephant.functional_connectivity_src.total_spiking_probability_edges import (
+    generate_filter_pairs,
+    tspe_filter_pair,
+)
+
+
+def test_generate_filter_pairs():
+    a = [1]
+    b = [1]
+    c = [1]
+    test_output = [
+        tspe_filter_pair(
+            edge_filter=np.array([-1.0, 0.0, 2.0, 0.0, -1.0]),
+            running_total_filter=np.array([1.0]),
+            needed_padding=2,
+            a=1,
+            b=1,
+            c=1,
+        )
+    ]
+
+    function_output = generate_filter_pairs(a, b, c)
+
+    for filter_pair_function, filter_pair_test in zip(function_output, test_output):
+        assert np.array_equal(
+            filter_pair_function.edge_filter, filter_pair_test.edge_filter
+        )
+        assert np.array_equal(
+            filter_pair_function.running_total_filter,
+            filter_pair_test.running_total_filter,
+        )
+        assert filter_pair_function.needed_padding == filter_pair_test.needed_padding
+        assert filter_pair_function.a == filter_pair_test.a
+        assert filter_pair_function.b == filter_pair_test.b
+        assert filter_pair_function.c == filter_pair_test.c


### PR DESCRIPTION
**Summary:**
TSPE enables the classification of excitatory and inhibitory synaptic effects using a connectivity estimation. It uses the cross-correlation of spiketrains at different delays combined with specially designed Edge-Filters to distinguish between excitatory and inhibitory connections.

Related issue: #557

**Currently implemented:**

- [x] generate_filter_pairs
- [x] normalized_cross_correlation
- [x] total_spiking_probability_edges
- [x] get_connectivity_matrix
- [x] normalization function inside tspe
       Not sure if working correctly.

**Current tests implemented for:**

- [x] generate_filter_pairs (Fairly Basic Test)
- [x] normalized_cross_correlation (Fairly Basic Test)
- [ ] total_spiking_probability_edges 
       The test is implemented, but currently not pushed because I need help where to put the evaluation data
- [ ] get_connectivity_matrix

**What remains to be done:**
- [ ] Upload evaluation data to data-repository
- [ ] Validate test-cases
- [ ] Proper documentation for:
    - [ ] total_spiking_probability_edges
    - [ ] get_connectivity_matrix
    - [ ] Module documentation?
- [ ] Add reference to the Elephant bibliography file

