### PR TITLE
[ENH] add include_t_stop flag to Synchrotool class, Issue 493

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ nosetests.xml
 *.tmp*
 .idea/
 venv/
+.venv
 env/
 .pytest_cache/
 **/*/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #########################################
-# Editor temporary/working/backup files #
+# Editor temporary/working/backup files
 .#*
 [#]*#
 *~

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -294,7 +294,18 @@ class BinnedSpikeTrain(object):
         slicing and computations efficiently.
         Default: 'csr'
     ignore_shared_time : bool, optional
-        If True, check for binning outside of common interval is possible.
+        If `True`, the method allows `t_start` and `t_stop` to extend beyond 
+        the shared time interval across all spike trains. This means that the 
+        binning process can include spikes that occur outside the common 
+        time range.
+        If `False` (default), the method enforces that `t_start` and `t_stop` 
+        must fall within the shared time interval of all spike trains. If 
+        either `t_start` or `t_stop` lies outside this range, a `ValueError` 
+        is raised, ensuring that only the time period where all spike trains 
+        overlap is considered for binning.
+        Use this parameter when you want to include spikes outside the common 
+        time interval, understanding that it may result in bins that do not 
+        have contributions from all spike trains.
 
     Raises
     ------
@@ -1235,18 +1246,7 @@ def discretise_spiketimes(spiketrains, sampling_rate):
 
     Examples
     --------
-    >>> import neo
-    >>> import numpy as np
-    >>> import quantities as pq
-    >>> from elephant import conversion
-    >>>
-    >>> np.random.seed(1)
-    >>> times = (np.arange(10) + np.random.uniform(size=10)) * pq.ms
-    >>> spiketrain = neo.SpikeTrain(times, t_stop=10*pq.ms)
-    >>>
-    >>> spiketrain.times
-    array([0.417022  , 1.72032449, 2.00011437, 3.30233257, 4.14675589,
-           5.09233859, 6.18626021, 7.34556073, 8.39676747, 9.53881673]) * ms
+    >>> import neo:
     >>>
     >>> discretised_spiketrain = conversion.discretise_spiketimes(spiketrain,
     ...                                                           1 / pq.ms)

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -1246,7 +1246,18 @@ def discretise_spiketimes(spiketrains, sampling_rate):
 
     Examples
     --------
-    >>> import neo:
+    >>> import neo
+    >>> import numpy as np
+    >>> import quantities as pq
+    >>> from elephant import conversion
+    >>>
+    >>> np.random.seed(1)
+    >>> times = (np.arange(10) + np.random.uniform(size=10)) * pq.ms
+    >>> spiketrain = neo.SpikeTrain(times, t_stop=10*pq.ms)
+    >>>
+    >>> spiketrain.times
+    array([0.417022  , 1.72032449, 2.00011437, 3.30233257, 4.14675589,
+           5.09233859, 6.18626021, 7.34556073, 8.39676747, 9.53881673]) * ms
     >>>
     >>> discretised_spiketrain = conversion.discretise_spiketimes(spiketrain,
     ...                                                           1 / pq.ms)

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -369,7 +369,7 @@ class BinnedSpikeTrain(object):
         self.ignore_shared_time = ignore_shared_time
         # Check all parameter, set also missing values
         self._resolve_input_parameters(spiketrains)
-        # Now create the sparse matrix
+        # Now create the sparse matrix.
         self.sparse_matrix = self._create_sparse_matrix(
             spiketrains, sparse_format=sparse_format)
 

--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -294,17 +294,17 @@ class BinnedSpikeTrain(object):
         slicing and computations efficiently.
         Default: 'csr'
     ignore_shared_time : bool, optional
-        If `True`, the method allows `t_start` and `t_stop` to extend beyond 
-        the shared time interval across all spike trains. This means that the 
-        binning process can include spikes that occur outside the common 
+        If `True`, the method allows `t_start` and `t_stop` to extend beyond
+        the shared time interval across all spike trains. This means that the
+        binning process can include spikes that occur outside the common
         time range.
-        If `False` (default), the method enforces that `t_start` and `t_stop` 
-        must fall within the shared time interval of all spike trains. If 
-        either `t_start` or `t_stop` lies outside this range, a `ValueError` 
-        is raised, ensuring that only the time period where all spike trains 
+        If `False` (default), the method enforces that `t_start` and `t_stop`
+        must fall within the shared time interval of all spike trains. If
+        either `t_start` or `t_stop` lies outside this range, a `ValueError`
+        is raised, ensuring that only the time period where all spike trains
         overlap is considered for binning.
-        Use this parameter when you want to include spikes outside the common 
-        time interval, understanding that it may result in bins that do not 
+        Use this parameter when you want to include spikes outside the common
+        time interval, understanding that it may result in bins that do not
         have contributions from all spike trains.
 
     Raises

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -279,7 +279,6 @@ class Synchrotool(Complexity):
                  include_t_stop=True):
 
         self.annotated = False
-        initial_t_stop = copy(spiketrains[0].t_stop)
 
         super(Synchrotool, self).__init__(
             spiketrains=spiketrains,
@@ -290,9 +289,6 @@ class Synchrotool(Complexity):
             tolerance=tolerance,
             t_stop=spiketrains[0].t_stop + (1 / sampling_rate) if include_t_stop else None,
             )
-
-        for st in spiketrains:
-            st.t_stop = initial_t_stop
 
     def delete_synchrofacts(self, threshold, in_place=False, mode='delete'):
         """

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -20,7 +20,7 @@ from __future__ import division, print_function, unicode_literals
 
 import warnings
 from collections import namedtuple
-from copy import deepcopy
+from copy import deepcopy, copy
 
 import neo
 import numpy as np
@@ -279,6 +279,7 @@ class Synchrotool(Complexity):
                  include_t_stop=True):
 
         self.annotated = False
+        initial_t_stop = copy(spiketrains[0].t_stop)
 
         super(Synchrotool, self).__init__(
             spiketrains=spiketrains,
@@ -289,6 +290,9 @@ class Synchrotool(Complexity):
             tolerance=tolerance,
             t_stop=spiketrains[0].t_stop + (1 / sampling_rate) if include_t_stop else None,
             )
+
+        for st in spiketrains:
+            st.t_stop = initial_t_stop
 
     def delete_synchrofacts(self, threshold, in_place=False, mode='delete'):
         """

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -20,7 +20,7 @@ from __future__ import division, print_function, unicode_literals
 
 import warnings
 from collections import namedtuple
-from copy import deepcopy, copy
+from copy import deepcopy
 
 import neo
 import numpy as np

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -255,6 +255,15 @@ class Synchrotool(Complexity):
     This class inherits from :class:`elephant.statistics.Complexity`, see its
     documentation for more details and input parameters description.
 
+    Parameters
+    ----------
+    include_t_stop : bool, optional
+        If True, the end of the spike train (`t_stop`) is included in the
+        analysis, ensuring that any spikes close to `t_stop` are properly
+        annotated.
+        Default is False.
+
+
     See also
     --------
     elephant.statistics.Complexity

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -405,11 +405,10 @@ class Synchrotool(Complexity):
         Annotate the complexity of each spike in the
         ``self.epoch.array_annotations`` *in-place*.
 
-        Warns
+        Raises
         -----
-        UserWarning
-            If spikes fall too close to `t_stop`.
-            Those spikes will be annotated with `NaN`.
+        ValueError
+            If spikes fall too close to `t_stop` and can not be associated with a bin.
         """
         epoch_complexities = self.epoch.array_annotations['complexity']
         right_edges = (

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -267,7 +267,7 @@ class Synchrotool(Complexity):
                  binary=True,
                  spread=0,
                  tolerance=1e-8,
-                 include_t_stop=True):
+                 include_t_stop=False):
 
         self.annotated = False
         self.include_t_stop = include_t_stop
@@ -278,6 +278,17 @@ class Synchrotool(Complexity):
                                           binary=binary,
                                           spread=spread,
                                           tolerance=tolerance)
+
+        if self.include_t_stop:
+            self.t_stop += self.bin_size
+            if spread == 0:
+                self.time_histogram, self.complexity_histogram = \
+                    self._histogram_no_spread()
+                self.epoch = self._epoch_no_spread()
+            else:
+                self.epoch = self._epoch_with_spread()
+                self.time_histogram, self.complexity_histogram = \
+                    self._histogram_with_spread()
 
     def delete_synchrofacts(self, threshold, in_place=False, mode='delete'):
         """

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -261,7 +261,7 @@ class Synchrotool(Complexity):
         If True, the end of the spike train (`t_stop`) is included in the
         analysis, ensuring that any spikes close to `t_stop` are properly
         annotated.
-        Default is True.
+        Default: True.
 
 
     See also

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1162,12 +1162,14 @@ def time_histogram(spiketrains, bin_size, t_start=None, t_stop=None,
     if binary:
         binned_spiketrain = BinnedSpikeTrain(spiketrains,
                                              t_start=t_start,
-                                             t_stop=t_stop, bin_size=bin_size
+                                             t_stop=t_stop, bin_size=bin_size,
+                                             ignore_shared_time=True
                                              ).binarize(copy=False)
     else:
         binned_spiketrain = BinnedSpikeTrain(spiketrains,
                                              t_start=t_start,
-                                             t_stop=t_stop, bin_size=bin_size
+                                             t_stop=t_stop, bin_size=bin_size,
+                                             ignore_shared_time=True
                                              )
 
     bin_hist: Union[int, ndarray] = binned_spiketrain.get_num_of_spikes(axis=0)
@@ -1439,8 +1441,6 @@ class Complexity(object):
         self.input_spiketrains = spiketrains
         self.t_start = spiketrains[0].t_start if t_start is None else t_start
         self.t_stop = spiketrains[0].t_stop if t_stop is None else t_stop
-        for st in self.input_spiketrains:
-            st.t_stop = self.t_stop
         self.sampling_rate = sampling_rate
         self.bin_size = bin_size
         self.binary = binary
@@ -1487,7 +1487,8 @@ class Complexity(object):
         # clip the spike trains before summing
         time_hist = time_histogram(self.input_spiketrains,
                                    self.bin_size,
-                                   binary=self.binary)
+                                   binary=self.binary,
+                                   t_stop=self.t_stop)
 
         time_hist_magnitude = time_hist.magnitude.flatten()
 

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1488,6 +1488,7 @@ class Complexity(object):
         time_hist = time_histogram(self.input_spiketrains,
                                    self.bin_size,
                                    binary=self.binary,
+                                   t_start=self.t_start,
                                    t_stop=self.t_stop)
 
         time_hist_magnitude = time_hist.magnitude.flatten()

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1423,7 +1423,10 @@ class Complexity(object):
                  bin_size=None,
                  binary=True,
                  spread=0,
-                 tolerance=1e-8):
+                 tolerance=1e-8,
+                 t_start=None,
+                 t_stop=None,
+                 ):
 
         check_neo_consistency(spiketrains, object_type=neo.SpikeTrain)
 
@@ -1434,8 +1437,10 @@ class Complexity(object):
             raise ValueError('Spread must be >=0')
 
         self.input_spiketrains = spiketrains
-        self.t_start = spiketrains[0].t_start
-        self.t_stop = spiketrains[0].t_stop
+        self.t_start = spiketrains[0].t_start if t_start is None else t_start
+        self.t_stop = spiketrains[0].t_stop if t_stop is None else t_stop
+        for st in self.input_spiketrains:
+            st.t_stop = self.t_stop
         self.sampling_rate = sampling_rate
         self.bin_size = bin_size
         self.binary = binary

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1434,8 +1434,8 @@ class Complexity(object):
             raise ValueError('Spread must be >=0')
 
         self.input_spiketrains = spiketrains
-        self.t_start = spiketrains[0].t_start.copy()
-        self.t_stop = spiketrains[0].t_stop.copy()
+        self.t_start = spiketrains[0].t_start
+        self.t_stop = spiketrains[0].t_stop
         self.sampling_rate = sampling_rate
         self.bin_size = bin_size
         self.binary = binary

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1434,8 +1434,8 @@ class Complexity(object):
             raise ValueError('Spread must be >=0')
 
         self.input_spiketrains = spiketrains
-        self.t_start = spiketrains[0].t_start
-        self.t_stop = spiketrains[0].t_stop
+        self.t_start = spiketrains[0].t_start.copy()
+        self.t_stop = spiketrains[0].t_stop.copy()
         self.sampling_rate = sampling_rate
         self.bin_size = bin_size
         self.binary = binary

--- a/elephant/test/test_conversion.py
+++ b/elephant/test/test_conversion.py
@@ -758,6 +758,29 @@ class BinnedSpikeTrainTestCase(unittest.TestCase):
         except ValueError:
             self.fail("BinnedSpikeTrain raised ValueError unexpectedly when ignore_shared_time=True")
 
+    def test_ignore_shared_time_correct_binning(self):
+        # Create spike trains with different time ranges
+        st1 = neo.SpikeTrain([0.5, 1.5, 2.5, 3.5] * pq.s, t_start=0.0 * pq.s, t_stop=4.0 * pq.s)
+        st2 = neo.SpikeTrain([1.0, 2.0, 3.0, 4.0] * pq.s, t_start=1.0 * pq.s, t_stop=5.0 * pq.s)
+        st3 = neo.SpikeTrain([1.5, 2.5, 3.5, 5.5] * pq.s, t_start=1.5 * pq.s, t_stop=5.5 * pq.s)
+
+        spiketrains = [st1, st2, st3]
+        bin_size = 1 * pq.s
+
+        # Test with ignore_shared_time=True
+        bst_ignore = cv.BinnedSpikeTrain(spiketrains, bin_size=bin_size,
+                                         t_start=0 * pq.s, t_stop=6 * pq.s,
+                                         ignore_shared_time=True)
+        self.assertEqual(bst_ignore.t_start, 0 * pq.s)
+        self.assertEqual(bst_ignore.t_stop, 6 * pq.s)
+        self.assertEqual(bst_ignore.n_bins, 6)
+        expected_array_ignore = np.array([
+            [1, 1, 1, 1, 0, 0],
+            [0, 1, 1, 1, 1, 0],
+            [0, 1, 1, 1, 0, 1]
+        ])
+        assert_array_equal(bst_ignore.to_array(), expected_array_ignore)
+
 
 class DiscretiseSpiketrainsTestCase(unittest.TestCase):
     def setUp(self):

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -197,8 +197,7 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
             spiketrains,
             sampling_rate=sampling_rate,
             binary=binary,
-            spread=spread,
-            include_t_stop=False)
+            spread=spread)
 
         # test annotation
         synchrofact_obj.annotate_synchrofacts()
@@ -451,8 +450,7 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
             [spiketrain],
             spread=0,
             sampling_rate=sampling_rate,
-            binary=False,
-            include_t_stop=False)
+            binary=False)
         synchrofact_obj.delete_synchrofacts(
             mode='delete',
             in_place=True,

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -207,6 +207,8 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
                        for st in spiketrains]
 
         assert_array_equal(annotations, correct_complexities)
+        for a in annotations:
+            self.assertEqual(a.dtype, np.dtype(np.uint16).type)
 
         if mode == 'extract':
             correct_spike_times = [

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -197,7 +197,8 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
             spiketrains,
             sampling_rate=sampling_rate,
             binary=binary,
-            spread=spread)
+            spread=spread,
+            include_t_stop=False)
 
         # test annotation
         synchrofact_obj.annotate_synchrofacts()
@@ -448,7 +449,8 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
             [spiketrain],
             spread=0,
             sampling_rate=sampling_rate,
-            binary=False)
+            binary=False,
+            include_t_stop=False)
         synchrofact_obj.delete_synchrofacts(
             mode='delete',
             in_place=True,

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -493,25 +493,12 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
         sampling_rate = 1/pq.ms
         st = neo.SpikeTrain(np.arange(0, 11)*pq.ms, t_start=0*pq.ms, t_stop=10*pq.ms)
 
-        synchrotool_instance = Synchrotool([st, st], sampling_rate, spread=0)
+        synchrotool_instance = Synchrotool([st, st], sampling_rate, spread=0, include_t_stop=False)
 
-        with self.assertWarns(UserWarning) as cm:
+        with self.assertRaises(ValueError):
             synchrotool_instance.annotate_synchrofacts()
 
-        self.assertIn("Some spikes in the input Spike Train are too close to t_stop", str(cm.warning))
-
-    def test_regression_PR_612_index_out_of_bounds_annotate_nan(self):
-        """
-        https://github.com/NeuralEnsemble/elephant/pull/612
-        """
-        sampling_rate = 1/pq.ms
-        st = neo.SpikeTrain(np.arange(0, 11)*pq.ms, t_start=0*pq.ms, t_stop=10*pq.ms)
-
-        synchrotool_instance = Synchrotool([st, st], sampling_rate, spread=0)
-        synchrotool_instance.annotate_synchrofacts()
-        self.assertTrue(np.isnan(st.array_annotations['complexity'][-1]))
-
-    def test_regression_PR_612_index_out_of_bounds_annotate_include_t_stop(self):
+    def test_regression_PR_612_index_out_of_bounds(self):
         """
         https://github.com/NeuralEnsemble/elephant/pull/612
         """
@@ -520,7 +507,6 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
 
         synchrotool_instance = Synchrotool([st, st], sampling_rate, spread=0, include_t_stop=True)
         synchrotool_instance.annotate_synchrofacts()
-        self.assertFalse(np.isnan(st.array_annotations['complexity'][-1]))  # non NaN
         self.assertEqual(len(st.array_annotations['complexity']), len(st))  # all spikes annotated
 
 

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -206,8 +206,6 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
                        for st in spiketrains]
 
         assert_array_equal(annotations, correct_complexities)
-        for a in annotations:
-            self.assertEqual(a.dtype, np.dtype(np.uint16).type)
 
         if mode == 'extract':
             correct_spike_times = [

--- a/elephant/test/test_spike_train_synchrony.py
+++ b/elephant/test/test_spike_train_synchrony.py
@@ -520,8 +520,8 @@ class SynchrofactDetectionTestCase(unittest.TestCase):
 
         synchrotool_instance = Synchrotool([st, st], sampling_rate, spread=0, include_t_stop=True)
         synchrotool_instance.annotate_synchrofacts()
-        self.assertFalse(np.isnan(st.array_annotations['complexity'][-1])) # non NaN
-        self.assertEqual(len(st.array_annotations['complexity']), len(st)) # all spikes annotated
+        self.assertFalse(np.isnan(st.array_annotations['complexity'][-1]))  # non NaN
+        self.assertEqual(len(st.array_annotations['complexity']), len(st))  # all spikes annotated
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adresses #493.

## New feature: `include_t_stop` flag in `Synchrotool` class

This pull request introduces a new feature to the Synchrotool class by adding the `include_t_stop flag`. This  allows users to include the end of the spike train (t_stop) in the analysis, ensuring that any spikes close to `t_stop` are properly annotated.

### Summary of changes

- added `include_t_stop` as a new optional boolean parameter to the Synchrotool class constructor.  If set to True, the spikes close to t_stop of the spike train are included in the analysis. 
- added description of the new parameter to the Synchrotool class docstring.

## Examples

The following minimal example should not longer raise an index out of bounds error:
```python
import neo
import numpy as np
import quantities as pq
from elephant.spike_train_synchrony import Synchrotool

sampling_rate = 1/pq.ms
st = neo.SpikeTrain(np.arange(0, 11)*pq.ms, t_start=0*pq.ms, t_stop=10*pq.ms)

synchrotool_instance = Synchrotool([st, st], sampling_rate, spread=0, include_t_stop=True)
synchrotool_instance.annotate_synchrofacts()
```