### PR TITLE
[MAIN] update build_wheels action

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.14.1
+          python -m pip install cibuildwheel==2.13.1
 
       - name: Install libomp
         if: runner.os == 'macOS'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v4
 
       - name: Install cibuildwheel
-        run: |
+        run:
           python -m pip install --upgrade pip
           python -m pip install cibuildwheel==2.13.1
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,7 +24,9 @@ jobs:
       - uses: actions/setup-python@v4
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.14.1
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==2.14.1
 
       - name: Install libomp
         if: runner.os == 'macOS'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v4
 
       - name: Install cibuildwheel
-        run:
+        run: |
           python -m pip install --upgrade pip
           python -m pip install cibuildwheel==2.13.1
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v4
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.3.1
+        run: python -m pip install cibuildwheel==2.14.1
 
       - name: Install libomp
         if: runner.os == 'macOS'


### PR DESCRIPTION
Update the build_wheels action to use cibuildwheel version 2.13.1.

With this change wheels will also build for Python 3.11.