### PR TITLE
[Fix] expired scipy deprecations, sp.sqrt

### DIFF
--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -38,7 +38,7 @@ from __future__ import division, print_function, unicode_literals
 import neo
 import numpy as np
 import quantities as pq
-from scipy.integrate import simps
+from scipy.integrate import simpson
 
 import elephant.current_source_density_src.utility_functions as utils
 from elephant.current_source_density_src import KCSD, icsd
@@ -281,7 +281,7 @@ def generate_lfp(csd_profile, x_positions, y_positions=None, z_positions=None,
     def integrate_1D(x0, csd_x, csd, h):
         m = np.sqrt((csd_x - x0) ** 2 + h ** 2) - abs(csd_x - x0)
         y = csd * m
-        I = simps(y, csd_x)
+        I = simpson(y, csd_x)
         return I
 
     def integrate_2D(x, y, xlin, ylin, csd, h, X, Y):
@@ -293,17 +293,17 @@ def generate_lfp(csd_profile, x_positions, y_positions=None, z_positions=None,
         m = np.sqrt((x - X) ** 2 + (y - Y) ** 2)
         np.clip(m, a_min=0.0000001, a_max=None, out=m)
         y = np.arcsinh(2 * h / m) * csd
-        I = simps(y.T, ylin)
-        F = simps(I, xlin)
+        I = simpson(y.T, ylin)
+        F = simpson(I, xlin)
         return F
 
     def integrate_3D(x, y, z, csd, xlin, ylin, zlin, X, Y, Z):
         m = np.sqrt((x - X) ** 2 + (y - Y) ** 2 + (z - Z) ** 2)
         np.clip(m, a_min=0.0000001, a_max=None, out=m)
         z = csd / m
-        Iy = simps(np.transpose(z, (1, 0, 2)), zlin)
-        Iy = simps(Iy, ylin)
-        F = simps(Iy, xlin)
+        Iy = simpson(np.transpose(z, (1, 0, 2)), zlin)
+        Iy = simpson(Iy, ylin)
+        F = simpson(Iy, xlin)
         return F
 
     dim = 1

--- a/elephant/current_source_density.py
+++ b/elephant/current_source_density.py
@@ -281,7 +281,7 @@ def generate_lfp(csd_profile, x_positions, y_positions=None, z_positions=None,
     def integrate_1D(x0, csd_x, csd, h):
         m = np.sqrt((csd_x - x0) ** 2 + h ** 2) - abs(csd_x - x0)
         y = csd * m
-        I = simpson(y, csd_x)
+        I = simpson(y, x=csd_x)
         return I
 
     def integrate_2D(x, y, xlin, ylin, csd, h, X, Y):
@@ -293,17 +293,17 @@ def generate_lfp(csd_profile, x_positions, y_positions=None, z_positions=None,
         m = np.sqrt((x - X) ** 2 + (y - Y) ** 2)
         np.clip(m, a_min=0.0000001, a_max=None, out=m)
         y = np.arcsinh(2 * h / m) * csd
-        I = simpson(y.T, ylin)
-        F = simpson(I, xlin)
+        I = simpson(y.T, x=ylin)
+        F = simpson(I, x=xlin)
         return F
 
     def integrate_3D(x, y, z, csd, xlin, ylin, zlin, X, Y, Z):
         m = np.sqrt((x - X) ** 2 + (y - Y) ** 2 + (z - Z) ** 2)
         np.clip(m, a_min=0.0000001, a_max=None, out=m)
         z = csd / m
-        Iy = simpson(np.transpose(z, (1, 0, 2)), zlin)
-        Iy = simpson(Iy, ylin)
-        F = simpson(Iy, xlin)
+        Iy = simpson(np.transpose(z, (1, 0, 2)), x=zlin)
+        Iy = simpson(Iy, x=ylin)
+        F = simpson(Iy, x=xlin)
         return F
 
     dim = 1

--- a/elephant/current_source_density_src/icsd.py
+++ b/elephant/current_source_density_src/icsd.py
@@ -95,26 +95,26 @@ class CSD(object):
                 raise ae('filter order f_order must be a tuple of length 2')
         else:
             try:
-                assert(self.f_order > 0 and isinstance(self.f_order, int))
+                assert (self.f_order > 0 and isinstance(self.f_order, int))
             except AssertionError as ae:
                 raise ae('Filter order must be int > 0!')
         try:
-            assert(filterfunction in ['filtfilt', 'convolve'])
+            assert (filterfunction in ['filtfilt', 'convolve'])
         except AssertionError as ae:
             raise ae("{} not equal to 'filtfilt' or \
                      'convolve'".format(filterfunction))
 
         if self.f_type == 'boxcar':
-            num = ss.boxcar(self.f_order)
+            num = ss.windows.boxcar(self.f_order)
             denom = np.array([num.sum()])
         elif self.f_type == 'hamming':
-            num = ss.hamming(self.f_order)
+            num = ss.windows.hamming(self.f_order)
             denom = np.array([num.sum()])
         elif self.f_type == 'triangular':
-            num = ss.triang(self.f_order)
+            num = ss.windows.triang(self.f_order)
             denom = np.array([num.sum()])
         elif self.f_type == 'gaussian':
-            num = ss.gaussian(self.f_order[0], self.f_order[1])
+            num = ss.windows.gaussian(self.f_order[0], self.f_order[1])
             denom = np.array([num.sum()])
         elif self.f_type == 'identity':
             num = np.array([1.])

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -1073,5 +1073,5 @@ def spike_train_timescale(binned_spiketrain, max_tau):
 
     # Calculate the timescale using trapezoidal integration
     integr = (corrfct / corrfct[0]) ** 2
-    timescale = 2 * integrate.trapz(integr, dx=bin_size)
+    timescale = 2 * integrate.trapezoid(integr, dx=bin_size)
     return pq.Quantity(timescale, units=binned_spiketrain.units, copy=False)

--- a/elephant/spike_train_dissimilarity.py
+++ b/elephant/spike_train_dissimilarity.py
@@ -24,7 +24,6 @@ from __future__ import division, print_function, unicode_literals
 
 import numpy as np
 import quantities as pq
-import scipy as sp
 from neo.core import SpikeTrain
 
 import elephant.kernels as kernels
@@ -364,7 +363,7 @@ def van_rossum_distance(spiketrains, time_constant=1.0 * pq.s, sort=True):
     for i, j in np.ndindex(k_dist.shape):
         vr_dist[i, j] = (
             k_dist[i, i] + k_dist[j, j] - k_dist[i, j] - k_dist[j, i])
-    return sp.sqrt(vr_dist)
+    return np.sqrt(vr_dist)
 
 
 def _summed_dist_matrix(spiketrains, tau, presorted=False):

--- a/elephant/test/test_kernels.py
+++ b/elephant/test/test_kernels.py
@@ -81,7 +81,7 @@ class kernel_TestCase(unittest.TestCase):
             restric_defdomain = np.linspace(
                 -b, b, num=n_points) * sigma.units
             kern = kernel(restric_defdomain)
-            norm = spint.cumtrapz(y=kern.magnitude,
+            norm = spint.cumulative_trapezoid(y=kern.magnitude,
                                   x=restric_defdomain.magnitude)[-1]
             self.assertAlmostEqual(norm, 1, delta=0.003)
 
@@ -104,11 +104,11 @@ class kernel_TestCase(unittest.TestCase):
                     -b, b, num=n_points) * sigma.units
                 kern = kernel(restric_defdomain)
                 av_integr = kern * restric_defdomain
-                average = spint.cumtrapz(
+                average = spint.cumulative_trapezoid(
                     y=av_integr.magnitude,
                     x=restric_defdomain.magnitude)[-1] * sigma.units
                 var_integr = (restric_defdomain - average) ** 2 * kern
-                variance = spint.cumtrapz(
+                variance = spint.cumulative_trapezoid(
                     y=var_integr.magnitude,
                     x=restric_defdomain.magnitude)[-1] * sigma.units ** 2
                 stddev = np.sqrt(variance)
@@ -132,7 +132,7 @@ class kernel_TestCase(unittest.TestCase):
                 restric_defdomain = np.linspace(
                     -b, b, num=n_points) * sigma.units
                 kern = kernel(restric_defdomain)
-                frac = spint.cumtrapz(y=kern.magnitude,
+                frac = spint.cumulative_trapezoid(y=kern.magnitude,
                                       x=restric_defdomain.magnitude)[-1]
                 self.assertAlmostEqual(frac, fraction, delta=0.002)
 

--- a/elephant/test/test_spike_train_dissimilarity.py
+++ b/elephant/test/test_spike_train_dissimilarity.py
@@ -491,7 +491,7 @@ class TimeScaleDependSpikeTrainDissimMeasuresTestCase(unittest.TestCase):
                 -((self.t - self.st08[1]) / self.tau3).simplified) -
             (self.t > self.st09[0]) * np.exp(
                 -((self.t - self.st09[0]) / self.tau3).simplified)) ** 2
-        distance = np.sqrt(2.0 * spint.cumtrapz(
+        distance = np.sqrt(2.0 * spint.cumulative_trapezoid(
             y=f_minus_g_squared, x=self.t.magnitude)[-1] /
                            self.tau3.rescale(self.t.units).magnitude)
         self.assertAlmostEqual(stds.van_rossum_distance(
@@ -573,7 +573,7 @@ class TimeScaleDependSpikeTrainDissimMeasuresTestCase(unittest.TestCase):
                 -((self.t - self.st34[0]) / self.tau3).simplified) -
               (self.t > self.st34[1]) * np.exp(
                 -((self.t - self.st34[1]) / self.tau3).simplified)) ** 2
-        distance = np.sqrt(2.0 * spint.cumtrapz(
+        distance = np.sqrt(2.0 * spint.cumulative_trapezoid(
             y=f_minus_g_squared, x=self.t.magnitude)[-1] /
                            self.tau3.rescale(self.t.units).magnitude)
         self.assertAlmostEqual(stds.van_rossum_distance([self.st31, self.st34],

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -616,7 +616,7 @@ class InstantaneousRateTest(unittest.TestCase):
                     border_correction=border_correction
                 )
                 num_spikes = len(self.spike_train)
-                area_under_curve = spint.cumtrapz(
+                area_under_curve = spint.cumulative_trapezoid(
                     y=rate_estimate.magnitude[:, 0],
                     x=rate_estimate.times.rescale('s').magnitude)[-1]
                 self.assertAlmostEqual(num_spikes, area_under_curve,

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.8
   - mpi4py
   - numpy>=1.19.5
-  - scipy
+  - scipy>=1.11.0
   - tqdm
   - scikit-learn
   - statsmodels

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.8
   - mpi4py
   - numpy>=1.19.5
-  - scipy>=1.11.0
+  - scipy>=1.10.0
   - tqdm
   - scikit-learn
   - statsmodels

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 neo>=0.10.0
 numpy>=1.19.5
 quantities>=0.14.1
-scipy>=1.11.0
+scipy>=1.10.0
 six>=1.10.0
 tqdm

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 neo>=0.10.0
 numpy>=1.19.5
 quantities>=0.14.1
-scipy>=1.5.4
+scipy>=1.11.0
 six>=1.10.0
 tqdm


### PR DESCRIPTION
This pull request (PR) replaces the usage of the `sp.sqrt` function with `np.sqrt`. 

The deprecation of sp.sqrt expired earlier than expected. Originally, it was planned to be removed with the release of scipy 2.0.0, but with scipy version greater than 1.10.1, unit tests are failing.

Deprecation was introduced in scipy 1.4.0:

https://docs.scipy.org/doc/scipy/release/1.4.0-notes.html#scipy-deprecations

Quote from the scipy release notes:

Support for NumPy functions exposed via the root SciPy namespace is deprecated and will be removed in 2.0.0. For example, if you use scipy.rand or scipy.diag, you should change your code to directly use numpy.random.default_rng or numpy.diag, respectively. They remain available in the currently continuing Scipy 1.x release series.

Further  deprecations  fixed:
- DeprecationWarning: 'scipy.integrate.simps' is deprecated in favour of 'scipy.integrate.simpson' and will be removed in SciPy 1.14.0
- DeprecationWarning: Importing gaussian from 'scipy.signal' is deprecated since SciPy 1.1.0 and will raise an error in SciPy 1.13.0. Please use 'scipy.signal.windows.gaussian' or the convenience function 'scipy.signal.get_window' instead.
- DeprecationWarning: 'scipy.integrate.cumtrapz' is deprecated in favour of 'scipy.integrate.cumulative_trapezoid' and will be removed in SciPy 1.14.0
- DeprecationWarning: You are passing x=[0.        ...      ] as a positional argument. Please change your invocation to use keyword arguments. From SciPy 1.14, passing these as positional arguments will result in an error.   F = simpson(I, x=xlin)