### PR TITLE
Fix Spade compile issue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ on:
       #- edited
       #- closed
       - reopened
-      # - synchronize
+      - synchronize
       #- converted_to_draft
       #- ready_for_review
       #- locked

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ on:
       #- edited
       #- closed
       - reopened
-      - synchronize
+      # - synchronize
       #- converted_to_draft
       #- ready_for_review
       #- locked

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Build wheels (macOS)
         if: runner.os == 'macOS'
         run: |
+          echo ${{env.LDFLAGS}}
           python -m pip install --upgrade pip setuptools wheel build
           python -m build --wheel --outdir wheelhouse
         env:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
 
     steps:
       - uses: actions/checkout@v4
@@ -47,19 +47,24 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_ARCHS: "auto64"
 
+      - name: Set macOS env vars
+        if: runner.os == 'macOS'
+        run: |
+          OMP_PATH=$(brew --prefix libomp)
+          echo "LDFLAGS=-L${OMP_PATH}/lib" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I${OMP_PATH}/include" >> $GITHUB_ENV
+          if [ "$RUNNER_ARCH" = "ARM64" ]; then
+            echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
+          else
+            echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+          fi
+
       - name: Build wheels (macOS)
         if: runner.os == 'macOS'
         run: |
-          echo ${{env.LDFLAGS}}
-          echo ${{ env.CPPFLAGS }}
-          echo ${{ env.CPLUS_INCLUDE_PATH }}
           python -m pip install --upgrade pip setuptools wheel build
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          LDFLAGS: "-L/opt/homebrew/opt/libomp/lib ${{ env.LDFLAGS }}"
-          CPPFLAGS: "-I/opt/homebrew/opt/libomp/include ${{ env.CPPFLAGS }}"
-          CPLUS_INCLUDE_PATH: "/opt/homebrew/opt/libomp/include:${{ env.CPLUS_INCLUDE_PATH }}"
-          MACOSX_DEPLOYMENT_TARGET: "15.0"
           CIBW_ARCHS: "auto"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -54,7 +54,7 @@ jobs:
           echo ${{ env.CPPFLAGS }}
           echo ${{ env.CPLUS_INCLUDE_PATH }}
           python -m pip install --upgrade pip setuptools wheel build
-          python -m build --wheel --outdir wheelhouse
+          python -m cibuildwheel --output-dir wheelhouse
         env:
           LDFLAGS: "-L/opt/homebrew/opt/libomp/lib ${{ env.LDFLAGS }}"
           CPPFLAGS: "-I/opt/homebrew/opt/libomp/include ${{ env.CPPFLAGS }}"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -59,6 +59,7 @@ jobs:
           LDFLAGS: "-L/opt/homebrew/opt/libomp/lib ${{ env.LDFLAGS }}"
           CPPFLAGS: "-I/opt/homebrew/opt/libomp/include ${{ env.CPPFLAGS }}"
           CPLUS_INCLUDE_PATH: "/opt/homebrew/opt/libomp/include:${{ env.CPLUS_INCLUDE_PATH }}"
+          MACOSX_DEPLOYMENT_TARGET: "15.0"
           CIBW_ARCHS: "auto"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -7,6 +7,11 @@ on:
       - master
   pull_request_review:
     types: [ submitted ]
+  pull_request:
+    branches:
+      - master
+    types:
+      - synchronize
 
 # Building wheels on Ubuntu, Windows and MacOS systems
 jobs:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -54,14 +54,13 @@ jobs:
           mkdir -p localwheels
           pip wheel --wheel-dir localwheels .
 
-          # Remove downloaded elephant and copy wheeels from cibuildwheel
+          # Remove downloaded elephant and copy wheels from cibuildwheel
           rm localwheels/elephant*.whl
           cp wheelhouse/elephant*.whl localwheels/
 
           # Install elephant and deps from local wheels and check for spade
           pip install --no-index --find-links localwheels elephant
-          cd $HOME
-          python -c "from elephant.spade_src import fim"
+          python -P -c "from elephant.spade_src import fim"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel build
           python -m build --wheel --outdir wheelhouse
+        env:
+          LDFLAGS: "-L/opt/homebrew/opt/libomp/lib ${{ env.LDFLAGS }}"
+          CPPFLAGS: "-I/opt/homebrew/opt/libomp/include ${{ env.CPPFLAGS }}"
+          CPLUS_INCLUDE_PATH: "/opt/homebrew/opt/libomp/include:${{ env.CPLUS_INCLUDE_PATH }}"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,17 +1,14 @@
 name: Build Wheels
 
-# Trigger the workflow on push to master. (this is equal to: PR is merged)
+# Triggers for the workflow (PR review submission and merge to master)
 on:
   push:
-    branches:
-      - master
+    branches: [ master ]
   pull_request_review:
     types: [ submitted ]
   pull_request:
-    branches:
-      - master
-    types:
-      - synchronize
+    branches: [ master ]
+    types: [ synchronize ]
 
 # Building wheels on Ubuntu, Windows and MacOS systems
 jobs:
