### PR TITLE
[Fix] CI deprecated cache action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -346,7 +346,7 @@ jobs:
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
 
@@ -431,7 +431,7 @@ jobs:
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           # Look to see if there is a cache hit for the corresponding requirements files
@@ -497,7 +497,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache test_env
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.2
         with:
           path: ~/test_env
           # Look to see if there is a cache hit for the corresponding requirements files

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
             echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/elephant-data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v4.0.2
+      - uses: actions/cache/restore@v4.2.2
         # Loading cache of elephant-data
         id: cache-datasets
         with:
@@ -148,7 +148,7 @@ jobs:
         run: |
             echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/elephant-data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v4.0.2
+      - uses: actions/cache/restore@v4.2.2
         # Loading cache of elephant-data
         id: cache-datasets
         with:
@@ -213,7 +213,7 @@ jobs:
         run: |
             echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/elephant-data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v4.0.2
+      - uses: actions/cache/restore@v4.2.2
         # Loading cache of elephant-data
         id: cache-datasets
         with:
@@ -279,7 +279,7 @@ jobs:
         run: |
             echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/elephant-data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v4.0.2
+      - uses: actions/cache/restore@v4.2.2
         # Loading cache of elephant-data
         id: cache-datasets
         with:
@@ -357,7 +357,7 @@ jobs:
         run: |
             echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/elephant-data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v4.0.2
+      - uses: actions/cache/restore@v4.2.2
         # Loading cache of elephant-data
         id: cache-datasets
         with:

--- a/.github/workflows/cache_elephant_data.yml
+++ b/.github/workflows/cache_elephant_data.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
             echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/elephant-data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4.2.2
         # Loading cache of elephant-data
         id: cache-datasets
         with:


### PR DESCRIPTION
This PR updates the cache action in the CI workflow to the latest version due to the deprecation of actions/cache: v4.0.2, which caused the tests to fail.

Error message:

`This request has been automatically failed because it uses a deprecated version of `actions/cache: v4.0.2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
`

See: <https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down>