### PR TITLE
Cut the lag axis together with the values in cross_correlation_function

### DIFF
--- a/elephant/signal_processing.py
+++ b/elephant/signal_processing.py
@@ -286,6 +286,8 @@ def cross_correlation_function(signal, channel_pairs, hilbert_envelope=False,
 
         If `n_lags` is not a positive integer.
 
+        If `n_lags` is larger than the number of lags available for `signal`.
+
         If `scaleopt` is not one of the predefined above keywords.
 
     Examples
@@ -372,7 +374,15 @@ def cross_correlation_function(signal, channel_pairs, hilbert_envelope=False,
     # Cut off lags outside the desired range
     if n_lags is not None:
         tau0 = np.argwhere(tau == 0).item()
+        max_n_lags = min(tau0, nt - tau0 - 1)
+        if n_lags > max_n_lags:
+            raise ValueError(
+                f"'n_lags' ({n_lags}) is larger than the number of lags "
+                f"available for a signal of {nt} samples ({max_n_lags}).")
         xcorr = xcorr[tau0 - n_lags: tau0 + n_lags + 1, :]
+        # The lag vector has to follow the same cut, it defines t_start of
+        # the returned signal below.
+        tau = tau[tau0 - n_lags: tau0 + n_lags + 1]
 
     # Return neo.AnalogSignal
     cross_corr = neo.AnalogSignal(xcorr,

--- a/elephant/test/test_signal_processing.py
+++ b/elephant/test/test_signal_processing.py
@@ -70,6 +70,65 @@ class PairwiseCrossCorrelationTest(unittest.TestCase):
         # Test if vector of lags tau has correct length
         assert len(rho.times) == 2 * int(nlags) + 1
 
+    def test_cross_correlation_nlags_time_axis(self):
+        """
+        The returned lag axis has to follow the cut applied by `n_lags`.
+        """
+        nlags = 30
+        signal = np.zeros((self.n_samples, 2))
+        signal[:, 0] = 0.2 * np.sin(2. * np.pi * self.freq * self.times)
+        signal[:, 1] = 5.3 * np.cos(2. * np.pi * self.freq * self.times)
+        # Convert signal to neo.AnalogSignal
+        signal = neo.AnalogSignal(signal, units='mV', t_start=0. * pq.ms,
+                                  sampling_rate=self.sampling_rate,
+                                  dtype=float)
+        rho = elephant.signal_processing.cross_correlation_function(
+            signal, [0, 1], n_lags=nlags)
+
+        # The lag axis runs from -nlags to +nlags in units of the sampling
+        # period, so zero lag sits in the centre sample.
+        expected_times = np.arange(-nlags, nlags + 1) * \
+            self.sampling_period.rescale('s').magnitude
+        assert_array_almost_equal(rho.times.rescale('s').magnitude,
+                                  expected_times)
+        self.assertAlmostEqual(
+            rho.t_start.rescale('s').magnitude.item(), expected_times[0])
+        self.assertAlmostEqual(
+            rho.times[nlags].rescale('s').magnitude.item(), 0.)
+
+        # Cross-correlation of sine and cosine is a sine of the lag. This is
+        # the same identity that the un-cut case is checked against in
+        # test_cross_correlation_freqs, and it only holds if the lag axis
+        # matches the returned values.
+        assert_array_almost_equal(
+            rho.magnitude[:, 0], np.sin(2. * np.pi * self.freq * rho.times),
+            decimal=2)
+
+    def test_cross_correlation_nlags_too_large(self):
+        """
+        More lags than the signal provides has to be rejected.
+        """
+        n_samples = 100
+        signal = np.zeros((n_samples, 2))
+        times = np.arange(n_samples) * self.sampling_period
+        signal[:, 0] = np.sin(2. * np.pi * self.freq * times)
+        signal[:, 1] = np.cos(2. * np.pi * self.freq * times)
+        signal = neo.AnalogSignal(signal, units='mV', t_start=0. * pq.ms,
+                                  sampling_rate=self.sampling_rate,
+                                  dtype=float)
+        # 100 samples give lags -50 ... 49, so 49 is the largest symmetric
+        # cut. Larger values used to produce a negative slice start, which
+        # wraps around and returns an array of the wrong length instead of
+        # the documented 2 * n_lags + 1 samples.
+        rho = elephant.signal_processing.cross_correlation_function(
+            signal, [0, 1], n_lags=49)
+        self.assertEqual(rho.shape, (99, 1))
+        for n_lags in (50, 60):
+            self.assertRaises(
+                ValueError,
+                elephant.signal_processing.cross_correlation_function,
+                signal, [0, 1], n_lags=n_lags)
+
     def test_cross_correlation_phi(self):
         """
         Sine with phase shift phi vs cosine


### PR DESCRIPTION
When `n_lags` is given, `cross_correlation_function` returns correct correlation values attached to a wrong lag axis.

This is the plotting example from the function's own docstring:

```python
import neo
import numpy as np
import quantities as pq
from elephant.signal_processing import cross_correlation_function

dt, N, f = 0.02, 2018, 0.5
t = np.arange(N) * dt
x = np.zeros((N, 2))
x[:, 0] = 0.2 * np.sin(2. * np.pi * f * t)
x[:, 1] = 5.3 * np.cos(2. * np.pi * f * t)
signal = neo.AnalogSignal(x, units='mV', t_start=0. * pq.ms,
                          sampling_rate=1 / dt * pq.Hz, dtype=float)

rho = cross_correlation_function(signal, [0, 1], n_lags=150)
print(rho.t_start.rescale('s'), rho.times[-1].rescale('s'))
print(rho.times[rho.shape[0] // 2].rescale('s'))
```

On current master:

```
-20.18 s -14.18 s
-17.18 s
```

The returned lag range is `[-20.18 s, -14.18 s]`. It does not contain zero lag at all, and the sample that actually is zero lag is labelled `-17.18 s`. The expected range for `n_lags=150` at `dt=0.02 s` is `[-3.0 s, 3.0 s]` with zero in the centre.

The cause is that only the values are sliced:

```python
    if n_lags is not None:
        tau0 = np.argwhere(tau == 0).item()
        xcorr = xcorr[tau0 - n_lags: tau0 + n_lags + 1, :]

    cross_corr = neo.AnalogSignal(xcorr,
                                  units='',
                                  t_start=tau[0] * signal.sampling_period,
```

`tau` keeps the full range, so `t_start` is taken from the uncut vector and the whole axis is shifted by `nt // 2 - n_lags` samples, which is 859 samples or 17.18 s here. The magnitudes are right, I verified they match the corresponding slice of the un-cut result exactly, so this shows up as a silently mislabelled plot rather than a crash. The docstring's own example does `plt.plot(rho.times, rho)` with `n_lags=150`. The fix slices `tau` with the same indices.

The same expression also wrapped silently when `n_lags` exceeded the available lag range, because `tau0 - n_lags` went negative. For a 100 sample signal, `n_lags=50` returned 100 rows and `n_lags=60` returned 10 rows, both contradicting the documented output shape `[2*n_lags+1, n]`. That now raises `ValueError` naming the largest usable value, and the `Raises` section gains the matching bullet.

Two tests are added. `test_cross_correlation_nlags_time_axis` checks that the lag axis runs from `-n_lags` to `+n_lags` with zero in the centre, and applies the same sine of the lag identity that `test_cross_correlation_freqs` already uses for the un-cut case, which only holds if the axis matches the values. `test_cross_correlation_nlags_too_large` pins the boundary at 49 for 100 samples and the rejection above it.

Reverting `signal_processing.py` to master fails with `Mismatched elements: 61 / 61 (100%), [0]: -20.18 (ACTUAL), -0.6 (DESIRED)`. After, 52 passed and 2 subtests passed. `signal_processing.py` and its test module are `pycodestyle` clean before and after.

I have not added myself to `doc/authors.rst`, since it is a numbered institutional affiliation list. Happy to add an entry if you would like one.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
