### PR TITLE
Added CI for latest upstream dependencies

### DIFF
--- a/.github/workflows/canary_ci.yml
+++ b/.github/workflows/canary_ci.yml
@@ -16,11 +16,13 @@ env:
       scipy
       scikit-learn
       statsmodels
+      nixio
   GITSOURCES: |
       NeuralEnsemble/python-neo
       python-quantities/python-quantities
       tqdm/tqdm
       pallets/jinja
+      pytest-dev/pytest
 
 jobs:
   test-dep-masters:
@@ -53,7 +55,7 @@ jobs:
           done
 
       - name: Install elephant
-        run: pip install -e .[extras,tests]
+        run: pip install --no-deps -e .
 
       - name: List installed packages
         run: |

--- a/.github/workflows/canary_ci.yml
+++ b/.github/workflows/canary_ci.yml
@@ -9,6 +9,16 @@ on:
   schedule:
     - cron: '0 6 * * 1'   # Every Monday 06:00 UTC
   workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
 
 env:
   PRERELEASE: |

--- a/.github/workflows/canary_ci.yml
+++ b/.github/workflows/canary_ci.yml
@@ -46,8 +46,8 @@ jobs:
     name: latest-dependencies (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        - python-version: "3.12"
+      matrix: 
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/canary_ci.yml
+++ b/.github/workflows/canary_ci.yml
@@ -1,0 +1,64 @@
+# Like the poor old canaries in mines, elephant gets tested against the unknown
+#
+# For dependencies that need compile, a pre release version from PyPI is used
+# for all other dependencies, the HEAD branch from default repo is used
+
+name: Canary Tests
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Every Monday 06:00 UTC
+  workflow_dispatch:
+
+env:
+  PRERELEASE: |
+      numpy
+      scipy
+      scikit-learn
+      statsmodels
+  GITSOURCES: |
+      NeuralEnsemble/python-neo
+      python-quantities/python-quantities
+      tqdm/tqdm
+      pallets/jinja
+
+jobs:
+  test-dep-masters:
+    name: latest-dependencies (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        - python-version: "3.12"
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          check-latest: true
+
+      - uses: ./.github/actions/restore-elephant-data
+
+      - name: Install pre release packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install --pre $PRERELEASE
+
+      - name: Install dependencies from source
+        run: |
+          for dep in $GITSOURCES; do
+            pip install "git+https://github.com/$dep.git"
+          done
+
+      - name: Install elephant
+        run: pip install -e .[extras,tests]
+
+      - name: List installed packages
+        run: |
+          pip list
+          python --version
+
+      - name: Test with pytest
+        run: pytest

--- a/.github/workflows/canary_ci.yml
+++ b/.github/workflows/canary_ci.yml
@@ -1,7 +1,7 @@
 # Like the poor old canaries in mines, elephant gets tested against the unknown
 #
-# For dependencies that need compile, a pre release version from PyPI is used
-# for all other dependencies, the HEAD branch from default repo is used
+# For dependencies that need compilation, the latest stable from PyPI is used.
+# For all other dependencies, the HEAD of the default branch is used.
 
 name: Canary Tests
 
@@ -28,14 +28,14 @@ on:
       - synchronize
 
 env:
-  PRERELEASE: |
+  PYPI: |
       numpy
       scipy
       scikit-learn
       statsmodels
-      nixio
   GITSOURCES: |
       NeuralEnsemble/python-neo
+      G-Node/nixpy
       python-quantities/python-quantities
       tqdm/tqdm
       pallets/jinja
@@ -60,10 +60,10 @@ jobs:
 
       - uses: ./.github/actions/restore-elephant-data
 
-      - name: Install pre release packages
+      - name: Install compiled packages
         run: |
           python -m pip install --upgrade pip
-          pip install --pre $PRERELEASE
+          pip install $PYPI
 
       - name: Install dependencies from source
         run: |

--- a/.github/workflows/canary_ci.yml
+++ b/.github/workflows/canary_ci.yml
@@ -30,12 +30,12 @@ on:
 env:
   PYPI: |
       numpy
-      scipy
-      scikit-learn
-      statsmodels
   GITSOURCES: |
       NeuralEnsemble/python-neo
+      scikit-learn/scikit-learn
+      statsmodels/statsmodels
       G-Node/nixpy
+      scipy/scipy
       python-quantities/python-quantities
       tqdm/tqdm
       pallets/jinja

--- a/.github/workflows/canary_ci.yml
+++ b/.github/workflows/canary_ci.yml
@@ -19,13 +19,6 @@ on:
           - info
           - warning
           - debug
-  pull_request:
-    branches:
-      - master
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 # At the moment quantites breaks on numpy prerelease
 # this is caused by an int() wrapper on numpy version in quanities which doesn't

--- a/.github/workflows/canary_ci.yml
+++ b/.github/workflows/canary_ci.yml
@@ -19,6 +19,13 @@ on:
           - info
           - warning
           - debug
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 env:
   PRERELEASE: |

--- a/.github/workflows/canary_ci.yml
+++ b/.github/workflows/canary_ci.yml
@@ -1,6 +1,6 @@
 # Like the poor old canaries in mines, elephant gets tested against the unknown
 #
-# For dependencies that need compilation, the latest stable from PyPI is used.
+# For dependencies that need compilation, latest stable/prerelease from PyPI is used.
 # For all other dependencies, the HEAD of the default branch is used.
 
 name: Canary Tests
@@ -27,15 +27,19 @@ on:
       - reopened
       - synchronize
 
+# At the moment quantites breaks on numpy prerelease
+# this is caused by an int() wrapper on numpy version in quanities which doesn't
+# strip rc from version string
 env:
   PYPI: |
       numpy
+  PYPI_PRERELEASE: |
+      scipy
   GITSOURCES: |
       NeuralEnsemble/python-neo
       scikit-learn/scikit-learn
       statsmodels/statsmodels
       G-Node/nixpy
-      scipy/scipy
       python-quantities/python-quantities
       tqdm/tqdm
       pallets/jinja
@@ -64,6 +68,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install $PYPI
+          pip install --pre $PYPI_PRERELEASE
 
       - name: Install dependencies from source
         run: |


### PR DESCRIPTION
# Desc
Adds a weekly workflow that tests elephant against the master/pre-release builds of its dependencies, so upstream breaking changes are caught early.
  
# Code
  - Compiled deps (numpy, scipy, scikit-learn, statsmodels) use latest stable from PyPI
  - Pure-Python deps (neo, quantities, tqdm, jinja, pytest) installed from git default branch
  - Elephant itself installed with `--no-deps` to prevent pip from downgrading canary versions
  - Triggers weekly (Monday 06:00 UTC) and on manual dispatch