@@ -25,31 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Used to host cibuildwheel
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
 
       - name: Install cibuildwheel
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==3.3.1
+        run: pip install cibuildwheel==3.3.1
 
-      - name: Install libomp
-        if: runner.os == 'macOS'
-        run: brew install libomp
-
-      - name: Build wheels (Linux / Windows)
-        if: runner.os != 'macOS'
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_SKIP: "cp38-*"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
-          CIBW_ARCHS: "auto64"
-
-      - name: Set macOS env vars
+      - name: Setup OpenMP for macOS and set deployement target
         if: runner.os == 'macOS'
         run: |
+          brew install libomp
           OMP_PATH=$(brew --prefix libomp)
           echo "LDFLAGS=-L${OMP_PATH}/lib" >> $GITHUB_ENV
           echo "CPPFLAGS=-I${OMP_PATH}/include" >> $GITHUB_ENV
@@ -59,18 +42,17 @@ jobs:
             echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
           fi
 
-      - name: Build wheels (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          python -m pip install --upgrade pip setuptools wheel build
-          python -m cibuildwheel --output-dir wheelhouse
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS: "auto"
+          CIBW_SKIP: cp38-*
 
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
+
   merge_wheels:
     runs-on: ubuntu-latest
     needs: build_wheels

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -51,12 +51,15 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           echo ${{env.LDFLAGS}}
+          echo ${{ env.CPPFLAGS }}
+          echo ${{ env.CPLUS_INCLUDE_PATH }}
           python -m pip install --upgrade pip setuptools wheel build
           python -m build --wheel --outdir wheelhouse
         env:
           LDFLAGS: "-L/opt/homebrew/opt/libomp/lib ${{ env.LDFLAGS }}"
           CPPFLAGS: "-I/opt/homebrew/opt/libomp/include ${{ env.CPPFLAGS }}"
           CPLUS_INCLUDE_PATH: "/opt/homebrew/opt/libomp/include:${{ env.CPLUS_INCLUDE_PATH }}"
+          CIBW_ARCHS: "auto"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -48,6 +48,21 @@ jobs:
           CIBW_ARCHS: "auto"
           CIBW_SKIP: cp38-*
 
+      - name: Verify wheels contain compiled code
+        run: |
+          # Download elephant and deps wheels to a DIR
+          mkdir -p localwheels
+          pip wheel --wheel-dir localwheels .
+
+          # Remove downloaded elephant and copy wheeels from cibuildwheel
+          rm localwheels/elephant*.whl
+          cp wheelhouse/elephant*.whl localwheels/
+
+          # Install elephant and deps from local wheels and check for spade
+          pip install --no-index --find-links localwheels elephant
+          cd $HOME
+          python -c "from elephant.spade_src import fim"
+
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -6,9 +6,6 @@ on:
     branches: [ master ]
   pull_request_review:
     types: [ submitted ]
-  pull_request:
-    branches: [ master ]
-    types: [ synchronize ]
 
 # Building wheels on Ubuntu, Windows and MacOS systems
 jobs:

--- a/elephant/spade_src/include/ClosedDetect.h
+++ b/elephant/spade_src/include/ClosedDetect.h
@@ -168,7 +168,18 @@ public:
 	}
 
 private:
+	// Elephant PR 695
+	// `m_size` is unused private attribute, and clang fires warning for this
+	// Being third party code, not removing `m_size` now
+	// Adding diagnostic pragma to skip warning for this line alone
+	#ifdef __clang__
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wunused-private-field"
+	#endif
 	std::size_t m_size;
+	#ifdef __clang__
+	#pragma GCC diagnostic pop
+	#endif
 	std::size_t m_cnt;
 	ClosedTree* m_pTrees;
 };

--- a/elephant/spade_src/include/FPGrowth.h
+++ b/elephant/spade_src/include/FPGrowth.h
@@ -44,7 +44,6 @@
 #include <mpi.h>
 #endif
 
-// #include <experimental/vector>
 
 #include "Defines.h"
 #include "FPNode.h"

--- a/elephant/spade_src/include/FPGrowth.h
+++ b/elephant/spade_src/include/FPGrowth.h
@@ -44,7 +44,7 @@
 #include <mpi.h>
 #endif
 
-#include <experimental/vector>
+// #include <experimental/vector>
 
 #include "Defines.h"
 #include "FPNode.h"
@@ -790,7 +790,13 @@ private:
 
 	void reduceTransactions(Transactions& transactions)
 	{
-		std::experimental::erase_if(transactions, [&minPatternLen = m_minPatternLen](const Transaction& t) { return t.size() < minPatternLen; });
+		// Replacing experimental method with erase-remove call, this lets us keep c++17
+		transactions.erase(
+					std::remove_if(transactions.begin(), transactions.end(),
+						[&minPatternLen = m_minPatternLen](const Transaction& t) { return t.size() < minPatternLen;} ),
+					transactions.end()
+				);
+		// std::experimental::erase_if(transactions, [&minPatternLen = m_minPatternLen](const Transaction& t) { return t.size() < minPatternLen; });
 	}
 
 private:

