### PR TITLE
Remove matplotlib upper-version cap to fix backend2gui deprecation

### DIFF
--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -5,6 +5,6 @@ sphinx>=3.3.0
 nbsphinx>=0.8.0
 sphinxcontrib-bibtex>1.0.0
 sphinx-tabs>=1.3.0
-matplotlib>=3.3.2, <3.9.0
+matplotlib>=3.3.2
 docutils<0.22
 # conda install -c conda-forge pandoc

--- a/requirements/requirements-tutorials.txt
+++ b/requirements/requirements-tutorials.txt
@@ -1,5 +1,5 @@
 # Packages required to execute jupyter notebook tutorials
-matplotlib>=3.3.2, <3.9.0
+matplotlib>=3.3.2
 h5py>=3.1.0
 nixio>=1.5.0
 viziphant


### PR DESCRIPTION
## Summary
Fixes `ImportError: cannot import name 'backend2gui' from 'IPython.core.pylabtools'`, hit during the docs build.

Root cause: `matplotlib<3.9.0` relies on IPython's `backend2gui`/`backends` dicts to resolve the GUI backend. Those were deprecated in IPython 8.24 (moved into matplotlib itself) and removed in IPython 9.16, so `matplotlib<3.9.0` + a current IPython breaks. `matplotlib>=3.9.0` already carries the compatibility fix and resolves backends itself, so removing the upper cap (added in #634 as a version at the time pin) fixes the root cause rather than re-pinning around it.

## Blocking note
This PR can only be merged once  a lower pin is applied on `viziphant` after it's patch release to PyPI to fix `plt.cm.get_cmap`, which matplotlib removed in 3.9. Raising matplotlib without a viziphant fix just trades the `backend2gui` ImportError for an `AttributeError` in `spade.ipynb`
- [ ] [viziphant#81](https://github.com/INM-6/viziphant/pull/81) is merged, and fix is released to PyPI.
- [ ] lower cap pin on viziphant is applied here