### PR TITLE
[Fix] Pin ipython<9.16 to unbreak the docs build

### DIFF
--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -1,10 +1,16 @@
 # Packages required to build docs (in addition to requirements-tutorials.rst)
 numpydoc>=1.1.0
 jupyter>=1.0.0
+# IPython 9.16 removed the public `backend2gui` alias from IPython.core.pylabtools.
+# matplotlib<3.9 imports that alias in pyplot.install_repl_displayhook(), so the two
+# cannot be installed together. Lift this pin once the matplotlib cap below is lifted.
+ipython<9.16
 sphinx>=3.3.0
 nbsphinx>=0.8.0
 sphinxcontrib-bibtex>1.0.0
 sphinx-tabs>=1.3.0
+# Capped at <3.9 because viziphant 0.4.0 (latest release, 2023-11) calls
+# matplotlib.cm.get_cmap, which matplotlib removed in 3.9.
 matplotlib>=3.3.2, <3.9.0
 docutils<0.22
 # conda install -c conda-forge pandoc

--- a/requirements/requirements-tutorials.txt
+++ b/requirements/requirements-tutorials.txt
@@ -1,4 +1,6 @@
 # Packages required to execute jupyter notebook tutorials
+# Capped at <3.9 because viziphant 0.4.0 (latest release, 2023-11) calls
+# matplotlib.cm.get_cmap, which matplotlib removed in 3.9.
 matplotlib>=3.3.2, <3.9.0
 h5py>=3.1.0
 nixio>=1.5.0


### PR DESCRIPTION
The docs build currently fails on every branch, including master.

**What breaks**

`make html` dies while nbsphinx executes `doc/tutorials/spade.ipynb`, on the first cell at `import viziphant`:

```
ImportError: cannot import name 'backend2gui' from 'IPython.core.pylabtools'
```

**Why**

`requirements-docs.txt` asks for `jupyter>=1.0.0`, which pulls IPython unpinned. Installing the current docs requirements on Python 3.12 resolves to `ipython 9.16.1` and `matplotlib 3.8.4`.

IPython 9.16 removed the public `backend2gui` alias from `IPython.core.pylabtools`. matplotlib below 3.9 imports that alias in `pyplot.install_repl_displayhook()`, which runs whenever pyplot is used inside a live IPython shell. `import viziphant` reaches it via holoviews calling `plt.switch_backend("agg")`. The resolved environment therefore cannot work.

**Why pin IPython rather than raise matplotlib**

Raising matplotlib does not fix it. viziphant 0.4.0, the latest release from November 2023 and a `requirements-tutorials.txt` dependency, calls `matplotlib.cm.get_cmap`, which matplotlib removed in 3.9. With matplotlib 3.11.1 the same notebook gets past the import and then fails at `viziphant.patterns.plot_patterns` with `AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'`.

So the `matplotlib<3.9` cap is load bearing, and `ipython<9.16` restores the last working combination. The pin goes in `requirements-docs.txt` because that is the only requirements file that brings in a Jupyter or IPython runtime. I confirmed empirically that a tutorials only install pulls neither.

This also records why the matplotlib cap exists. It was added in #634 without a note, which makes it easy to remove by mistake. The commit is `6ce65584`, titled "[Fix] Tests for Neo 0.13.1, add same object to list", so the requirements change was incidental to that PR's stated purpose.

The durable fix is a viziphant release that stops using `cm.get_cmap`. Both pins can come off then, and `environment-docs.yml` could drop its `python=3.12`, whose stated reason is this same cap.

**Verified** on Python 3.12, matching the docs CI job:

- Reproduced. The unmodified requirements resolve to ipython 9.16.1 and matplotlib 3.8.4, and `spade.ipynb` fails with the error above on its first cell.
- With this change the same install resolves to ipython 9.15.0 and matplotlib 3.8.4, and `spade.ipynb` executes cleanly at 6 of 6 cells with no error outputs. `statistics.ipynb`, `unitary_event_analysis.ipynb` and `granger_causality.ipynb` also pass.
- Confirmed `cm.get_cmap` present in matplotlib 3.8.4 and absent in 3.9.0, and `backend2gui` present in IPython 9.15.0 and absent in 9.16.1.
- setuptools still parses the files, and `ipython<9.16` appears in the built wheel's `docs` extra, so CI's `pip install -e .[extras,tutorials,docs]` picks it up.

**Not verified**

- I did not run a full `make html`, only notebook execution.
- `gpfa.ipynb` and `asset.ipynb` did not finish in my local environment and `parallel.ipynb` needs mpi4py, so I make no claim about those three.
- Tested on macOS arm64, not ubuntu-latest.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
