### PR TITLE
[Fix] "too many resources requested for launch" error in the ASSET joint probability matrix computation when using CUDA

### DIFF
--- a/elephant/asset/asset.py
+++ b/elephant/asset/asset.py
@@ -2538,6 +2538,18 @@ class ASSET(object):
             Old GPUs (Tesla K80) perform faster with `cuda_threads` larger
             than 64 while new series (Tesla T4) with capabilities 6.x and more
             work best with 32 threads.
+            The computation of the joint probability matrix consists of two
+            GPU-accelerated steps. In the first step, the optimal number of
+            CUDA threads is determined automatically. The `cuda_threads`
+            parameter primarily controls the number of threads used in the
+            second (main) computation step. However, if the `n_largest`
+            parameter is set to a high value, the first step may fail with a
+            "too many resources" CUDA error due to excessive register usage.
+            To avoid this, you can explicitly specify the number of threads
+            for both steps using a tuple for `cuda_threads`. In this case, the
+            first element of the tuple sets the thread count for the main
+            computation, and the second element overrides the automatically
+            determined thread count for the first step.
             Default: 64
         cuda_cwr_loops : int, optional
             [CUDA/OpenCL performance parameter that does not influence the

--- a/elephant/asset/asset.py
+++ b/elephant/asset/asset.py
@@ -1375,6 +1375,26 @@ class _PMatNeighbors(_GPUBackend):
                 # It's more efficient to make the number of threads
                 # a multiple of the warp size (32).
                 n_threads -= n_threads % device.WARP_SIZE
+
+            if logger.level == logging.DEBUG:
+                logger.debug(f"Registers per thread: {kernel.NUM_REGS}")
+
+                shared_memory = kernel.SHARED_SIZE_BYTES
+                local_memory = kernel.LOCAL_SIZE_BYTES
+                const_memory = kernel.CONST_SIZE_BYTES,
+                logger.debug(f"Memory: shared = {shared_memory}; "
+                             f"local = {local_memory}, const = {const_memory}")
+
+                logger.debug("Maximum per block: threads = "
+                             f"{device.MAX_THREADS_PER_BLOCK}; "
+                             "registers = "
+                             f"{device.MAX_REGISTERS_PER_BLOCK}; "
+                             "shared memory = "
+                             f"{device.MAX_SHARED_MEMORY_PER_BLOCK}")
+
+                logger.debug(f"Grid size: {grid_size}")
+                logger.debug(f"N threads: {n_threads}")
+
             grid_size = math.ceil(it_todo / n_threads)
             if grid_size > device.MAX_GRID_DIM_X:
                 raise ValueError("Cannot launch a CUDA kernel with "


### PR DESCRIPTION
The computation of the joint probability matrix involves two GPU-accelerated steps. The two steps are invoked using the private classes `_PMatNeighbors` (first step) and `_JSFUniformOrderStat3D` (second step). With recent versions of PyCUDA (> 2021.1), the unit test for `_PMatNeighbors` failed with error

`pycuda._driver.LaunchError: cuLaunchKernel failed: too many resources requested for launch`

The number of registers used by the kernel in `_PMatNeighbors` is determined at run time, depending on the `n_largest` and `filter_size` parameters. Recent CUDA versions may produce compiled code that uses a larger number of registers. As the current behavior of `_PMatNeighbors` when using CUDA GPU acceleration is to utilize the maximum number of threads available on the GPU (typically 1024), this may exceed the maximum number of registers available when running with the maximum 1024 threads, raising that error. 

Therefore, this PR fixes the error by automatically determining the number of threads based on the number of registers in the compiled kernel.

To mirror functionality in `_JSFUniformOrderStat3D`, where the number of CUDA threads can be passed by a parameter to the ASSET function, additional functionality is implemented to allow overriding the number that was automatically determined. The `cuda_threads` parameter can also be passed as a tuple, where the second element will determine the number of threads used by `_PMatNeighbors`. If the usual single integer parameter value is passed, `_PMatNeighbors` will use the maximum number automatically determined.