### PR TITLE
Enhance security of actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,7 +139,7 @@ jobs:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{hashFiles('requirements/environment.yml') }}-${{ hashFiles('**/CI.yml') }}-${{ steps.date.outputs.date }}
 
-      - uses: conda-incubator/setup-miniconda@v2.2.0
+      - uses: conda-incubator/setup-miniconda@3b0f2504dd76ef23b6d31f291f4913fb60ab5ff3 # corresponds to v2.2.0
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ebrains.yml
+++ b/.github/workflows/ebrains.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.repository_owner == 'NeuralEnsemble' }}
     steps:
       - name: syncmaster
-        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83 # corresponds to v3
         with:
           source_repo: "NeuralEnsemble/elephant"
           source_branch: "master"
@@ -18,7 +18,7 @@ jobs:
           destination_branch: "master"
 
       - name: synctags
-        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83 # corresponds to v3
         with:
           source_repo: "NeuralEnsemble/elephant"
           source_branch: "refs/tags/*"

--- a/.github/workflows/ebrains.yml
+++ b/.github/workflows/ebrains.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.repository_owner == 'NeuralEnsemble' }}
     steps:
       - name: syncmaster
-        uses: wei/git-sync@v3
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
         with:
           source_repo: "NeuralEnsemble/elephant"
           source_branch: "master"
@@ -18,7 +18,7 @@ jobs:
           destination_branch: "master"
 
       - name: synctags
-        uses: wei/git-sync@v3
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
         with:
           source_repo: "NeuralEnsemble/elephant"
           source_branch: "refs/tags/*"


### PR DESCRIPTION
This is a mini PR to increase security of github actions. When using third party actions, using a tag such as `v3` is not good practice, as an attacker to redirect this tag to a potentially malicious commit. Instead, using a SHA of that particular tag is better, since it will link to one particular well-defined commit.