### PR TITLE
Pin docutils<0.22 to fix Doc Build CI

### DIFF
--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -6,4 +6,5 @@ nbsphinx>=0.8.0
 sphinxcontrib-bibtex>1.0.0
 sphinx-tabs>=1.3.0
 matplotlib>=3.3.2, <3.9.0
+docutils<0.22
 # conda install -c conda-forge pandoc


### PR DESCRIPTION
**Bug**
Doc build CI failing because `sphinx-tabs` (as used in `install.rst` ) no longer compatible with newer version of Sphinx (Refer https://github.com/executablebooks/sphinx-tabs/issues/206)

**Fix**
Pin `docutils<0.22`  so that  `sphinx-tabs` remains compatile.  