### PR TITLE
[FIX] add skip test_multitaper_cohere_perfect_cohere for numpy == 1.25.2

### DIFF
--- a/elephant/test/test_spectral.py
+++ b/elephant/test/test_spectral.py
@@ -954,9 +954,9 @@ class MultitaperCoherenceTestCase(unittest.TestCase):
                                    signal_freq*np.ones(len(peak_freqs)),
                                    rtol=0.05)
 
-    @pytest.mark.skipif(np.__version__ in ['1.25.0', '1.25.1'],
+    @pytest.mark.skipif(np.__version__ in ['1.25.0', '1.25.1', '1.25.2'],
                         reason="This test will fail with numpy version"
-                               "1.25.0, 1.25.1 see issue #24000"
+                               "1.25.0 - 1.25.2,  see issue #24000"
                                "https://github.com/numpy/numpy/issues/24000 ")
     def test_multitaper_cohere_perfect_cohere(self):
         # Generate dummy data


### PR DESCRIPTION
Added `numpy == 1.25.2` to the following code snippet, since the related numpy issue was not fixed with the latest release.

https://github.com/NeuralEnsemble/elephant/blob/2bd871aec145d897031aed327a7a4af0102c47cb/elephant/test/test_spectral.py#L957-L960