### PR TITLE
[ENH] Added ASSET class initialization parameter to define the binning rounding error tolerance

### DIFF
--- a/elephant/asset/asset.py
+++ b/elephant/asset/asset.py
@@ -1967,8 +1967,9 @@ class ASSET(object):
     bin_tolerance : float or 'default' or None, optional
         Defines the tolerance value for rounding errors when binning the
         spike trains. If 'default', the value is the default as defined in
-        :class:`conv.BinnedSpikeTrain`. If None, no correction for binning
-        errors is performed. If a number, the binning will consider this value.
+        :class:`~.conversion.BinnedSpikeTrain`. If None, no correction for
+        binning errors is performed. If a number, the binning will consider
+        this value.
         Default: 'default'
     verbose : bool, optional
         If True, print messages and show progress bar.
@@ -1985,7 +1986,7 @@ class ASSET(object):
 
     See Also
     --------
-    conv.BinnedSpikeTrain
+    :class:`elephant.conversion.BinnedSpikeTrain`
 
     """
 

--- a/elephant/test/test_asset.py
+++ b/elephant/test/test_asset.py
@@ -55,44 +55,66 @@ class AssetBinningTestCase(unittest.TestCase):
         spiketrain_2 = neo.SpikeTrain(
             [0.9999999999, 1.9999, 4, 5], units=pq.ms, t_stop=6*pq.ms)
 
-        self.spiketrains = [spiketrain_1, spiketrain_2]
+        self.spiketrains_i = [spiketrain_1, spiketrain_2]
+        self.spiketrains_j = [spiketrain_2, spiketrain_1]
 
     def test_bin_tolerance_default(self):
-        asset_obj = asset.ASSET(self.spiketrains, bin_size=1*pq.ms)
-        bins = asset_obj.spiketrains_binned_i.to_array()
+        asset_obj = asset.ASSET(spiketrains_i=self.spiketrains_i,
+                                spiketrains_j=self.spiketrains_j,
+                                bin_size=1*pq.ms)
+        bins_i = asset_obj.spiketrains_binned_i.to_array()
+        bins_j = asset_obj.spiketrains_binned_j.to_array()
 
         # Should shift spikes closer than 1e-8 to the right bin edge.
         # This is the current default tolerance for `BinnedSpikeTrain`.
-        expected_bins = np.array(
+        expected_bins_i = np.array(
             [[0, 1, 1, 0, 2, 0],
              [0, 2, 0, 0, 1, 1]])
+        expected_bins_j = np.array(
+            [[0, 2, 0, 0, 1, 1],
+             [0, 1, 1, 0, 2, 0]])
 
-        self.assertTrue(np.array_equal(bins, expected_bins))
+        self.assertTrue(np.array_equal(bins_i, expected_bins_i))
+        self.assertTrue(np.array_equal(bins_j, expected_bins_j))
 
     def test_bin_tolerance_none(self):
-        asset_obj = asset.ASSET(self.spiketrains, bin_size=1*pq.ms,
+        asset_obj = asset.ASSET(spiketrains_i=self.spiketrains_i,
+                                spiketrains_j=self.spiketrains_j,
+                                bin_size=1*pq.ms,
                                 bin_tolerance=None)
-        bins = asset_obj.spiketrains_binned_i.to_array()
+        bins_i = asset_obj.spiketrains_binned_i.to_array()
+        bins_j = asset_obj.spiketrains_binned_j.to_array()
 
         # Should not shift any spikes. Bin should be the same as the integer
         # part of the time.
-        expected_bins = np.array(
+        expected_bins_i = np.array(
             [[0, 1, 1, 1, 1, 0],
              [1, 1, 0, 0, 1, 1]])
+        expected_bins_j = np.array(
+            [[1, 1, 0, 0, 1, 1],
+             [0, 1, 1, 1, 1, 0]])
 
-        self.assertTrue(np.array_equal(bins, expected_bins))
+        self.assertTrue(np.array_equal(bins_i, expected_bins_i))
+        self.assertTrue(np.array_equal(bins_j, expected_bins_j))
 
     def test_bin_tolerance_float(self):
-        asset_obj = asset.ASSET(self.spiketrains, bin_size=1*pq.ms,
+        asset_obj = asset.ASSET(spiketrains_i=self.spiketrains_i,
+                                spiketrains_j=self.spiketrains_j,
+                                bin_size=1*pq.ms,
                                 bin_tolerance=1e-3)
-        bins = asset_obj.spiketrains_binned_i.to_array()
+        bins_i = asset_obj.spiketrains_binned_i.to_array()
+        bins_j = asset_obj.spiketrains_binned_j.to_array()
 
         # Should shift spikes closer than 1e-3 to the right bin edge.
-        expected_bins = np.array(
+        expected_bins_i = np.array(
+            [[0, 1, 1, 0, 1, 1],
+             [0, 1, 1, 0, 1, 1]])
+        expected_bins_j = np.array(
             [[0, 1, 1, 0, 1, 1],
              [0, 1, 1, 0, 1, 1]])
 
-        self.assertTrue(np.array_equal(bins, expected_bins))
+        self.assertTrue(np.array_equal(bins_i, expected_bins_i))
+        self.assertTrue(np.array_equal(bins_j, expected_bins_j))
 
 
 @unittest.skipUnless(HAVE_SKLEARN, 'requires sklearn')

--- a/elephant/test/test_asset.py
+++ b/elephant/test/test_asset.py
@@ -46,6 +46,55 @@ except ImportError:
     HAVE_CUDA = False
 
 
+class AssetBinningTestCase(unittest.TestCase):
+
+    def setUp(self):
+        spiketrain_1 = neo.SpikeTrain(
+            [1.3, 2.1, 3.9999999999, 4.9999], units=pq.ms, t_stop=6*pq.ms)
+
+        spiketrain_2 = neo.SpikeTrain(
+            [0.9999999999, 1.9999, 4, 5], units=pq.ms, t_stop=6*pq.ms)
+
+        self.spiketrains = [spiketrain_1, spiketrain_2]
+
+    def test_bin_tolerance_default(self):
+        asset_obj = asset.ASSET(self.spiketrains, bin_size=1*pq.ms)
+        bins = asset_obj.spiketrains_binned_i.to_array()
+
+        # Should shift spikes closer than 1e-8 to the right bin edge.
+        # This is the current default tolerance for `BinnedSpikeTrain`.
+        expected_bins = np.array(
+            [[0, 1, 1, 0, 2, 0],
+             [0, 2, 0, 0, 1, 1]])
+
+        self.assertTrue(np.array_equal(bins, expected_bins))
+
+    def test_bin_tolerance_none(self):
+        asset_obj = asset.ASSET(self.spiketrains, bin_size=1*pq.ms,
+                                bin_tolerance=None)
+        bins = asset_obj.spiketrains_binned_i.to_array()
+
+        # Should not shift any spikes. Bin should be the same as the integer
+        # part of the time.
+        expected_bins = np.array(
+            [[0, 1, 1, 1, 1, 0],
+             [1, 1, 0, 0, 1, 1]])
+
+        self.assertTrue(np.array_equal(bins, expected_bins))
+
+    def test_bin_tolerance_float(self):
+        asset_obj = asset.ASSET(self.spiketrains, bin_size=1*pq.ms,
+                                bin_tolerance=1e-3)
+        bins = asset_obj.spiketrains_binned_i.to_array()
+
+        # Should shift spikes closer than 1e-3 to the right bin edge.
+        expected_bins = np.array(
+            [[0, 1, 1, 0, 1, 1],
+             [0, 1, 1, 0, 1, 1]])
+
+        self.assertTrue(np.array_equal(bins, expected_bins))
+
+
 @unittest.skipUnless(HAVE_SKLEARN, 'requires sklearn')
 class AssetTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Currently, the `ASSET` class performs the binning of the spiketrains using the default behavior of the `BinnedSpikeTrain` class in `conversion`. 

Therefore, when spike times are closer to the right bin edge than a defined tolerance value, the `BinnedSpikeTrain` class shifts the spike to the next bin. This behavior can be controlled by the `tolerance` parameter of `BinnedSpikeTrain`.

This PR adds the new parameter `bin_tolerance` to the `ASSET` class, in order to allow the user to define the desired tolerance (and hence `BinnedSpikeTrain` behavior).

The parameter can take a string `'default'` to use the default behavior of `BinnedSpikeTrain` (and which corresponds to the current status of `ASSET` before this PR), or a float value or None. In the latter two cases, these values are forwarded to the binning class, and will result in either shifting or not shifting the spikes, respectively.