### PR TITLE
Shorten pyproject.toml description to comply with PyPI Summary field limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "elephant"
 dynamic = ["version", "dependencies", "optional-dependencies"]
-description = "Elephant (Electrophysiology Analysis Toolkit) - open-source library for th e analysis of electrophysiological data in Python."
+description = "Elephant (Electrophysiology Analysis Toolkit) is an open-source library for the analysis of electrophysiological data in Python."
 license = "BSD-3-Clause"
 license-files = [ "LICENSE.txt"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "elephant"
 dynamic = ["version", "dependencies", "optional-dependencies"]
-description = "Elephant (Electrophysiology Analysis Toolkit) is an open-source, community centered library for the analysis of electrophysiological data in the Python programming language. The focus of Elephant is on generic analysis functions for spike train data and time series recordings from electrodes, such as the local field potentials (LFP) or intracellular voltages.In addition to providing a common platform for analysis code from different laboratories, the Elephant project aims to provide a consistent and homogeneous analysis framework that is built on a modular foundation. Elephant is the direct successor to Neurotools and maintains ties to complementary projects such as OpenElectrophy and spykeviewer."
+description = "Elephant (Electrophysiology Analysis Toolkit) - open-source library for th e analysis of electrophysiological data in Python."
 license = "BSD-3-Clause"
 license-files = [ "LICENSE.txt"]
 classifiers = [


### PR DESCRIPTION
# Desc
The `description` field in `pyproject.toml` maps to the [Summary](https://packaging.python.org/en/latest/specifications/core-metadata/#summary)
metadata field, which PyPI enforces a 512-character cap on. Observed on push to test-pypi with the error:
```
'summary' field must be 512 characters or less. See https://packaging.python.org/specifications/core-metadata for more information.
```
The previous value was a multi-sentence paragraph that exceeded this limit, causing upload rejection on TestPyPI.

# Fix
Replaced with a concise one-liner as required.