### PR TITLE
[ENH] replace warnings with logging to elephant.utils.round_binning_errors

### DIFF
--- a/elephant/test/test_utils.py
+++ b/elephant/test/test_utils.py
@@ -44,15 +44,13 @@ class TestUtils(unittest.TestCase):
                           object_type=neo.SpikeTrain)
 
     def test_round_binning_errors(self):
-        with self.assertWarns(UserWarning):
-            n_bins = utils.round_binning_errors(0.999999, tolerance=1e-6)
-            self.assertEqual(n_bins, 1)
+        n_bins = utils.round_binning_errors(0.999999, tolerance=1e-6)
+        self.assertEqual(n_bins, 1)
         self.assertEqual(utils.round_binning_errors(0.999999, tolerance=None),
                          0)
         array = np.array([0, 0.7, 1 - 1e-8, 1 - 1e-9])
-        with self.assertWarns(UserWarning):
-            corrected = utils.round_binning_errors(array.copy())
-            assert_array_equal(corrected, [0, 0, 1, 1])
+        corrected = utils.round_binning_errors(array.copy())
+        assert_array_equal(corrected, [0, 0, 1, 1])
         assert_array_equal(
             utils.round_binning_errors(array.copy(), tolerance=None),
             [0, 0, 0, 0])

--- a/elephant/utils.py
+++ b/elephant/utils.py
@@ -12,6 +12,7 @@
 from __future__ import division, print_function, unicode_literals
 
 import ctypes
+import logging
 import warnings
 from functools import wraps
 
@@ -31,6 +32,15 @@ __all__ = [
     "round_binning_errors"
 ]
 
+
+# Create logger and set configuration
+logger = logging.getLogger(__file__)
+log_handler = logging.StreamHandler()
+log_handler.setFormatter(
+    logging.Formatter(f"[%(asctime)s] {__name__[__name__.rfind('.')+1::]} -"
+                       " %(levelname)s: %(message)s"))
+logger.addHandler(log_handler)
+logger.propagate = False
 
 def is_binary(array):
     """
@@ -288,18 +298,18 @@ def round_binning_errors(values, tolerance=1e-8):
     if isinstance(values, np.ndarray):
         num_corrections = correction_mask.sum()
         if num_corrections > 0:
-            warnings.warn(f'Correcting {num_corrections} rounding errors by '
-                          f'shifting the affected spikes into the following '
-                          f'bin. You can set tolerance=None to disable this '
-                          'behaviour.')
+            logger.info(f'Correcting {num_corrections} rounding errors by '
+                         'shifting the affected spikes into the following '
+                         'bin. You can set tolerance=None to disable this '
+                         'behaviour.')
             values[correction_mask] += 0.5
         return values.astype(np.int32)
 
     if correction_mask:
-        warnings.warn('Correcting a rounding error in the calculation '
-                      'of the number of bins by incrementing the value by 1. '
-                      'You can set tolerance=None to disable this '
-                      'behaviour.')
+        logger.info('Correcting a rounding error in the calculation '
+                    'of the number of bins by incrementing the value by 1. '
+                    'You can set tolerance=None to disable this '
+                    'behaviour.')
         values += 0.5
     return int(values)
 


### PR DESCRIPTION
This PR aims to suggest a solution to Issue #567 .

The warnings in function `round_binning_errors()` from `elephant/utils.py` are replaced by log calls.

**t.b.d.**
- [ ] decide on loglevel, e.g. logging.warning ?
- [ ] default log level for the logger