### PR TITLE
[FIX] Failing spectral and signal processing unit tests with SciPy 1.16

### DIFF
--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -448,23 +448,24 @@ class ButterTestCase(unittest.TestCase):
         # this by using an identity function for detrending
         filtered_noise = elephant.signal_processing.butter(
             noise, 250.0 * pq.Hz, None)
-        _, psd = spsig.welch(filtered_noise.T, nperseg=1024, fs=1000.0,
-                             detrend=lambda x: x)
+        _, psd = spsig.welch(filtered_noise.magnitude.T,
+                             nperseg=1024, fs=1000.0, detrend=lambda x: x)
         self.assertAlmostEqual(psd[0, 0], 0)
 
         # test low-pass filtering: power at the highest frequency
         # should be almost zero
         filtered_noise = elephant.signal_processing.butter(
             noise, None, 250.0 * pq.Hz)
-        _, psd = spsig.welch(filtered_noise.T, nperseg=1024, fs=1000.0)
+        _, psd = spsig.welch(filtered_noise.magnitude.T, nperseg=1024,
+                             fs=1000.0)
         self.assertAlmostEqual(psd[0, -1], 0)
 
         # test band-pass filtering: power at the lowest and highest frequencies
         # should be almost zero
         filtered_noise = elephant.signal_processing.butter(
             noise, 200.0 * pq.Hz, 300.0 * pq.Hz)
-        _, psd = spsig.welch(filtered_noise.T, nperseg=1024, fs=1000.0,
-                             detrend=lambda x: x)
+        _, psd = spsig.welch(filtered_noise.magnitude.T, nperseg=1024,
+                             fs=1000.0, detrend=lambda x: x)
         self.assertAlmostEqual(psd[0, 0], 0)
         self.assertAlmostEqual(psd[0, -1], 0)
 
@@ -472,7 +473,8 @@ class ButterTestCase(unittest.TestCase):
         # should be almost zero
         filtered_noise = elephant.signal_processing.butter(
             noise, 400.0 * pq.Hz, 100.0 * pq.Hz)
-        _, psd = spsig.welch(filtered_noise.T, nperseg=1024, fs=1000.0)
+        _, psd = spsig.welch(filtered_noise.magnitude.T, nperseg=1024,
+                             fs=1000.0)
         self.assertAlmostEqual(psd[0, 256], 0)
 
     def test_butter_filter_function(self):
@@ -493,17 +495,20 @@ class ButterTestCase(unittest.TestCase):
                 'lowpass_frequency': None, 'filter_function': 'filtfilt'}
         filtered_noise = elephant.signal_processing.butter(**kwds)
         _, psd_filtfilt = spsig.welch(
-            filtered_noise.T, nperseg=1024, fs=1000.0, detrend=lambda x: x)
+            filtered_noise.magnitude.T, nperseg=1024, fs=1000.0,
+            detrend=lambda x: x)
 
         kwds['filter_function'] = 'lfilter'
         filtered_noise = elephant.signal_processing.butter(**kwds)
         _, psd_lfilter = spsig.welch(
-            filtered_noise.T, nperseg=1024, fs=1000.0, detrend=lambda x: x)
+            filtered_noise.magnitude.T, nperseg=1024, fs=1000.0,
+            detrend=lambda x: x)
 
         kwds['filter_function'] = 'sosfiltfilt'
         filtered_noise = elephant.signal_processing.butter(**kwds)
         _, psd_sosfiltfilt = spsig.welch(
-            filtered_noise.T, nperseg=1024, fs=1000.0, detrend=lambda x: x)
+            filtered_noise.magnitude.T, nperseg=1024, fs=1000.0,
+            detrend=lambda x: x)
 
         self.assertAlmostEqual(psd_filtfilt[0, 0], psd_lfilter[0, 0])
         self.assertAlmostEqual(psd_filtfilt[0, 0], psd_sosfiltfilt[0, 0])

--- a/elephant/test/test_spectral.py
+++ b/elephant/test/test_spectral.py
@@ -97,9 +97,13 @@ class WelchPSDTestCase(unittest.TestCase):
         for key, val in params.items():
             freqs, psd = elephant.spectral.welch_psd(
                 data, len_segment=1000, overlap=0, **{key: val})
-            freqs_spsig, psd_spsig = spsig.welch(np.rollaxis(data, 0, len(
-                data.shape)), fs=1 / sampling_period, nperseg=1000,
-                                                 noverlap=0, **{key: val})
+            freqs_spsig, psd_spsig = spsig.welch(
+                np.rollaxis(data.magnitude, 0, len(data.shape)),
+                fs=1 / sampling_period,
+                nperseg=1000,
+                noverlap=0,
+                **{key: val}
+            )
             self.assertTrue(
                 (freqs == freqs_spsig).all() and (
                         psd == psd_spsig).all())


### PR DESCRIPTION
This PR fixes unit tests for the `spectral` and `signal_processing` modules, which failed after SciPy was updated to version 1.16.

In the new SciPy version, changes were made to the `scipy.signal.welch` function that originally worked with Neo objects. The new function fails if the inputs are not plain NumPy arrays.

The statements using the SciPy function were changed to explicitly use NumPy arrays by converting with `.magnitude`.