### PR TITLE
[MAIN] add Python 3.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,8 +57,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python versions for elephant: [3.8, 3.9, "3.10", 3.11]
-        python-version: [3.8, 3.9, "3.10", 3.11]
+        # python versions for elephant: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12]
         # OS [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
       # do not cancel all in-progress jobs if any matrix job fails

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.13.1
+          python -m pip install cibuildwheel==2.16.2
 
       - name: Install libomp
         if: runner.os == 'macOS'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,10 +18,12 @@ jobs:
         os: [ubuntu-20.04, windows-2019]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10' 
 
       - name: Install cibuildwheel
         run: |

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,7 +14,7 @@ Below is the explanation of how to proceed with these two steps.
 Prerequisites
 *************
 
-Elephant requires `Python <http://python.org/>`_ 3.8, 3.9, 3.10 or 3.11.
+Elephant requires `Python <http://python.org/>`_ 3.8, 3.9, 3.10, 3.11 or 3.12.
 
 .. tabs::
 


### PR DESCRIPTION
This pull request introduces support for Python 3.12, which was  released as of October 2, 2023.

Python 3.12 release, see: <https://www.python.org/downloads/release/python-3120/>

# Changes
- add Python 3.12 to CI workflow. 
- update ci-buildwheels to create wheels for python 3.12