### PR TITLE
[Fix] Failed ASSET GPU backend selection test when running in an environment with CUDA

### DIFF
--- a/elephant/test/test_asset.py
+++ b/elephant/test/test_asset.py
@@ -505,6 +505,7 @@ class AssetTestCase(unittest.TestCase):
 
     #  regression test Issue #481
     #  see: https://github.com/NeuralEnsemble/elephant/issues/481
+    @unittest.skipIf(HAVE_CUDA, "CUDA available, will be used instead of CPU")
     def test_asset_choose_backend_opencl(self):
         class TestClassBackend(asset._GPUBackend):
 

--- a/elephant/test/test_asset.py
+++ b/elephant/test/test_asset.py
@@ -22,6 +22,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from elephant import statistics, kernels
 from elephant.spike_train_generation import homogeneous_poisson_process
+from elephant.utils import get_cuda_capability_major, get_opencl_capability
 
 try:
     import sklearn
@@ -33,17 +34,8 @@ else:
     HAVE_SKLEARN = True
     stretchedmetric2d = asset._stretched_metric_2d
 
-try:
-    import pyopencl
-    HAVE_PYOPENCL = asset.get_opencl_capability()
-except ImportError:
-    HAVE_PYOPENCL = False
-
-try:
-    import pycuda
-    HAVE_CUDA = asset.get_cuda_capability_major() > 0
-except ImportError:
-    HAVE_CUDA = False
+HAVE_PYOPENCL = get_opencl_capability()
+HAVE_CUDA = get_cuda_capability_major() != 0
 
 
 class AssetBinningTestCase(unittest.TestCase):


### PR DESCRIPTION
The unit test `test_asset_choose_backend_opencl` failed when running in a system with a GPU and CUDA libraries available, generating the error

`AssertionError: 'cuda' != 'cpu'`.

Interestingly, the test failed with or without PyCUDA installed in the environment, which is not the expected behavior. In a system without PyCUDA or OpenCL, it should always use the CPU backend.

It was detected that the utility function for CUDA capabilities detection `utils.get_cuda_capability_major` used the CUDA libraries in the system directly, which returns valid capabilities regardless of the availability of PyCUDA. The latter is required by the functions in ASSET when running CUDA GPU code. Therefore, the first fix in this PR modifies the function to return zero if PyCUDA is not available. It then uses PyCUDA instead of the libraries to detect if a GPU is available and accessible to use with the ASSET function.

This was the behavior enforced when setting flags for the tests in `test_asset.py`. Therefore, the flags are now set to use the utility functions.

Finally, the failed `test_asset_choose_backend_opencl` was implemented as a regression test to check the conditions where no GPU was available and no environmental variable flags were set, which in the past resulted in trying to use the OpenCL backend instead of the CPU. Therefore, in a CI runner with GPU/CUDA, the test is not intended to run, as the default behavior in Elephant is to use the CUDA GPU acceleration and, hence, the backend selection returned `'cuda'` correctly. Therefore, the second fix in the PR conditions the test execution on not having PyCUDA and a GPU.