### PR TITLE
[Fix] deprecation warnings numpy 1.25.0

### DIFF
--- a/elephant/causality/granger.py
+++ b/elephant/causality/granger.py
@@ -284,8 +284,9 @@ def _vector_arm(signals, dimension, order):
     positive_lag_covariances = np.reshape(lag_covariances[1:],
                                           (dimension*order, dimension))
 
-    lstsq_coeffs = \
-        np.linalg.lstsq(yule_walker_matrix, positive_lag_covariances)[0]
+    lstsq_coeffs = np.linalg.lstsq(yule_walker_matrix,
+                                   positive_lag_covariances,
+                                   rcond=None)[0]
 
     coeffs = []
     for index in range(order):

--- a/elephant/current_source_density_src/KCSD.py
+++ b/elephant/current_source_density_src/KCSD.py
@@ -317,17 +317,18 @@ class KCSD(CSD):
             V_train = self.pots[idx_train]
             V_test = self.pots[idx_test]
             I_matrix = np.identity(len(idx_train))
-            B_new = np.matrix(B_train) + (lambd*I_matrix)
+            B_new = np.array(B_train) + (lambd * I_matrix)
             try:
-                beta_new = np.dot(np.matrix(B_new).I, np.matrix(V_train))
+                beta_new = np.linalg.inv(B_new) @ V_train
                 B_test = self.k_pot[np.ix_(idx_test, idx_train)]
                 V_est = np.zeros((len(idx_test), self.pots.shape[1]))
                 for ii in range(len(idx_train)):
                     for tt in range(self.pots.shape[1]):
                         V_est[:, tt] += beta_new[ii, tt] * B_test[:, ii]
-                err += np.linalg.norm(V_est-V_test)
-            except LinAlgError:
-                raise LinAlgError('Encoutered Singular Matrix Error: try changing ele_pos slightly')
+                err += np.linalg.norm(V_est - V_test)
+            except np.linalg.LinAlgError:
+                raise np.linalg.LinAlgError(
+                    'Encountered Singular Matrix Error: try changing ele_pos slightly')
         return err
 
 class KCSD1D(KCSD):

--- a/elephant/current_source_density_src/icsd.py
+++ b/elephant/current_source_density_src/icsd.py
@@ -691,10 +691,10 @@ class SplineiCSD(CSD):
         for j in range(self.num_steps):
             if out_zs[j] >= z_js[i + 1]:
                 i += 1
-            csd[j, ] = a_mat0[i, :] + a_mat1[i, :] * \
-                             (out_zs[j] - z_js[i]) + \
-                a_mat2[i, :] * (out_zs[j] - z_js[i])**2 + \
-                a_mat3[i, :] * (out_zs[j] - z_js[i])**3
+            csd[j] = (a_mat0[i, :] + a_mat1[i, :] *
+                      (out_zs[j] - z_js[i]) +
+                      a_mat2[i, :] * (out_zs[j] - z_js[i])**2 +
+                      a_mat3[i, :] * (out_zs[j] - z_js[i])**3).item()
 
         csd_unit = (self.f_matrix.units**-1 * self.lfp.units).simplified
 

--- a/elephant/gpfa/gpfa_core.py
+++ b/elephant/gpfa/gpfa_core.py
@@ -494,7 +494,7 @@ def learn_gp_params(seqs_latent, params, verbose=False):
         res_opt = optimize.minimize(gpfa_util.grad_betgam, initp,
                                     args=(precomp[i], const),
                                     method='L-BFGS-B', jac=True)
-        param_opt['gamma'][i] = np.exp(res_opt.x)
+        param_opt['gamma'][i] = np.exp(res_opt.x.item())
 
         if verbose:
             print('\n Converged p; xDim:{}, p:{}'.format(i, res_opt.x))

--- a/elephant/phase_analysis.py
+++ b/elephant/phase_analysis.py
@@ -182,8 +182,10 @@ def spike_triggered_phase(hilbert_transform, spiketrains, interpolate):
                     hilbert_transform[phase_i].sampling_period
 
                 # Save hilbert_transform (interpolate on circle)
-                p1 = np.angle(hilbert_transform[phase_i][ind_at_spike_j])
-                p2 = np.angle(hilbert_transform[phase_i][ind_at_spike_j + 1])
+                p1 = np.angle(hilbert_transform[phase_i][ind_at_spike_j]
+                              ).item()
+                p2 = np.angle(hilbert_transform[phase_i][ind_at_spike_j + 1]
+                              ).item()
                 interpolation = (1 - z) * np.exp(complex(0, p1)) \
                                     + z * np.exp(complex(0, p2))
                 p12 = np.angle([interpolation])

--- a/elephant/test/test_icsd.py
+++ b/elephant/test/test_icsd.py
@@ -130,10 +130,10 @@ def potential_of_cylinder(z_j,
 
     Tested with
 
-    >>> from sympy import *
-    >>> C_i, z_i, h, z_j, z_j, sigma, R = symbols('C_i z_i h z z_j sigma R')
-    >>> C_i*integrate(1/(2*sigma)*(sqrt((z-z_j)**2 + R**2) -
-    ... abs(z-z_j)), (z, z_i-h/2, z_i+h/2))
+    # >>> from sympy import *
+    # >>> C_i, z_i, h, z_j, z_j, sigma, R = symbols('C_i z_i h z z_j sigma R')
+    # >>> C_i*integrate(1/(2*sigma)*(sqrt((z-z_j)**2 + R**2) -
+    # ... abs(z-z_j)), (z, z_i-h/2, z_i+h/2))
 
 
     """

--- a/elephant/test/test_icsd.py
+++ b/elephant/test/test_icsd.py
@@ -3,7 +3,6 @@
 iCSD testing suite
 """
 
-import os
 import numpy as np
 import numpy.testing as nt
 import quantities as pq
@@ -122,20 +121,6 @@ def potential_of_cylinder(z_j,
         radius of disk source
     sigma : float*pq.S/pq.m
         conductivity of medium in units of S/m
-
-    Notes
-    -----
-    Sympy can't deal with eq. 11 in Pettersen et al 2006, J neurosci Meth,
-    so we numerically evaluate it in this function.
-
-    Tested with
-
-    # >>> from sympy import *
-    # >>> C_i, z_i, h, z_j, z_j, sigma, R = symbols('C_i z_i h z z_j sigma R')
-    # >>> C_i*integrate(1/(2*sigma)*(sqrt((z-z_j)**2 + R**2) -
-    # ... abs(z-z_j)), (z, z_i-h/2, z_i+h/2))
-
-
     """
     try:
         assert(z_j.units == z_i.units == R_i.units == h_i.units)

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -15,7 +15,7 @@ import quantities as pq
 import scipy.signal as spsig
 import scipy.stats
 from numpy.ma.testutils import assert_array_equal, assert_allclose
-from numpy.testing.utils import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 
 import elephant.signal_processing
 

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -11,7 +11,7 @@ import unittest
 import neo
 import numpy as np
 import quantities as pq
-from numpy.testing.utils import assert_array_equal, assert_array_almost_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 import elephant.conversion as conv
 import elephant.spike_train_correlation as sc


### PR DESCRIPTION
## Deprecation
1. The default behavior of `numpy.linalg.lstsq` will be changed, to fix this, set a parameter for `rcond`
  - set to `rcond = None` in granger
2. Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation.
 - fixed in gpfa, icsd, phase analysis 
3. changed import from `numpy.testing.utils` to `numpy.testing`
4. Comment out  example in doc string of icsd unittest, pytest is trying to run this as a docstest
5. replaced np.matrix with ndarray in KCSD
