### PR TITLE
[Fix] Use default tolerances for np.testing.allclose() in WPLI ground truth test

### DIFF
--- a/elephant/test/test_phase_analysis.py
+++ b/elephant/test/test_phase_analysis.py
@@ -496,7 +496,7 @@ class WeightedPhaseLagIndexTestCase(unittest.TestCase):
                 self.lfps1_real, self.lfps2_real, self.sf1_real)
             np.testing.assert_allclose(
                 wpli, self.wpli_ground_truth_ft_connectivity_wpli_real,
-                atol=self.tolerance, rtol=self.tolerance, equal_nan=True)
+                equal_nan=True)
         # np.array-input
         with self.subTest(msg="np.array input"):
             freq, wpli = elephant.phase_analysis.weighted_phase_lag_index(
@@ -504,14 +504,14 @@ class WeightedPhaseLagIndexTestCase(unittest.TestCase):
                 self.sf1_real)
             np.testing.assert_allclose(
                 wpli, self.wpli_ground_truth_ft_connectivity_wpli_real,
-                atol=self.tolerance, rtol=self.tolerance, equal_nan=True)
+                equal_nan=True)
         # neo.AnalogSignal-input
         with self.subTest(msg="neo.AnalogSignal input"):
             freq, wpli = elephant.phase_analysis.weighted_phase_lag_index(
                 self.lfps1_real_AnalogSignal, self.lfps2_real_AnalogSignal)
             np.testing.assert_allclose(
                 wpli, self.wpli_ground_truth_ft_connectivity_wpli_real,
-                atol=self.tolerance, rtol=self.tolerance, equal_nan=True)
+                equal_nan=True)
 
     def test_WPLI_ground_truth_consistency_artificial_LFP_dataset(self):
         """


### PR DESCRIPTION
This PR addresses an issue  when testing Elephant on JUSUF and Galileo100, see #569 .

For the ground truth test in WPLI, see:
https://github.com/NeuralEnsemble/elephant/blob/5b464ecd358e871719b47990c48ac039871cfd63/elephant/test/test_phase_analysis.py#L494-L514

The default tolerance values were used for `np.testing.allclose` to prevent test failures in cases where the deviations very small and therefore negligible.