### PR TITLE
[Fix] neo v0.13.4 deprecated copy

### DIFF
--- a/elephant/conversion.py
+++ b/elephant/conversion.py
@@ -854,7 +854,7 @@ class BinnedSpikeTrain(object):
                     array_ants = dict(bins=bin_indices)
                 spiketrain = neo.SpikeTrain(spiketrain, t_start=self._t_start,
                                             t_stop=self._t_stop,
-                                            units=self.units, copy=False,
+                                            units=self.units,
                                             description=description,
                                             array_annotations=array_ants,
                                             bin_size=self.bin_size)

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -809,7 +809,7 @@ def cross_correlation_histogram(
         signal=np.expand_dims(cross_corr, axis=1),
         units=pq.dimensionless,
         t_start=t_start,
-        sampling_period=binned_spiketrain_i.bin_size, copy=False,
+        sampling_period=binned_spiketrain_i.bin_size,
         **annotations)
     return cch_result, lags
 

--- a/elephant/spike_train_surrogates.py
+++ b/elephant/spike_train_surrogates.py
@@ -736,7 +736,6 @@ def _continuous_time_bin_shuffling(spiketrain, max_displacement, bin_size,
             units=units,
             t_start=t_start,
             t_stop=t_stop,
-            copy=False,
         )
 
         surrogate_spiketrains.append(surrogate_spiketrain)
@@ -1252,8 +1251,7 @@ def trial_shifting(spiketrains, dither, n_surrogates=1):
             surrogate_spiketrain[trial_id] * pq.s,
             t_start=t_starts[trial_id] * pq.s,
             t_stop=t_stops[trial_id] * pq.s,
-            units=units,
-            sampling_rate=sampling_rates[trial_id])
+            sampling_rate=sampling_rates[trial_id]).rescale(units)
           for trial_id in range(len(surrogate_spiketrain))]
          for surrogate_spiketrain in surrogate_spiketrains]
 
@@ -1337,8 +1335,7 @@ def _trial_shifting_of_concatenated_spiketrain(
         np.hstack(surrogate_spiketrain) * pq.s,
         t_start=t_start * pq.s,
         t_stop=t_stop * pq.s,
-        units=units,
-        sampling_rate=spiketrain.sampling_rate)
+        sampling_rate=spiketrain.sampling_rate).rescale(units)
         for surrogate_spiketrain in surrogate_spiketrains]
     return surrogate_spiketrains
 

--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1201,7 +1201,7 @@ def time_histogram(spiketrains, bin_size, t_start=None, t_stop=None,
                             sampling_period=bin_size,
                             units=normalised_bin_hist.units,
                             t_start=binned_spiketrain.t_start,
-                            normalization=output, copy=False)
+                            normalization=output)
 
 
 @deprecated_alias(binsize='bin_size')


### PR DESCRIPTION
With release of neo v0.13.4. `copy` got removed for all  neo objects.

See: 
https://github.com/NeuralEnsemble/python-neo/pull/1554

Change in quantities:
https://github.com/python-quantities/python-quantities/pull/232

numpy copy behavior:
https://numpy.org/doc/stable/release/2.0.0-notes.html#new-copy-keyword-meaning-for-array-and-asarray-constructors