### PR TITLE
[ENH] add CITATIO.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,40 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Elephant
+message: Please cite this software using these metadata.
+type: software
+authors:
+  - given-names: Michael
+    family-names: Denker
+    affiliation: >-
+      Institute of Neuroscience and Medicine (INM-6) and
+      Institute for Advanced Simulation (IAS-6) and
+      JARA-Institute Brain Structure-Function Relationships
+      (INM-10), Jülich Research Centre, Jülich, Germany
+    orcid: 'https://orcid.org/0000-0003-1255-7300'
+  - given-names: Moritz
+    family-names: Kern
+    affiliation: >-
+      Institute of Neuroscience and Medicine (INM-6) and
+      Institute for Advanced Simulation (IAS-6) and
+      JARA-Institute Brain Structure-Function Relationships
+      (INM-10), Jülich Research Centre, Jülich, Germany
+    orcid: 'https://orcid.org/0000-0001-7292-1982'
+identifiers:
+  - type: doi
+    value: 10.12751/incf.ni2018.0019
+    description: Concept of publication
+repository-code: 'https://github.com/NeuralEnsemble/elephant'
+url: 'http://python-elephant.org'
+keywords:
+  - neuroscience
+  - neurophysiology
+  - electrophysiology
+  - statistics
+  - data-analysis
+license: BSD-3-Clause
+commit: 77274f6
+version: 1.0.0
+date-released: '2023-11-10'


### PR DESCRIPTION
A `citation.cff` file contains metadata about a software project. It can be used to generate citations for Elephant and link it to other sources of information, such as repositories, archives, or DOI services. 

The `citation.cff` file can eventually replace the `.zenodo.json` file, which is currently used to provide metadata for Zenodo.

More information on the citation file format can be found here: https://citation-file-format.github.io/.

One of the current open issues with the citation.cff file is that it does not support specifying grants the project. This is a feature that is available in the `.zenodo.json` file and that is useful for acknowledging the financial support of the project. A related issue has been opened on the CFF GitHub repository: https://github.com/citation-file-format/citation-file-format/issues/491
