### PR TITLE
[MAIN] Fix CI runner macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,7 +158,6 @@ jobs:
         shell: bash -l {0}
         run: |
           python --version
-          mamba install mpi4py openmpi
           mamba install pytest
           mamba install pytest-cov coveralls
           pip install -e .[extras]


### PR DESCRIPTION
This PR fixes an Issue related to installation of mpi4py on macOS gh-actions runner