### PR TITLE
[Fix] Inactive links in asset docs

### DIFF
--- a/elephant/asset/asset.py
+++ b/elephant/asset/asset.py
@@ -9,6 +9,7 @@ ASSET analysis class object of finding patterns
 
 .. autosummary::
     :toctree: _toctree/asset/
+    :template: class.rst
 
     ASSET
 

--- a/elephant/asset/asset.py
+++ b/elephant/asset/asset.py
@@ -2041,6 +2041,8 @@ class ASSET(object):
 
     def is_symmetric(self):
         """
+        Checks if intersection matrix is symmetric or not.
+
         Returns
         -------
         bool


### PR DESCRIPTION
This PR closes #584 .

### Changes
- use the `class.rst` template to generate the documentation for ASSET class.

See docs build: https://elephant--593.org.readthedocs.build/en/593/reference/_toctree/asset/elephant.asset.asset.ASSET.html#elephant.asset.asset.ASSET