### PR TITLE
Updating release notes for Release 1.2 on RTD to match github release notes

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -38,6 +38,7 @@ Other changes
 -------------
 - Added Python 3.13 CI runner to ensure compatibility with the latest Python language features (#654)
 - Updated README with maintainer contact information. (#683)
+- Note: macOS wheels for Elephant are currently distributed as pure Python wheels. The C++ accelerated spade module falls back to a Python implementation on macOS, which may result in reduced performance compared to builds using the C++ backend. Full macOS compiled-acceleration support will be restored in a future patch release.
 
 Selected dependency changes
 ---------------------------


### PR DESCRIPTION
Small follow-up fix, missing line in ReadTheDocs file from previous merge about macOS having only pure python code.