### PR TITLE
[MAIN] Use micromamba GitHub action in CI jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -366,29 +366,24 @@ jobs:
           restore-keys: datasets-
           enableCrossOsArchive: true 
 
-      - uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # corresponds to v3.1.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: conda-forge
-          channel-priority: true
-          activate-environment: elephant
+          create-args: python=${{ matrix.python-version }}
           environment-file: requirements/environment-tests.yml
-          conda-remove-defaults: true
+          init-shell: bash
 
       - name: Install dependencies
         shell: bash -el {0}
         run: |
           python --version
-          mamba install -c conda-forge pytest pytest-cov coveralls mpi4py openmpi
+          micromamba install -y -c conda-forge pytest pytest-cov coveralls mpi4py openmpi
           pip install -e .
 
       - name: List packages
         shell: bash -el {0}
         run: |
           pip list
-          mamba list
+          micromamba list
           python --version
 
       - name: Test with pytest
@@ -438,23 +433,20 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-docs.txt') }}-${{ hashFiles('**/requirements-tutorials.txt') }}-${{ hashFiles('**/environment-docs.yml') }}
            -${{ hashFiles('**/CI.yml') }}-${{ steps.date.outputs.date }}
 
-      - uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # corresponds to v3.1.0
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          activate-environment: elephant
+          create-args: python=${{ matrix.python-version }}
           environment-file: requirements/environment.yml
-          conda-remove-defaults: true
+          init-shell: bash
 
       - name: Install dependencies
-        shell: bash -el {0} # enables conda incubator to activate environment
+        shell: bash -el {0}
         run: |
           sudo apt-get update
           sudo apt install -y libopenmpi-dev openmpi-bin
           
-          mamba install -c conda-forge openmpi pandoc libstdcxx-ng # fix libstdc++.so.6: version for new scipy versions > 1.9.1
-          mamba env update --file requirements/environment-docs.yml --name elephant
+          micromamba install -y -c conda-forge openmpi pandoc libstdcxx-ng # fix libstdc++.so.6: version for new scipy versions > 1.9.1
+          micromamba env update --file requirements/environment-docs.yml --name elephant
           python -m pip install --upgrade pip
           pip install -e .[extras,tutorials,docs]
           # run notebooks
@@ -464,7 +456,7 @@ jobs:
         shell: bash -el {0}
         run: |
           pip list
-          mamba list
+          micromamba list
           python --version
 
       - name: make html


### PR DESCRIPTION
Conda-based CI jobs in Elephant use the `conda-incubator/setup-miniconda` action, which installs the environment definition in the YAML file and allows using `mamba` for the final installation of the test environment.

Recently, the CI jobs based on conda (`test-conda` and `docs`) failed, apparently due to an error in the `setup-miniconda` action.

This PR updates the CI workflow to use the [mamba-org/setup-micromamba](https://github.com/marketplace/actions/setup-micromamba) GitHub action, which provides `micromamba` (a lightweight version of `mamba`) and serves as a replacement for `setup-miniconda`. This also makes the CI independent of Miniconda.