### PR TITLE
Skip `AssetBinningTestCase` when sklearn is unavailable

### DIFF
--- a/elephant/test/test_asset.py
+++ b/elephant/test/test_asset.py
@@ -38,6 +38,7 @@ HAVE_PYOPENCL = get_opencl_capability()
 HAVE_CUDA = get_cuda_capability_major() != 0
 
 
+@unittest.skipUnless(HAVE_SKLEARN, 'requires sklearn')
 class AssetBinningTestCase(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Adds `@unittest.skipUnless(HAVE_SKLEARN, 'requires sklearn')` to AssetBinningTestCase to ensure the test is skipped when sklearn is not installed.

This aligns the behavior with other test classes in the same module where sklearn-dependent tests are already conditionally skipped.