--- a/elephant/spade_src/include/Timer.h
+++ b/elephant/spade_src/include/Timer.h
@@ -42,11 +42,13 @@
 #define FILL_CNT   3
 #endif
 
-#ifdef _MSC_VER
+// Elephant PR #695
+// Original author used alias `high_resolution_clock` for non MSVC platforms
+// this resolves to `steady_clock` on macos which lacks method `to_time_t` used
+// here in overloading << operator.
+// Fix is to ditch the alias and use `system_clock` accross all platforms
+// There is a tradeoff in precision that is acceptable for this use case.
 using Clock = std::chrono::system_clock;
-#else
-using Clock = std::chrono::high_resolution_clock;
-#endif
 
 class Timer
 {

--- a/elephant/spade_src/include/Utils.h
+++ b/elephant/spade_src/include/Utils.h
@@ -391,6 +391,10 @@ uint64_t GetCurrentRSS()
 	in.close();
 
 	return static_cast<uint64_t>(resident * sysconf(_SC_PAGE_SIZE));
+#else
+	// macos: not implemented by original author, so return 0 is a no-op
+	// Adding this as a fix to Wreturn-type clang warning, see Elephant PR #695
+	return 0;
 #endif
 }
 

--- a/elephant/spade_src/src/fim.cpp
+++ b/elephant/spade_src/src/fim.cpp
@@ -123,7 +123,10 @@ static PyMethodDef ModuleFunctions[] = {
 
 // Disable the missing-field-initializers warning as some
 // sub states of PyModuleDef won't be initialized here
-#if !defined(_MSC_VER) && !defined(__clang__)
+// Elephant PR 695, original author excluded clang, but the
+// warning fired on clang too. Also clang supports diagnostic
+// pragmas
+#if !defined(_MSC_VER)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
@@ -138,7 +141,7 @@ static struct PyModuleDef ModuleDefinitions = {
 	ModuleFunctions // Functions exposed to the module
 };
 
-#if !defined(_MSC_VER) && !defined(__clang__)
+#if !defined(_MSC_VER)
 #pragma GCC diagnostic pop
 #endif
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup_kwargs = {
 options = {"--no-compile": None, "--no-compile-spade": fim_module}
 # check if any option was specified
 if not any([True for key in options.keys() if key in sys.argv]):
-    if platform.system() in ["Windows", "Linux"]:
+    if platform.system() in ["Windows", "Linux", "Darwin"]:
         setup_kwargs["ext_modules"] = [fim_module]
 else:  # ...any option was specified
     # select extensions accordingly

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if platform.system() == "Windows":
         libraries=[],
         extra_compile_args=[
             '-DMODULE_NAME=fim', '-DUSE_OPENMP', '-DWITH_SIG_TERM',
-            '-Dfim_EXPORTS', '-fopenmp', '/std:c++17'],
+            '-Dfim_EXPORTS', '-openmp', '/std:c++17'],
         optional=True
     )
 elif platform.system() == "Darwin":


### PR DESCRIPTION
### Desc
Current Spade source code uses an experimental method `std::experimental::erase_if` which has been added as a standard library method in c++20. However spade src code is currently compiled with only c++17 causing newer runners such as macos-latest and windows-latest on github to fail as they deprecated the c++ library that contained the experimental methods.

Several other compiler warnings also came up with clang during this fix.

This will resolve issue #689 

### Changes

**C++ fixes in `spade_src`:**
- Replaced `std::experimental::erase_if` with an erase-remove idiom in `FPGrowth.h`, keeping the code compliant with C++17
- Replaced `high_resolution_clock` with `system_clock` uniformly across all platforms in `Timer.h`, `high_resolution_clock`  is just an alias that resolves to `steady_clock` or `system_clock`, unfortunately on macOS it resolves to `steady_clock` which lacks `to_time_t` method, causing a compilation error
- Added a `return 0` fallback in `Utils.h` as a no-op for the macOS branch of `GetCurrentRSS` to fix a `-Wreturn-type` clang warning
- Extended the `-Wmissing-field-initializers` pragma suppression in `fim.cpp` to cover clang as well
- Added pragma suppression for `-Wunused-private-field` warning around `m_size` attribute in `ClosedDetect.h`

**`setup.py` fixes:**
- Fixed OpenMP flag for Windows: `-fopenmp` to `-openmp` (MSVC syntax)
- Added `"Darwin"` to the platforms that include the `fim` extension module, so macOS builds now compile the C extension

**CI (`build_wheels.yml`):**
- Added `macos-15-intel` runner to the matrix to cover x86 builds alongside the arm64 runner (`macos-latest`)
- Fixed OpenMP discovery on macOS by using brew to dynamically get omp library paths during compile
- Set `MACOSX_DEPLOYMENT_TARGET` conditionally per architecture: `15.0` for ARM64, `14.0` for Intel
- Removed separate macOS and Linux+Windows split, now using a single build wheel task
- Added a post-build verification step that installs the built wheel and checks if compiled fim*.so is available.