### PR TITLE
[Fix] skip multitaper unittest for new numpy version 1.26.0

### DIFF
--- a/elephant/test/test_spectral.py
+++ b/elephant/test/test_spectral.py
@@ -17,6 +17,7 @@ import scipy.fft
 import scipy.signal as spsig
 from neo import AnalogSignal
 from numpy.testing import assert_array_equal
+from packaging import version
 
 import elephant.spectral
 from elephant.datasets import download_datasets, ELEPHANT_TMP_DIR
@@ -954,7 +955,7 @@ class MultitaperCoherenceTestCase(unittest.TestCase):
                                    signal_freq*np.ones(len(peak_freqs)),
                                    rtol=0.05)
 
-    @pytest.mark.skipif(np.__version__ in ['1.25.0', '1.25.1', '1.25.2'],
+    @pytest.mark.skipif(version.parse(np.__version__)>version.parse("1.25.0"),
                         reason="This test will fail with numpy version"
                                "1.25.0 - 1.25.2,  see issue #24000"
                                "https://github.com/numpy/numpy/issues/24000 ")


### PR DESCRIPTION
This PR is in Line with e.g. PR #588 .

Skipping unittest for multitaper perfect cohere as the underlying issue was not resolved with release of numpy 1.26.0.