### PR TITLE
[Enh] add example and handle one-dimensional arrays in CSD.generate lfp

### DIFF
--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -79,8 +79,8 @@ def estimate_csd(lfp, coordinates='coordinates', method=None,
         with dimension of space, where M is the number of signals in 'lfp',
         and N is equal to the dimensionality of the method.
         Alternatively, if coordinates is a string, the function will fetch the
-        coordinates, supplied in the same format, as annotation of 'lfp' by that
-        name.
+        coordinates, supplied in the same format, as annotation of 'lfp' by
+        that name.
         Default: 'coordinates'
     method : string
         Pick a method corresponding to the setup, in this implementation
@@ -253,10 +253,32 @@ def generate_lfp(csd_profile, x_positions, y_positions=None, z_positions=None,
 
     Returns
     -------
-    LFP : neo.AnalogSignal
+    LFP : :class:`neo.core.AnalogSignal`
        The potentials created by the csd profile at the electrode positions.
        The electrode positions are attached as an annotation named
        'coordinates'.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from elephant.current_source_density import generate_lfp, estimate_csd
+    >>> from elephant.current_source_density_src.utility_functions import gauss_1d_dipole  # noqa
+    >>> # 1. Define an array xs to x coordinate values with a length of 2304
+    >>> xs=np.linspace(0, 10, 2304).reshape(2304,1)
+
+    >>> # 2. Run generate_lfp(gauss_1d_dipole, xs)
+    >>> lfp = generate_lfp(gauss_1d_dipole, xs)
+
+    >>> # 3. Run estimate_csd(lfp, method="StandardCSD")
+    >>> csd = estimate_csd(lfp, method="StandardCSD")  #doctest: +ELLIPSIS
+    discrete ...
+    >>> # 4. Print the results
+    >>> print(f"LFPs: {lfp}")
+    LFPs: [[-0.01483716 -0.01483396 -0.01483075 ...  0.01219233  0.0121911
+       0.01218986]] mV
+    >>> print(f"CSD estimate: {csd}")
+    CSD estimate: [[-1.00025592e-04 -6.06684588e-05  2.30042086e-10 ... -4.07008302e-09
+      -2.33715292e-05 -3.85293808e-05]] A/m**2
     """
 
     def integrate_1D(x0, csd_x, csd, h):

--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -264,7 +264,7 @@ def generate_lfp(csd_profile, x_positions, y_positions=None, z_positions=None,
     >>> from elephant.current_source_density import generate_lfp, estimate_csd
     >>> from elephant.current_source_density_src.utility_functions import gauss_1d_dipole  # noqa
     >>> # 1. Define an array xs to x coordinate values with a length of 2304
-    >>> xs=np.linspace(0, 10, 2304).reshape(2304,1)
+    >>> xs=np.linspace(0, 10, 2304)
 
     >>> # 2. Run generate_lfp(gauss_1d_dipole, xs)
     >>> lfp = generate_lfp(gauss_1d_dipole, xs)
@@ -319,6 +319,10 @@ def generate_lfp(csd_profile, x_positions, y_positions=None, z_positions=None,
     sigma = 1.0
     h = 50.
     if dim == 1:
+        # Handle 1 dimensional case,
+        # see https://github.com/NeuralEnsemble/elephant/issues/546
+        if len(x_positions.shape) == 1:
+            x_positions = np.expand_dims(x_positions, axis=1)
         chrg_x = x
         csd = csd_profile(chrg_x)
         pots = integrate_1D(x_positions, chrg_x, csd, h)

--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -182,14 +182,14 @@ def estimate_csd(lfp, coordinates='coordinates', method=None,
                 # All iCSD methods explicitly assume a source
                 # diameter in contrast to the stdCSD  that
                 # implicitly assume infinite source radius
-                raise ValueError("Parameter diam must be specified for iCSD \
-                                  methods: {}".format(", ".join(icsd_methods)))
+                raise ValueError(f"Parameter diam must be specified for iCSD "
+                                 f"methods: {', '.join(icsd_methods)}")
 
         if 'f_type' in kwargs:
             if (kwargs['f_type'] != 'identity') and  \
                (kwargs['f_order'] is None):
-                raise ValueError("The order of {} filter must be \
-                                  specified".format(kwargs['f_type']))
+                raise ValueError(f"The order of {kwargs['f_type']} filter must"
+                                 f" be specified")
 
         csd_method = getattr(icsd, method)  # fetch class from icsd.py file
         csd_estimator = csd_method(lfp=lfp.T.magnitude * lfp.units,

--- a/elephant/test/test_current_source_density.py
+++ b/elephant/test/test_current_source_density.py
@@ -15,6 +15,7 @@ import numpy as np
 import quantities as pq
 from elephant import current_source_density as csd
 import elephant.current_source_density_src.utility_functions as utils
+from elephant.current_source_density import generate_lfp
 
 available_1d = ['StandardCSD', 'DeltaiCSD', 'StepiCSD', 'SplineiCSD', 'KCSD1D']
 available_2d = ['KCSD2D', 'MoIKCSD']
@@ -151,6 +152,30 @@ class CSD3D_TestCase(unittest.TestCase):
         self.assertEqual(result.t_start, 0.0 * pq.s)
         self.assertEqual(result.sampling_rate, 1000 * pq.Hz)
         self.assertEqual(len(result.times), 1)
+
+
+class GenerateLfpTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.one_dimensional = np.linspace(0, 10, 2304)
+        cls.two_dimensional = np.linspace(0, 10, 2304
+                                          ).reshape(2304, 1)
+
+    def test_generate_lfp_one_dimensional_array(self):
+        """
+        Regression test for Issue #546,
+        see: https://github.com/NeuralEnsemble/elephant/issues/546
+        """
+        # this should raise an error
+        generate_lfp(utils.gauss_1d_dipole, self.one_dimensional)
+
+    def test_generate_lfp_two_dimensional_array(self):
+        """
+        Regression test for Issue #546,
+        see: https://github.com/NeuralEnsemble/elephant/issues/546
+        """
+        # this should raise an error
+        generate_lfp(utils.gauss_1d_dipole, self.two_dimensional)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR closes #546 .

### Changes
- add example to doc-string
- handle one-dimensional arrays as input for `x_positions`
- add regression unit-tests