### PR TITLE
[Fix] z score inplace

### DIFF
--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -167,7 +167,7 @@ def zscore(signal, inplace=True):
     for sig in signal:
         # Perform inplace operation only if array is of dtype float.
         # Otherwise, raise an error.
-        if inplace and not np.issubdtype(float, sig.dtype):
+        if inplace and not np.issubdtype(sig.dtype, np.floating):
             raise ValueError(f"Cannot perform inplace operation as the "
                              f"signal dtype is not float. Source: {sig.name}")
 

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -415,7 +415,7 @@ class ZscoreTestCase(unittest.TestCase):
         """
         Regression test: Inplace operations for z_score failed when using
         np.float32 or np.float64 types.
-        See Issue #591
+        See Issue #591.
         https://github.com/NeuralEnsemble/elephant/issues/591
         """
         test_types = (np.float32, np.float64)

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -401,7 +401,7 @@ class ZscoreTestCase(unittest.TestCase):
         self.assertIs(result[0], signal_list[0])
         self.assertIs(result[1], signal_list[1])
 
-    def test_wrong_input(self):
+    def test_z_score_wrong_input(self):
         # wrong type
         self.assertRaises(TypeError, elephant.signal_processing.zscore,
                           signal=[1, 2] * pq.uV)
@@ -410,6 +410,23 @@ class ZscoreTestCase(unittest.TestCase):
         asig2 = neo.AnalogSignal([0, 1], units=pq.V, sampling_rate=1 * pq.ms)
         self.assertRaises(ValueError, elephant.signal_processing.zscore,
                           signal=[asig1, asig2])
+
+    def test_z_score_np_float32_64(self):
+        """
+        Regression test: Inplace operations for z_score failed when using
+        np.float32 or np.float64 types.
+        See Issue #591
+        https://github.com/NeuralEnsemble/elephant/issues/591
+        """
+        test_types = (np.float32, np.float64)
+        for test_type in test_types:
+            with self.subTest(test_type):
+                signal = neo.AnalogSignal(self.test_seq1, units='mV',
+                                          t_start=0. * pq.ms,
+                                          sampling_rate=1000. * pq.Hz,
+                                          dtype=test_type)
+                # This should not raise a ValueError
+                elephant.signal_processing.zscore(signal, inplace=True)
 
 
 class ButterTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR closes #591 .

## Changes:

The check for the signal type when using z_score inplace was changed from:
```python
 if inplace and not np.issubdtype(float, sig.dtype): 
```

to:
```python 
if inplace and not np.issubdtype(sig.dtype, np.floating):
```

Additionally a regression unittest was added.

This was originally discovered in the `Elephant_Tutorial_-_LFP_analysis.ipynb` notebook, see also https://tutorials.python-elephant.org .