### PR TITLE
Apply the border correction before pooling spike trains in instantaneous_rate

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -1113,9 +1113,6 @@ def instantaneous_rate(spiketrains, sampling_period, kernel='auto',
                              sigma=str(kernel.sigma),
                              invert=kernel.invert)
 
-    if pool_spike_trains:
-        rate = np.mean(rate, axis=1)
-
     rate = neo.AnalogSignal(signal=rate,
                             sampling_period=sampling_period,
                             units=pq.Hz, t_start=t_start,
@@ -1138,6 +1135,21 @@ def instantaneous_rate(spiketrains, sampling_period, kernel='auto',
             if len(spiketrain) > 0:
                 rate[:, i] *= len(spiketrain) /\
                               (np.mean(rate[:, i]).magnitude * duration)
+
+    # Pooling happens after the border correction, because the correction is
+    # defined per spike train: it rescales each column so that the integral
+    # over that column returns the spike count of the corresponding spike
+    # train. Pooling first collapses the column axis to a single column and
+    # leaves the loop above indexing columns that no longer exist. Correcting
+    # first also keeps the pooled rate equal to the mean over the columns of
+    # the corresponding `pool_spike_trains=False` result, which is the order
+    # already used for `elephant.trials` input.
+    if pool_spike_trains:
+        rate = neo.AnalogSignal(
+            signal=np.mean(rate.magnitude, axis=1, keepdims=True),
+            sampling_period=rate.sampling_period,
+            units=rate.units, t_start=rate.t_start,
+            kernel=kernel_annotation)
 
     return rate
 

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -1152,6 +1152,16 @@ class InstantaneousRateTestCase(unittest.TestCase):
         self.assertAlmostEqual(mean_spike_count, area_under_curve,
                                delta=0.01 * mean_spike_count)
 
+        # The same spike trains wrapped in a Trials object already take this
+        # order, the trials branch estimates the rates per spike train and
+        # averages the corrected result afterwards. Both routes have to give
+        # the same answer.
+        rate_from_trials = statistics.instantaneous_rate(
+            TrialsFromLists([spiketrains]), pool_trials=False,
+            pool_spike_trains=True, **kwargs)[0]
+        assert_array_almost_equal(rate_from_trials.magnitude,
+                                  rate_pooled.magnitude)
+
     def test_instantaneous_rate_trials_pool_trials(self):
         # Input:
         #   Trials object with self.n_trials, self.n_spiketrains

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -1107,6 +1107,51 @@ class InstantaneousRateTestCase(unittest.TestCase):
             self.assertLess(np.min(average_estimated_rate),
                             (1. - rtol) * rate.item())
 
+    def test_instantaneous_rate_border_correction_pool_spike_trains(self):
+        # The border correction rescales every column of the rate estimate
+        # with the spike count of the corresponding spike train, so it has to
+        # run before the spike trains are pooled. Pooling first collapses the
+        # column axis to a single column and the correction loop then indexes
+        # columns that no longer exist.
+        np.random.seed(0)
+        n_spiketrains = 5
+        t_start = 0. * pq.ms
+        t_stop = 1000. * pq.ms
+        sampling_period = 1. * pq.ms
+        kernel = kernels.GaussianKernel(sigma=50. * pq.ms)
+        spiketrains = StationaryPoissonProcess(
+            rate=30. * pq.Hz, t_start=t_start, t_stop=t_stop
+        ).generate_n_spiketrains(n_spiketrains)
+
+        kwargs = dict(sampling_period=sampling_period, kernel=kernel,
+                      border_correction=True)
+        rate_pooled = statistics.instantaneous_rate(
+            spiketrains, pool_spike_trains=True, **kwargs)
+        rate_per_spiketrain = statistics.instantaneous_rate(
+            spiketrains, pool_spike_trains=False, **kwargs)
+
+        n_bins = int(((t_stop - t_start) / sampling_period).simplified)
+        self.assertIsInstance(rate_pooled, neo.AnalogSignal)
+        self.assertEqual(rate_pooled.shape, (n_bins, 1))
+        self.assertEqual(rate_per_spiketrain.shape, (n_bins, n_spiketrains))
+
+        # Pooling is documented as an average over spike trains, so the
+        # pooled rate has to equal the mean over the columns of the
+        # un-pooled rate.
+        assert_array_almost_equal(
+            rate_pooled.magnitude[:, 0],
+            np.mean(rate_per_spiketrain.magnitude, axis=1))
+
+        # The border correction makes the integral over each un-pooled rate
+        # equal to the spike count of the corresponding spike train, hence
+        # the integral over the pooled rate equals the mean spike count.
+        mean_spike_count = np.mean([len(st) for st in spiketrains])
+        area_under_curve = spint.cumulative_trapezoid(
+            y=rate_pooled.magnitude[:, 0],
+            x=rate_pooled.times.rescale('s').magnitude)[-1]
+        self.assertAlmostEqual(mean_spike_count, area_under_curve,
+                               delta=0.01 * mean_spike_count)
+
     def test_instantaneous_rate_trials_pool_trials(self):
         # Input:
         #   Trials object with self.n_trials, self.n_spiketrains


### PR DESCRIPTION
Combining the two documented flags `border_correction=True` and `pool_spike_trains=True` on a list of spike trains raises `IndexError`.

```python
import neo
import quantities as pq
from elephant.kernels import GaussianKernel
from elephant.statistics import instantaneous_rate

st1 = neo.SpikeTrain([0.1, 0.3, 0.5, 0.7] * pq.s, t_start=0*pq.s, t_stop=1*pq.s)
st2 = neo.SpikeTrain([0.2, 0.4, 0.6, 0.8] * pq.s, t_start=0*pq.s, t_stop=1*pq.s)

instantaneous_rate([st1, st2], sampling_period=10 * pq.ms,
                   kernel=GaussianKernel(50 * pq.ms),
                   border_correction=True, pool_spike_trains=True)
```

On current master:

```
  File "elephant/statistics.py", line 1139, in instantaneous_rate
    rate[:, i] *= len(spiketrain) /\
    ~~~~^^^^^^
IndexError: index 1 is out of bounds for axis 1 with size 1
```

Pooling runs first and collapses the column axis to a single column, then the border correction loops over every input spike train and rescales `rate[:, i]`, so every column past the first is out of bounds.

The order is the bug, not the indexing. The correction is defined per spike train, and its second half rescales a column so that the integral over it returns the spike count of the matching spike train, so it has to run while the columns still correspond one to one with the spike trains. Correcting first also preserves the documented meaning of `pool_spike_trains`, "calculate firing rates averaged over spike trains", because the pooled rate is then exactly the mean over the columns of the `pool_spike_trains=False` result, an invariant that already holds when `border_correction=False`.

This is not a judgement call, the same order is already in the file. For an `elephant.trials` input the trials branch passes `pool_spike_trains: False` down and averages the corrected per spike train rates afterwards. The two routes disagree today: with the same four spike trains and the same flags, wrapping them in `TrialsFromLists` works while passing them as a plain list raises `IndexError`. After this change both return the same array, with a max absolute difference of 0.0, which the test now asserts.

Behaviour on inputs that already worked is unchanged. With `border_correction=False, pool_spike_trains=True` the output is bit identical to master for both `trim=False` and `trim=True`, including shape, `t_start`, `sampling_period` and the kernel annotation.

The new test checks the output shape `(n_bins, 1)`, equality with the column mean of the un-pooled result, that the integral over the pooled rate equals the mean spike count, and agreement with the trials path.

Reverting `statistics.py` to master fails with the `IndexError` above. After, 102 passed, 1 skipped and 33 subtests passed. `pycodestyle` reports no new findings. The 5 pre-existing `statistics.py` doctest failures are identical on master and on this branch, consistent with known issue #686.

I have not added myself to `doc/authors.rst`, since it is a numbered institutional affiliation list. Happy to add an entry if you would like one.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
