### PR TITLE
[MAIN] Drop support for numpy 1.22 and Python 3.8 following NEP 29

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,8 +57,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python versions for elephant: [3.8, 3.9, "3.10", 3.11]
-        python-version: [3.8, 3.9, "3.10", 3.11]
+        # python versions for elephant: [3.9, "3.10", 3.11]
+        python-version: [3.9, "3.10", 3.11]
         # OS [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
       # do not cancel all in-progress jobs if any matrix job fails
@@ -181,8 +181,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python versions for elephant: [3.8, 3.9, 3.10, 3.11]
-        python-version: [3.8,]
+        # python versions for elephant: [3.9, 3.10, 3.11]
+        python-version: [3.11,]
         # OS [ubuntu-latest, macos-latest, windows-latest]
         os: [windows-latest]
         include:
@@ -243,8 +243,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python versions for elephant: [3.8, 3.9, 3.10, 3.11]
-        python-version: [3.9]
+        # python versions for elephant: [3.9, 3.10, 3.11]
+        python-version: [3.11]
         # OS [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
 
@@ -421,7 +421,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python versions for elephant: [3.7, 3.8, 3.9, "3.10"]
+        # python versions for elephant: [3.9, "3.10"]
         python-version: ["3.10"]
 
         # OS [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -34,7 +34,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* cp36-* cp37-* pp*"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_ARCHS: "auto64"
 
       - uses: actions/upload-artifact@v3

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,7 +14,7 @@ Below is the explanation of how to proceed with these two steps.
 Prerequisites
 *************
 
-Elephant requires `Python <http://python.org/>`_ 3.8, 3.9, 3.10 or 3.11.
+Elephant requires `Python <http://python.org/>`_ 3.9, 3.10 or 3.11.
 
 .. tabs::
 
@@ -25,7 +25,7 @@ Elephant requires `Python <http://python.org/>`_ 3.8, 3.9, 3.10 or 3.11.
 
            .. code-block:: sh
 
-              conda create --name elephant python=3.8 numpy scipy tqdm
+              conda create --name elephant python=3.11 numpy scipy tqdm
 
         2. Activate your environment:
 

--- a/requirements/environment-docs.yml
+++ b/requirements/environment-docs.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.8
 
   - mpi4py
-  - numpy>=1.19.5
+  - numpy>=1.23.0
   - scipy
   - tqdm
   - pandas

--- a/requirements/environment-docs.yml
+++ b/requirements/environment-docs.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge  # required for MPI
 
 dependencies:
-  - python>=3.8
+  - python>=3.9
 
   - mpi4py
   - numpy>=1.23.0

--- a/requirements/environment-tests.yml
+++ b/requirements/environment-tests.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.8
 
   - mpi4py
-  - numpy>=1.19.5
+  - numpy>=1.23.0
   - scipy
   - tqdm
   - pandas

--- a/requirements/environment-tests.yml
+++ b/requirements/environment-tests.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge  # required for MPI
 
 dependencies:
-  - python>=3.8
+  - python>=3.9
 
   - mpi4py
   - numpy>=1.23.0

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge  # required for MPI
 
 dependencies:
-  - python>=3.8
+  - python>=3.9
   - mpi4py
   - numpy>=1.23.0
   - scipy

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.8
   - mpi4py
-  - numpy>=1.19.5
+  - numpy>=1.23.0
   - scipy
   - tqdm
   - pandas

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 neo>=0.10.0
-numpy>=1.19.5
+numpy>=1.23.0
 quantities>=0.14.1
 scipy>=1.5.4
 six>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup_kwargs = {
             "Documentation": "https://elephant.readthedocs.io/en/latest/",
             "Source Code": "https://github.com/NeuralEnsemble/elephant",
         },
-    "python_requires": ">=3.8",
+    "python_requires": ">=3.9",
     "classifiers": [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
@@ -89,7 +89,6 @@ setup_kwargs = {
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
In accordance with NEP 29 + 1 year support for Python 3.8 and numpy 1.22 is dropped. 
(https://numpy.org/neps/nep-0029-deprecation_policy.html)