### PR TITLE
Fix/dither spike train with numpy>1.23.0

### DIFF
--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -37,7 +37,7 @@ from __future__ import division, print_function, unicode_literals
 import random
 import warnings
 import copy
-from typing import Union, Optional
+from typing import Union, Optional, List
 
 import neo
 import numpy as np
@@ -148,7 +148,7 @@ def dither_spikes(spiketrain: neo.SpikeTrain,
                   decimals: Optional[int] = None,
                   edges: Optional[bool] = True,
                   refractory_period: Optional[Union[pq.Quantity, None]] = None
-                  ) -> list[neo.SpikeTrain]:
+                  ) -> List[neo.SpikeTrain]:
     """
     Generates surrogates of a spike train by spike dithering.
 

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -241,7 +241,7 @@ def dither_spikes(spiketrain: neo.SpikeTrain,
     # Round the surrogate data to decimal position, if requested
     if decimals:
         return [neo.SpikeTrain(
-                train * units.rescale(pq.ms).round(decimals).rescale(units),
+                (train * units).rescale(pq.ms).round(decimals).rescale(units),
                 t_start=spiketrain.t_start, t_stop=spiketrain.t_stop,
                 sampling_rate=spiketrain.sampling_rate)
                 for train in dithered_spiketrains]

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -166,7 +166,7 @@ def dither_spikes(spiketrain: neo.SpikeTrain,
 
     Returns
     -------
-    list of neo.SpikeTrain
+    list of :class:`neo.core.SpikeTrain`
         Each surrogate spike train obtained independently of `spiketrain` by
         randomly dithering its spikes. The range of the surrogate spike trains
         is the same as of `spiketrain`.

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -393,7 +393,7 @@ def dither_spike_train(spiketrain, shift, n_surrogates=1, decimals=None,
 
     Parameters
     ----------
-    spiketrain : neo.SpikeTrain
+    spiketrain : :class:`neo.core.SpikeTrain`
         The spike train from which to generate the surrogates.
     shift : pq.Quantity
         Amount of shift. `spiketrain` is shifted by a random amount uniformly
@@ -413,8 +413,8 @@ def dither_spike_train(spiketrain, shift, n_surrogates=1, decimals=None,
 
     Returns
     -------
-    list of neo.SpikeTrain
-        Each surrogate spike train obtained independently from `spiketrain` by
+    list of :class:`neo.core.SpikeTrain`
+        Each surrogate spike train obtained independently of `spiketrain` by
         randomly dithering the whole spike train. The time range of the
         surrogate spike trains is the same as in `spiketrain`.
 

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -114,8 +114,13 @@ def _dither_spikes_with_refractory_period(spiketrain, dither, n_surrogates,
 
 
 @deprecated_alias(n='n_surrogates')
-def dither_spikes(spiketrain, dither, n_surrogates=1, decimals=None,
-                  edges=True, refractory_period=None):
+def dither_spikes(spiketrain: neo.SpikeTrain,
+                  dither: pq.Quantity,
+                  n_surrogates: int = 1,
+                  decimals: int = None,
+                  edges: bool = True,
+                  refractory_period: pq.Quantity = None
+                  ) -> list[neo.SpikeTrain]:
     """
     Generates surrogates of a spike train by spike dithering.
 

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -37,6 +37,7 @@ from __future__ import division, print_function, unicode_literals
 import random
 import warnings
 import copy
+from typing import Union, Optional
 
 import neo
 import numpy as np
