### PR TITLE
[MAIN] add python 3.13 to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         # python versions for elephant: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
-        python-version: [3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
         # OS [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
       # do not cancel all in-progress jobs if any matrix job fails

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # python versions for elephant: [3.8, 3.9, "3.10", 3.11, 3.12]
+        # python versions for elephant: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
         python-version: [3.9, "3.10", 3.11, 3.12]
         # OS [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]


### PR DESCRIPTION
Adds Python 3.13 testing to our CI pipeline to ensure compatibility with the latest Python version. 

Changes: https://docs.python.org/3/whatsnew/3.13.html