### PR TITLE
[FIX] CI runner for macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,8 +147,6 @@ jobs:
           channel-priority: true
           activate-environment: elephant
           environment-file: requirements/environment-tests.yml
-          auto-activate-base: false
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 
       - name: Install dependencies
         shell: bash -l {0}


### PR DESCRIPTION
When using github action conda-incubator, the setup for mamba requires different options.

This was missed for the macOS runner in: https://github.com/NeuralEnsemble/elephant/pull/615 

This PR fixes the macOS runner with mamba.

Closes #624 .