@@ -116,10 +117,10 @@ def _dither_spikes_with_refractory_period(spiketrain, dither, n_surrogates,
 @deprecated_alias(n='n_surrogates')
 def dither_spikes(spiketrain: neo.SpikeTrain,
                   dither: pq.Quantity,
-                  n_surrogates: int = 1,
-                  decimals: int = None,
-                  edges: bool = True,
-                  refractory_period: pq.Quantity = None
+                  n_surrogates: Optional[int] = 1,
+                  decimals: Optional[int] = None,
+                  edges: Optional[bool] = True,
+                  refractory_period: Optional[Union[pq.Quantity, None]] = None
                   ) -> list[neo.SpikeTrain]:
     """
     Generates surrogates of a spike train by spike dithering.
@@ -199,7 +200,7 @@ def dither_spikes(spiketrain: neo.SpikeTrain,
     t_start = spiketrain.t_start.rescale(units).magnitude
     t_stop = spiketrain.t_stop.rescale(units).magnitude
 
-    if refractory_period is None or refractory_period == 0:
+    if not refractory_period:
         # Main: generate the surrogates
         dither = dither.rescale(units).magnitude
         dithered_spiketrains = \

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -129,7 +129,7 @@ def dither_spikes(spiketrain, dither, n_surrogates=1, decimals=None,
 
     Parameters
     ----------
-    spiketrain : neo.SpikeTrain
+    spiketrain : :class:`neo.core.SpikeTrain`
         The spike train from which to generate the surrogates.
     dither : pq.Quantity
         Amount of dithering. A spike at time `t` is placed randomly within
@@ -162,7 +162,7 @@ def dither_spikes(spiketrain, dither, n_surrogates=1, decimals=None,
     Returns
     -------
     list of neo.SpikeTrain
-        Each surrogate spike train obtained independently from `spiketrain` by
+        Each surrogate spike train obtained independently of `spiketrain` by
         randomly dithering its spikes. The range of the surrogate spike trains
         is the same as of `spiketrain`.
 

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -67,8 +67,11 @@ SURR_METHODS = ('dither_spike_train', 'dither_spikes', 'jitter_spikes',
                 'bin_shuffling', 'isi_dithering')
 
 
-def _dither_spikes_with_refractory_period(spiketrain, dither, n_surrogates,
-                                          refractory_period):
+def _dither_spikes_with_refractory_period(spiketrain: neo.SpikeTrain,
+                                          dither: pq.Quantity,
+                                          n_surrogates: int,
+                                          refractory_period: pq.Quantity
+                                          ) -> pq.Quantity:
     units = spiketrain.units
     t_start = spiketrain.t_start.rescale(units).magnitude
     t_stop = spiketrain.t_stop.rescale(units).magnitude

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -127,8 +127,7 @@ def _dither_spikes(spiketrain: neo.SpikeTrain, dither: float,
     dithered_spiketrains.sort(axis=1)
 
     if edges:
-        # Leave out all spikes outside
-        # [spiketrain.t_start, spiketrain.t_stop]
+        # Leave out all spikes outside [spiketrain.t_start, spiketrain.t_stop]
         dithered_spiketrains = [
             train[np.all([t_start < train, train < t_stop], axis=0)]
             for train in dithered_spiketrains]

--- a/elephant/test/test_spike_train_surrogates.py
+++ b/elephant/test/test_spike_train_surrogates.py
@@ -24,25 +24,27 @@ class SurrogatesTestCase(unittest.TestCase):
         np.random.seed(0)
         random.seed(0)
 
-    def test_dither_spikes_output_format(self):
+    @classmethod
+    def setUpClass(cls) -> None:
+        st1 = neo.SpikeTrain([90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
+        cls.st1 = st1
 
-        spiketrain = neo.SpikeTrain([90, 93, 97, 100, 105,
-                                     150, 180, 350] * pq.ms, t_stop=.5 * pq.s)
-        spiketrain.t_stop = .5 * pq.s
+    def test_dither_spikes_output_format(self):
+        self.st1.t_stop = .5 * pq.s
         n_surrogates = 2
         dither = 10 * pq.ms
         surrogate_trains = surr.dither_spikes(
-            spiketrain, dither=dither, n_surrogates=n_surrogates)
+            self.st1, dither=dither, n_surrogates=n_surrogates)
 
         self.assertIsInstance(surrogate_trains, list)
         self.assertEqual(len(surrogate_trains), n_surrogates)
 
         self.assertIsInstance(surrogate_trains[0], neo.SpikeTrain)
         for surrogate_train in surrogate_trains:
-            self.assertEqual(surrogate_train.units, spiketrain.units)
-            self.assertEqual(surrogate_train.t_start, spiketrain.t_start)
-            self.assertEqual(surrogate_train.t_stop, spiketrain.t_stop)
-            self.assertEqual(len(surrogate_train), len(spiketrain))
+            self.assertEqual(surrogate_train.units, self.st1.units)
+            self.assertEqual(surrogate_train.t_start, self.st1.t_start)
+            self.assertEqual(surrogate_train.t_stop, self.st1.t_stop)
+            self.assertEqual(len(surrogate_train), len(self.st1))
             assert_array_less(0., np.diff(surrogate_train))  # check ordering
 
     def test_dither_spikes_empty_train(self):
@@ -54,18 +56,32 @@ class SurrogatesTestCase(unittest.TestCase):
             st, dither=dither, n_surrogates=1)[0]
         self.assertEqual(len(surrogate_train), 0)
 
+    def test_dither_spikes_refactory_period_zero_or_none(self):
+        dither = 10 * pq.ms
+        decimals = 3
+        n_surrogates = 1
+
+        np.random.seed(42)
+        surrogate_trains_zero = surr.dither_spikes(
+            self.st1, dither, decimals=decimals, n_surrogates=n_surrogates,
+            refractory_period=0)
+        np.random.seed(42)
+        surrogate_trains_none = surr.dither_spikes(
+            self.st1, dither, decimals=decimals, n_surrogates=n_surrogates,
+            refractory_period=None)
+        np.testing.assert_array_almost_equal(
+            surrogate_trains_zero[0].magnitude,
+            surrogate_trains_none[0].magnitude)
+
     def test_dither_spikes_output_decimals(self):
-
-        st = neo.SpikeTrain([90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         n_surrogates = 2
         dither = 10 * pq.ms
         np.random.seed(42)
         surrogate_trains = surr.dither_spikes(
-            st, dither=dither, decimals=3, n_surrogates=n_surrogates)
+            self.st1, dither=dither, decimals=3, n_surrogates=n_surrogates)
 
         np.random.seed(42)
-        dither_values = np.random.random_sample((n_surrogates, len(st)))
+        dither_values = np.random.random_sample((n_surrogates, len(self.st1)))
         expected_non_dithered = np.sum(dither_values == 0)
 
         observed_non_dithered = 0
@@ -78,17 +94,14 @@ class SurrogatesTestCase(unittest.TestCase):
         self.assertEqual(observed_non_dithered, expected_non_dithered)
 
     def test_dither_spikes_false_edges(self):
-
-        st = neo.SpikeTrain([90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         n_surrogates = 2
         dither = 10 * pq.ms
         surrogate_trains = surr.dither_spikes(
-            st, dither=dither, n_surrogates=n_surrogates, edges=False)
+            self.st1, dither=dither, n_surrogates=n_surrogates, edges=False)
 
         for surrogate_train in surrogate_trains:
             for i in range(len(surrogate_train)):
-                self.assertLessEqual(surrogate_train[i], st.t_stop)
+                self.assertLessEqual(surrogate_train[i], self.st1.t_stop)
 
     def test_dither_spikes_with_refractory_period_output_format(self):
 
@@ -132,23 +145,19 @@ class SurrogatesTestCase(unittest.TestCase):
         self.assertEqual(len(surrogate_train), 0)
 
     def test_randomise_spikes_output_format(self):
-
-        spiketrain = neo.SpikeTrain(
-            [90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         n_surrogates = 2
         surrogate_trains = surr.randomise_spikes(
-            spiketrain, n_surrogates=n_surrogates)
+            self.st1, n_surrogates=n_surrogates)
 
         self.assertIsInstance(surrogate_trains, list)
         self.assertEqual(len(surrogate_trains), n_surrogates)
 
         self.assertIsInstance(surrogate_trains[0], neo.SpikeTrain)
         for surrogate_train in surrogate_trains:
-            self.assertEqual(surrogate_train.units, spiketrain.units)
-            self.assertEqual(surrogate_train.t_start, spiketrain.t_start)
-            self.assertEqual(surrogate_train.t_stop, spiketrain.t_stop)
-            self.assertEqual(len(surrogate_train), len(spiketrain))
+            self.assertEqual(surrogate_train.units, self.st1.units)
+            self.assertEqual(surrogate_train.t_start, self.st1.t_start)
+            self.assertEqual(surrogate_train.t_stop, self.st1.t_stop)
+            self.assertEqual(len(surrogate_train), len(self.st1))
 
     def test_randomise_spikes_empty_train(self):
 
@@ -158,12 +167,9 @@ class SurrogatesTestCase(unittest.TestCase):
         self.assertEqual(len(surrogate_train), 0)
 
     def test_randomise_spikes_output_decimals(self):
-        spiketrain = neo.SpikeTrain(
-            [90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         n_surrogates = 2
         surrogate_trains = surr.randomise_spikes(
-            spiketrain, n_surrogates=n_surrogates, decimals=3)
+            self.st1, n_surrogates=n_surrogates, decimals=3)
 
         for surrogate_train in surrogate_trains:
             for i in range(len(surrogate_train)):
@@ -173,23 +179,19 @@ class SurrogatesTestCase(unittest.TestCase):
                                     surrogate_train[i])
 
     def test_shuffle_isis_output_format(self):
-
-        spiketrain = neo.SpikeTrain(
-            [90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         n_surrogates = 2
         surrogate_trains = surr.shuffle_isis(
-            spiketrain, n_surrogates=n_surrogates)
+            self.st1, n_surrogates=n_surrogates)
 
         self.assertIsInstance(surrogate_trains, list)
         self.assertEqual(len(surrogate_trains), n_surrogates)
 
         self.assertIsInstance(surrogate_trains[0], neo.SpikeTrain)
         for surrogate_train in surrogate_trains:
-            self.assertEqual(surrogate_train.units, spiketrain.units)
-            self.assertEqual(surrogate_train.t_start, spiketrain.t_start)
-            self.assertEqual(surrogate_train.t_stop, spiketrain.t_stop)
-            self.assertEqual(len(surrogate_train), len(spiketrain))
+            self.assertEqual(surrogate_train.units, self.st1.units)
+            self.assertEqual(surrogate_train.t_start, self.st1.t_start)
+            self.assertEqual(surrogate_train.t_stop, self.st1.t_stop)
+            self.assertEqual(len(surrogate_train), len(self.st1))
 
     def test_shuffle_isis_empty_train(self):
 
@@ -199,16 +201,12 @@ class SurrogatesTestCase(unittest.TestCase):
         self.assertEqual(len(surrogate_train), 0)
 
     def test_shuffle_isis_same_isis(self):
+        surrogate_train = surr.shuffle_isis(self.st1, n_surrogates=1)[0]
 
-        spiketrain = neo.SpikeTrain(
-            [90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
-        surrogate_train = surr.shuffle_isis(spiketrain, n_surrogates=1)[0]
-
-        st_pq = spiketrain.view(pq.Quantity)
+        st_pq = self.st1.view(pq.Quantity)
         surr_pq = surrogate_train.view(pq.Quantity)
 
-        isi0_orig = spiketrain[0] - spiketrain.t_start
+        isi0_orig = self.st1[0] - self.st1.t_start
         ISIs_orig = np.sort([isi0_orig] + [isi for isi in np.diff(st_pq)])
 
         isi0_surr = surrogate_train[0] - surrogate_train.t_start
@@ -217,17 +215,13 @@ class SurrogatesTestCase(unittest.TestCase):
         self.assertTrue(np.all(ISIs_orig == ISIs_surr))
 
     def test_shuffle_isis_output_decimals(self):
-
-        spiketrain = neo.SpikeTrain(
-            [90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         surrogate_train = surr.shuffle_isis(
-            spiketrain, n_surrogates=1, decimals=95)[0]
+            self.st1, n_surrogates=1, decimals=95)[0]
 
-        st_pq = spiketrain.view(pq.Quantity)
+        st_pq = self.st1.view(pq.Quantity)
         surr_pq = surrogate_train.view(pq.Quantity)
 
-        isi0_orig = spiketrain[0] - spiketrain.t_start
+        isi0_orig = self.st1[0] - self.st1.t_start
         ISIs_orig = np.sort([isi0_orig] + [isi for isi in np.diff(st_pq)])
 
         isi0_surr = surrogate_train[0] - surrogate_train.t_start
@@ -254,24 +248,20 @@ class SurrogatesTestCase(unittest.TestCase):
                         dt=dither)
 
     def test_dither_spike_train_output_format(self):
-
-        spiketrain = neo.SpikeTrain(
-            [90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         n_surrogates = 2
         shift = 10 * pq.ms
         surrogate_trains = surr.dither_spike_train(
-            spiketrain, shift=shift, n_surrogates=n_surrogates)
+            self.st1, shift=shift, n_surrogates=n_surrogates)
 
         self.assertIsInstance(surrogate_trains, list)
         self.assertEqual(len(surrogate_trains), n_surrogates)
 
         self.assertIsInstance(surrogate_trains[0], neo.SpikeTrain)
         for surrogate_train in surrogate_trains:
-            self.assertEqual(surrogate_train.units, spiketrain.units)
-            self.assertEqual(surrogate_train.t_start, spiketrain.t_start)
-            self.assertEqual(surrogate_train.t_stop, spiketrain.t_stop)
-            self.assertEqual(len(surrogate_train), len(spiketrain))
+            self.assertEqual(surrogate_train.units, self.st1.units)
+            self.assertEqual(surrogate_train.t_start, self.st1.t_start)
+            self.assertEqual(surrogate_train.t_stop, self.st1.t_stop)
+            self.assertEqual(len(surrogate_train), len(self.st1))
 
     def test_dither_spike_train_empty_train(self):
 
@@ -283,12 +273,10 @@ class SurrogatesTestCase(unittest.TestCase):
         self.assertEqual(len(surrogate_train), 0)
 
     def test_dither_spike_train_output_decimals(self):
-        st = neo.SpikeTrain([90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         n_surrogates = 2
         shift = 10 * pq.ms
         surrogate_trains = surr.dither_spike_train(
-            st, shift=shift, n_surrogates=n_surrogates, decimals=3)
+            self.st1, shift=shift, n_surrogates=n_surrogates, decimals=3)
 
         for surrogate_train in surrogate_trains:
             for i in range(len(surrogate_train)):
@@ -298,38 +286,30 @@ class SurrogatesTestCase(unittest.TestCase):
                                     surrogate_train[i])
 
     def test_dither_spike_train_false_edges(self):
-
-        spiketrain = neo.SpikeTrain(
-            [90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         n_surrogates = 2
         shift = 10 * pq.ms
         surrogate_trains = surr.dither_spike_train(
-            spiketrain, shift=shift, n_surrogates=n_surrogates, edges=False)
+            self.st1, shift=shift, n_surrogates=n_surrogates, edges=False)
 
         for surrogate_train in surrogate_trains:
             for i in range(len(surrogate_train)):
-                self.assertLessEqual(surrogate_train[i], spiketrain.t_stop)
+                self.assertLessEqual(surrogate_train[i], self.st1.t_stop)
 
     def test_jitter_spikes_output_format(self):
-
-        spiketrain = neo.SpikeTrain(
-            [90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         n_surrogates = 2
         bin_size = 100 * pq.ms
         surrogate_trains = surr.jitter_spikes(
-            spiketrain, bin_size=bin_size, n_surrogates=n_surrogates)
+            self.st1, bin_size=bin_size, n_surrogates=n_surrogates)
 
         self.assertIsInstance(surrogate_trains, list)
         self.assertEqual(len(surrogate_trains), n_surrogates)
 
         self.assertIsInstance(surrogate_trains[0], neo.SpikeTrain)
         for surrogate_train in surrogate_trains:
-            self.assertEqual(surrogate_train.units, spiketrain.units)
-            self.assertEqual(surrogate_train.t_start, spiketrain.t_start)
-            self.assertEqual(surrogate_train.t_stop, spiketrain.t_stop)
-            self.assertEqual(len(surrogate_train), len(spiketrain))
+            self.assertEqual(surrogate_train.units, self.st1.units)
+            self.assertEqual(surrogate_train.t_start, self.st1.t_start)
+            self.assertEqual(surrogate_train.t_stop, self.st1.t_stop)
+            self.assertEqual(len(surrogate_train), len(self.st1))
 
     def test_jitter_spikes_empty_train(self):
 
@@ -341,16 +321,12 @@ class SurrogatesTestCase(unittest.TestCase):
         self.assertEqual(len(surrogate_train), 0)
 
     def test_jitter_spikes_same_bins(self):
-
-        spiketrain = neo.SpikeTrain(
-            [90, 150, 180, 350] * pq.ms, t_stop=500 * pq.ms)
-
         bin_size = 100 * pq.ms
         surrogate_train = surr.jitter_spikes(
-            spiketrain, bin_size=bin_size, n_surrogates=1)[0]
+            self.st1, bin_size=bin_size, n_surrogates=1)[0]
 
         bin_ids_orig = np.array(
-            (spiketrain.view(
+            (self.st1.view(
                 pq.Quantity) /
              bin_size).rescale(
                 pq.dimensionless).magnitude,
@@ -365,7 +341,7 @@ class SurrogatesTestCase(unittest.TestCase):
 
         # Bug encountered when the original and surrogate trains have
         # different number of spikes
-        self.assertEqual(len(spiketrain), len(surrogate_train))
+        self.assertEqual(len(self.st1), len(surrogate_train))
 
     def test_jitter_spikes_unequal_bin_size(self):
 


### PR DESCRIPTION
This PR addresses issue #586 .

### Changes
- refactor unit tests using `setUpClass`
- add regression test for issue #586 
- refactoring `dither_spikes` function
- updated docstrings
- added typehints

### Notes
- option `edges` has no effect if `refractory_period` is of type `pq.Quantity `
- no default value for `dither`, e.g. use `0 * pq.s` and just return copies of the input spiketrain ? similar to the behavior of passing an empty spiketrain as input ?
