### PR TITLE
[MAIN] update gh-action runner from macOS12 to macOS14

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -399,7 +399,6 @@ jobs:
         shell: bash -el {0}
         run: |
           python --version
-          # conda install mpi4py openmpi
           mamba install -c conda-forge pytest pytest-cov coveralls mpi4py openmpi
           pip install -e .
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -171,6 +171,7 @@ jobs:
           channel-priority: true
           activate-environment: elephant
           environment-file: requirements/environment-tests.yml
+          conda-remove-defaults: true
 
       - name: Install dependencies
         shell: bash -l {0}
@@ -392,6 +393,7 @@ jobs:
           channel-priority: true
           activate-environment: elephant
           environment-file: requirements/environment-tests.yml
+          conda-remove-defaults: true
 
       - name: Install dependencies
         shell: bash -el {0}
@@ -462,6 +464,7 @@ jobs:
           mamba-version: "*"
           activate-environment: elephant
           environment-file: requirements/environment.yml
+          conda-remove-defaults: true
 
       - name: Install dependencies
         shell: bash -el {0} # enables conda incubator to activate environment

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -399,8 +399,8 @@ jobs:
         shell: bash -el {0}
         run: |
           python --version
-          conda install mpi4py openmpi
-          mamba install pytest pytest-cov coveralls
+          conda install -c conda-forge mpi4py openmpi
+          mamba install -c conda-forge pytest pytest-cov coveralls
           pip install -e .
 
       - name: List packages

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         # OS [ubuntu-latest, macos-latest, windows-latest]
-        os: [macos-12,macos-13]
+        os: [macos-13,macos-14]
         python-version: [3.11]
     steps:
       - name: Get current year-month

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -162,7 +162,7 @@ jobs:
           key: datasets-${{ steps.elephant-data.outputs.dataset_hash }}
           restore-keys: datasets-      
 
-      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # corresponds to v3.0.4
+      - uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # corresponds to v3.1.0
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -383,7 +383,7 @@ jobs:
           restore-keys: datasets-
           enableCrossOsArchive: true 
 
-      - uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # corresponds to v3.0.3
+      - uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # corresponds to v3.1.0
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -455,7 +455,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-docs.txt') }}-${{ hashFiles('**/requirements-tutorials.txt') }}-${{ hashFiles('**/environment-docs.yml') }}
            -${{ hashFiles('**/CI.yml') }}-${{ steps.date.outputs.date }}
 
-      - uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # corresponds to v3.0.3
+      - uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # corresponds to v3.1.0
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,7 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
-          channels: conda-forge,defaults
+          channels: conda-forge
           channel-priority: true
           activate-environment: elephant
           environment-file: requirements/environment-tests.yml
@@ -388,7 +388,7 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
-          channels: conda-forge,defaults
+          channels: conda-forge
           channel-priority: true
           activate-environment: elephant
           environment-file: requirements/environment-tests.yml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -399,8 +399,8 @@ jobs:
         shell: bash -el {0}
         run: |
           python --version
-          conda install -c conda-forge mpi4py openmpi
-          mamba install -c conda-forge pytest pytest-cov coveralls
+          # conda install mpi4py openmpi
+          mamba install -c conda-forge pytest pytest-cov coveralls mpi4py openmpi
           pip install -e .
 
       - name: List packages
@@ -472,7 +472,7 @@ jobs:
           sudo apt-get update
           sudo apt install -y libopenmpi-dev openmpi-bin
           
-          conda install -c conda-forge openmpi pandoc libstdcxx-ng # fix libstdc++.so.6: version for new scipy versions > 1.9.1
+          mamba install -c conda-forge openmpi pandoc libstdcxx-ng # fix libstdc++.so.6: version for new scipy versions > 1.9.1
           mamba env update --file requirements/environment-docs.yml --name elephant
           python -m pip install --upgrade pip
           pip install -e .[extras,tutorials,docs]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/checkout@v4.1.6
 
       - name: Cache conda
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{hashFiles('requirements/environment.yml') }}-${{ hashFiles('**/CI.yml') }}-${{ steps.date.outputs.date }}
@@ -364,7 +364,7 @@ jobs:
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
 
@@ -449,7 +449,7 @@ jobs:
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           # Look to see if there is a cache hit for the corresponding requirements files
@@ -515,7 +515,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache test_env
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/test_env
           # Look to see if there is a cache hit for the corresponding requirements files

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
-  merge:
+  merge_wheels:
     runs-on: ubuntu-latest
     needs: build_wheels
     steps:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -41,6 +41,6 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
           CIBW_ARCHS: "auto64"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -44,3 +44,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          pattern: *.whl
+          merge-multiple: true

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -43,6 +43,14 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
-          pattern: *.whl
-          merge-multiple: true
+  merge:
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: all-wheels
+          pattern: wheels-*


### PR DESCRIPTION
The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721

### Changes Made
- Updated macOS runners to now use macOS-13 and 14 (dropped macOS-12)
- Updated the `upload-artifact` action to version 4. The migration guide was followed to ensure compatibility and proper usage. See: [here](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).
- Updated the `cache` action to version 4.