### PR TITLE
[ENH] CI: Cancel previous workflows on the same pull request

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,11 @@ on:
     branches:
       - master
 
+# Cancel previous workflows on the same pull request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # jobs define the steps that will be executed on the runner
 jobs:
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# jobs define the steps that will be executed on the runner
+# Jobs define the steps that will be executed on the runner
 jobs:
 
   #        _

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@
 # On a pull requests and on pushes to master it will run different tests for elephant.
 
 name: tests
-# define events that trigger workflow 'tests'
+# Define events that trigger workflow 'tests'
 on:
   workflow_dispatch: # enables manual triggering of workflow
     inputs:


### PR DESCRIPTION
This pull request introduces an enhancement to our GitHub Actions workflow. 

The added lines in the GitHub Actions YAML file enable the cancellation of previous workflows associated with the same pull request.

```
# Cancel previous workflows on the same pull request
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

With these changes, we ensure that only the latest workflow for a given pull request will be executed, enhancing efficiency. This adjustment is particularly beneficial in scenarios where multiple workflows for the same pull request may overlap.