### PR TITLE
Raise the intended error for a zero sampling_period in instantaneous_rate

### DIFF
--- a/elephant/statistics.py
+++ b/elephant/statistics.py
@@ -760,14 +760,13 @@ def instantaneous_rate(spiketrains, sampling_period, kernel='auto',
     TypeError
         *  If `spiketrain` is not an instance of :class:`neo.core.SpikeTrain`.
         *  If `sampling_period` is not a `pq.Quantity`.
-        *  If `sampling_period` is not larger than zero.
         *  If `kernel` is neither instance of :mod:`elephant.kernels` nor string
            'auto'.
         *  If `cutoff` is neither `float` nor `int`.
         *  If `t_start` and `t_stop` are neither None nor a `pq.Quantity`.
         *  If `trim` is not `bool`.
     ValueError
-        *  If `sampling_period` is smaller than zero.
+        *  If `sampling_period` is not larger than zero.
         *  If `kernel` is 'auto' and the function was unable to calculate
            optimal kernel width for instantaneous rate from input data.
         *  If `kernel` length is larger than binned spiketrain length
@@ -987,9 +986,9 @@ def instantaneous_rate(spiketrains, sampling_period, kernel='auto',
         raise TypeError(f"The 'sampling_period' must be a time Quantity."
                         f"Found: {type(sampling_period)}")
 
-    if sampling_period.magnitude < 0:
+    if sampling_period.magnitude <= 0:
         raise ValueError(f"The 'sampling_period' ({sampling_period}) "
-                         f"must be non-negative.")
+                         f"must be larger than zero.")
 
     if not (isinstance(kernel, kernels.Kernel) or kernel == 'auto'):
         raise TypeError(f"'kernel' must be instance of class "

--- a/elephant/test/test_statistics.py
+++ b/elephant/test/test_statistics.py
@@ -565,6 +565,16 @@ class InstantaneousRateTestCase(unittest.TestCase):
             ValueError, statistics.instantaneous_rate,
             spiketrains=self.spike_train, kernel=self.kernel,
             sampling_period=-0.01 * pq.ms)
+        self.assertRaisesRegex(  # sampling period is == 0
+            ValueError, r"must be larger than zero",
+            statistics.instantaneous_rate,
+            spiketrains=self.spike_train, kernel=self.kernel,
+            sampling_period=0 * pq.ms)
+        self.assertRaisesRegex(  # sampling period is == 0, list input
+            ValueError, r"must be larger than zero",
+            statistics.instantaneous_rate,
+            spiketrains=[self.spike_train, self.spike_train],
+            kernel=self.kernel, sampling_period=0 * pq.s)
         self.assertRaises(  # no kernel or kernel='auto'
             TypeError, statistics.instantaneous_rate,
             spiketrains=self.spike_train, sampling_period=0.01 * pq.ms,


### PR DESCRIPTION
`instantaneous_rate` accepts a `sampling_period` of exactly zero and then dies deep inside the bin count computation with an error that says nothing about the argument that caused it.

```python
import neo
import quantities as pq
from elephant.kernels import GaussianKernel
from elephant.statistics import instantaneous_rate

st = neo.SpikeTrain([0.1, 0.3, 0.5, 0.7] * pq.s, t_start=0 * pq.s, t_stop=1 * pq.s)
instantaneous_rate(st, sampling_period=0 * pq.ms, kernel=GaussianKernel(50 * pq.ms))
```

On current master:

```
elephant/statistics.py:1032: RuntimeWarning: divide by zero encountered in divide
  n_bins = int(((t_stop - t_start) / sampling_period).simplified)
OverflowError: cannot convert float infinity to integer
```

The documented contract is already correct, only the validation is wrong. The `Raises` section of `instantaneous_rate` says:

```
    TypeError
        ...
        *  If `sampling_period` is not larger than zero.
```

"not larger than zero" includes zero, but the guard only rejects negative values, so zero slips through, the duration divided by zero is infinity, and `int()` raises `OverflowError`. This widens the guard to `<= 0` and reports the intended message, so the same script now ends with `ValueError: The 'sampling_period' (0.0 ms) must be larger than zero.`

The `Raises` section is also made self consistent. It listed the zero case under `TypeError` and a separate "smaller than zero" case under `ValueError`, while the function has always raised `ValueError` here. The single bullet now sits under `ValueError` and reads "not larger than zero", which is both the documented contract and what the code does.

`test_instantaneous_rate_errors` gains two cases, a single spike train and a list of spike trains, both with `sampling_period=0`, asserting the `ValueError` message. Reverting `statistics.py` to master makes it fail with the `OverflowError` above. After, 101 passed, 1 skipped and 33 subtests passed. `pycodestyle` reports no new findings on either changed file.

Unrelated but noticed in the same module while reading: `cv2`, `lv` and `lvr` all document `with_nan` as `Default: True` while their signatures use `with_nan=False`. Happy to send that as a separate docs only change if it is wanted.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.