### PR TITLE
[doc] add development install of Elephant contributers guide

### DIFF
--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -88,6 +88,11 @@ your local machine.
             pip install -r requirements/requirements-extras.txt  # optional
             pip install -r requirements/requirements-tests.txt
 
+Install elephant development version:
+
+.. code-block:: sh
+
+    pip install -e .
 
 3. Before you make any changes, run the test suite to make sure all the tests
    pass on your system::


### PR DESCRIPTION
In the contributors guide [Setting up a development environment](https://elephant.readthedocs.io/en/latest/contribute.html#setting-up-a-development-environment) only the requirements are installed, but not Elephant itself.

Fixed by adding a `pip install -e .` command to the guide.