### PR TITLE
[Fix] Update links in codemeta.json for  v1.0.0

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
     "dateCreated": "2013-17-15",
     "datePublished": "2015-04-08",
     "dateModified": "2023-11-10",
-    "downloadUrl": "https://files.pythonhosted.org/packages/aa/e5/a42131ffa1de8e379ba56d67c85824d2471e6fbedcf710283f589c0dd4a4/elephant-0.13.0.tar.gz",
+    "downloadUrl": "https://files.pythonhosted.org/packages/cb/b5/893fadd5505e638a4c8788bf0a2f5a211f59f45203f3dfa3919469e83ed4/elephant-1.0.0.tar.gz",
     "issueTracker": "https://github.com/NeuralEnsemble/elephant/issues",
     "name": "Elephant",
     "version": "1.0.0",

--- a/codemeta.json
+++ b/codemeta.json
@@ -34,7 +34,7 @@
         "MacOS"
     ],
     "softwareRequirements": [
-        "https://github.com/NeuralEnsemble/elephant/tree/v0.14.0/requirements"
+        "https://github.com/NeuralEnsemble/elephant/tree/v1.0.0/requirements"
     ],
     "relatedLink": [
         "http://python-elephant.org",


### PR DESCRIPTION
This PR updates the downloadURL field in the `codemeta.json` to the current version 1.0.0 .