### PR TITLE
Updating GitHub cache action to v5

### DIFF
--- a/.github/workflows/cache_elephant_data.yml
+++ b/.github/workflows/cache_elephant_data.yml
@@ -7,6 +7,12 @@ on:
       - master
   schedule:
     - cron: "11 23 * * *"  # Daily at 23:11 UTC
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
 
 
 jobs:

--- a/.github/workflows/cache_elephant_data.yml
+++ b/.github/workflows/cache_elephant_data.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
             echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/elephant-data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v4.2.2
+      - uses: actions/cache@v5
         # Loading cache of elephant-data
         id: cache-datasets
         with:

--- a/.github/workflows/cache_elephant_data.yml
+++ b/.github/workflows/cache_elephant_data.yml
@@ -7,12 +7,6 @@ on:
       - master
   schedule:
     - cron: "11 23 * * *"  # Daily at 23:11 UTC
-  pull_request:
-    branches:
-      - master
-    types:
-      - opened
-      - synchronize
 
 
 jobs:


### PR DESCRIPTION
# Desc

* Observing unexpected cache misses even when the input key was available.
* GitHub giving out warnings related to Node.js 20 deprecation in the runner environment that is used in current v4 of cache action

# Fix
Just version bumping cache action to v5, I’ll merge this once checks pass, so skipping review due to minor change.